### PR TITLE
chore: prevents CD from running after PR CI

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -10,8 +10,8 @@ jobs:
   buildAndDeploy:
     name: Build and deploy
 
-    # either triggered manually, or when CI completed, and it was not on a PR
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # either triggered manually, or when CI completed on master branch
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
 
     runs-on: ubuntu-latest
 
@@ -20,9 +20,6 @@ jobs:
         node-version: [15.x]
 
     steps:
-      - name: Debug
-        run: echo "coucou ${{ github.event.workflow_run.head_branch }}"
-
       - name: Check code out
         uses: actions/checkout@v2
 


### PR DESCRIPTION
### What's in there?

As opposed to Github action documentation, `github.event.workflow_run.head_branch` is always set. 
It equals to `master` when the CI job ran on master branch, 
![image](https://user-images.githubusercontent.com/186268/132065848-e5c7cfbe-d0d6-477f-bc7d-ab9646a06bd6.png)

or on the branch name when it ran against a PR.
![image](https://user-images.githubusercontent.com/186268/132065815-2fc306b6-6e64-4bf6-915d-4e7e031878ce.png)


Are included here:

- [x] chore: prevents CD from running after PR CI, and removes debug output
