### PR TITLE
feat: creates data storage path when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 certbot/
 coverage/
+data/
 dist/
 keys/
 node_modules/

--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,10 @@
 
 ## Refactor
 
-- server logging (warning on invalid descriptors)
 - all manager managing a collection of behaviors should check their capabilities
-- moves images to server
 - completly disable Babylon input management
 - UI lib: https://svelte-materialify.vercel.app/getting-started/installation/
 - parametrize and serialize UVs
-- automate SSH renewal with certbot
 
 ## Single player
 
@@ -27,8 +24,25 @@
 - search players by name
 - indicates when remote stream is muted/stopped
 
+## Server
+
+- use JWT as authentication token (stores player id and username)
+- allows a single connection per player (discards other JWTs)
+- logging (warning on invalid descriptors)
+
+## Hosting
+
+- where to store secrets?
+- use an env file
+- deploy in a folder named after the commit SHA
+- use symlink to switch between deployments (including conf files)
+- rotates log files
+- notifies on deployment failures/success
+- automate SSH renewal with certbot
+
 # Known issues
 
+- DATA_PATH folder is not created when it does not exist
 - moving items bellow other does not apply gravity to them
 - on vite reload, all players could become hosts or peers simultaneously
 

--- a/apps/server/src/repositories/abstract-repository.js
+++ b/apps/server/src/repositories/abstract-repository.js
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
-import { readFile, writeFile } from 'fs/promises'
-import { join } from 'path'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
 
 /**
  * @typedef {object} Page
@@ -54,6 +54,7 @@ export class AbstractRepository {
   async connect({ path } = {}) {
     if (path) {
       this.file = join(path, `${this.name}.json`)
+      await mkdir(dirname(this.file), { recursive: true })
       try {
         this.modelsById = new Map(
           JSON.parse(await readFile(this.file, 'utf-8'))
@@ -61,6 +62,7 @@ export class AbstractRepository {
       } catch (err) {
         if (err?.code === 'ENOENT') {
           this.modelsById = new Map()
+          persist(this)
         } else {
           throw new Error(
             `Failed to connect repository ${this.name}: ${err.message}`

--- a/apps/server/tests/repositories/abstract-repository.test.js
+++ b/apps/server/tests/repositories/abstract-repository.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import faker from 'faker'
-import { chmod, readFile, rm, watch, writeFile } from 'fs/promises'
+import { chmod, readFile, rm, stat, watch, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { AbstractRepository } from '../../src/repositories/abstract-repository.js'
@@ -47,12 +47,17 @@ describe('Abstract repository', () => {
       )
     })
 
-    it('handles unexisting file', async () => {
+    it('handles unexisting file and creates it', async () => {
       await rm(file, { force: true })
+      const watcher = watch(file, { signal: ac.signal })
+
       await repository.connect({ path })
       expect(await repository.list()).toEqual(
         expect.objectContaining({ total: 0 })
       )
+
+      await watcher
+      await expect(stat(file)).resolves.toBeDefined()
     })
 
     it('throws errors on unwritable file', async () => {


### PR DESCRIPTION
### What's in there?

The server stores game and player data in plain files, within `DATA_PATH` folder.
When this folder does not exist, saving data will output some error in logs.

Are included here:

- [x] feat(server): creates data storage path when needed

### How to test?

1. set `DATA_PATH` env variable to some nonexistent folder (it can include several nonexistent parents)
1. start the app with `npm start`
1. log in to trigger data save
   > there should not be any error in console
   > `player.json` will appear within your data folder
