### PR TITLE
chore: restarts server with SystemD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy
 
     # either triggered manually, or when CI completed, and it was not on a PR
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && !github.event.workflow_run.head_branch) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 
@@ -20,6 +20,9 @@ jobs:
         node-version: [15.x]
 
     steps:
+      - name: Debug
+        run: echo "coucou ${{ github.event.workflow_run.head_branch }}"
+
       - name: Check code out
         uses: actions/checkout@v2
 

--- a/hosting/start.sh
+++ b/hosting/start.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 . ~/.nvm/nvm.sh
+trap 'kill 0' exit
 node .
+wait


### PR DESCRIPTION
### What's in there?

Restarting Tabulous server with SystemD does not work because the bash script which run the node application does not proxy SIGTERM and SIGKILL event.

Besides, I'm having trouble triggering CD only on successful _master_ CI.

Are included here:

- [x] chore: fixes restarting server with SystemD
- [x] chore: debug github action context
