### PR TITLE
feat(web): supports colored meshes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@
 
 ## UI
 
-- support color textures
+- only allow draw for drawable meshes (indicator)
 - apply action on entire selection
 - multiple stack actions (draw, flip, rotate)
 - display peer's name when running draw animations + show peer avatar/name instead of pointer
@@ -45,6 +45,7 @@
 - indicates when remote stream is muted/stopped
 - zoom in/out on rules
 - always display stack size (user configurable)
+- issue: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 
 ## Server
 

--- a/apps/web/src/3d/meshes/card.js
+++ b/apps/web/src/3d/meshes/card.js
@@ -1,15 +1,11 @@
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
-import { Texture } from '@babylonjs/core/Materials/Textures/texture'
 import { Axis } from '@babylonjs/core/Maths/math.axis'
-import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector'
 import { Mesh } from '@babylonjs/core/Meshes/mesh'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
 import { CreatePlane } from '@babylonjs/core/Meshes/Builders/planeBuilder'
 import { controlManager } from '../managers/control'
 import {
-  adaptTexture,
-  attachMaterialError,
+  configureMaterial,
   registerBehaviors,
   serializeBehaviors
 } from '../utils'
@@ -21,7 +17,7 @@ import {
  * A card's texture must have 2 faces, back then front, aligned horizontally.
  * @param {object} params - card parameters, including (all other properties will be passed to the created mesh):
  * @param {string} params.id - card's unique id.
- * @param {string} params.texture - card's texture url.
+ * @param {string} params.texture - card's texture url or hexadecimal string color.
  * @param {number[][]} params.faceUV? - up to 2 face UV (Vector4 components), to map texture on the card.
  * @param {number} params.x? - initial position along the X axis.
  * @param {number} params.y? - initial position along the Y axis.
@@ -61,12 +57,7 @@ export function createCard(
     },
     scene
   )
-  faces.receiveShadows = true
-  faces.material = new StandardMaterial(id, scene)
-  faces.material.diffuseTexture = new Texture(adaptTexture(texture), scene)
-  faces.material.diffuseTexture.hasAlpha = true
-  faces.material.freeze()
-  attachMaterialError(faces.material)
+  configureMaterial(faces, texture)
 
   const mesh = CreateBox('card', { width, height, depth }, scene)
   mesh.id = id
@@ -105,8 +96,6 @@ export function createCard(
     })
   }
 
-  faces.overlayColor = new Color3(0, 0.8, 0)
-  faces.overlayAlpha = 0.2
   Object.defineProperty(mesh, 'renderOverlay', {
     get() {
       return faces.renderOverlay

--- a/apps/web/src/3d/meshes/round-token.js
+++ b/apps/web/src/3d/meshes/round-token.js
@@ -1,12 +1,8 @@
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
-import { Texture } from '@babylonjs/core/Materials/Textures/texture'
-import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import { controlManager } from '../managers/control'
 import {
-  adaptTexture,
-  attachMaterialError,
+  configureMaterial,
   registerBehaviors,
   serializeBehaviors
 } from '../utils'
@@ -17,7 +13,7 @@ import {
  * A token's texture must have 3 faces, back then edge then front, aligned horizontally.
  * @param {object} params - token parameters, including (all other properties will be passed to the created mesh):
  * @param {string} params.id - token's unique id.
- * @param {string} params.texture - token's texture url.
+ * @param {string} params.texture - card's texture url or hexadecimal string color.
  * @param {number[][]} params.faceUV? - up to 3 face UV (Vector4 components), to map texture on the token.
  * @param {number} params.x? - initial position along the X axis.
  * @param {number} params.y? - initial position along the Y axis.
@@ -56,13 +52,7 @@ export function createRoundToken(
     scene
   )
   mesh.id = id
-  mesh.material = new StandardMaterial(id, scene)
-  mesh.material.diffuseTexture = new Texture(adaptTexture(texture), scene)
-  mesh.material.diffuseTexture.hasAlpha = true
-  mesh.material.freeze()
-  attachMaterialError(mesh.material)
-
-  mesh.receiveShadows = true
+  configureMaterial(mesh, texture)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
 
@@ -80,9 +70,6 @@ export function createRoundToken(
       ...serializeBehaviors(mesh.behaviors)
     })
   }
-
-  mesh.overlayColor = new Color3(0, 0.8, 0)
-  mesh.overlayAlpha = 0.2
 
   registerBehaviors(mesh, behaviorStates)
 

--- a/apps/web/src/3d/meshes/rounded-tile.js
+++ b/apps/web/src/3d/meshes/rounded-tile.js
@@ -1,15 +1,11 @@
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
-import { Texture } from '@babylonjs/core/Materials/Textures/texture'
 import { Axis } from '@babylonjs/core/Maths/math.axis'
-import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector'
 import { CSG } from '@babylonjs/core/Meshes/csg'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import { controlManager } from '../managers/control'
 import {
-  adaptTexture,
-  attachMaterialError,
+  configureMaterial,
   registerBehaviors,
   serializeBehaviors
 } from '../utils'
@@ -50,7 +46,7 @@ function makeCornerMesh(
  * A tile's texture must have 2 faces, back then front, aligned horizontally.
  * @param {object} params - tile parameters, including (all other properties will be passed to the created mesh):
  * @param {string} params.id - tile's unique id.
- * @param {string} params.texture - tile's texture url.
+ * @param {string} params.texture - card's texture url or hexadecimal string color.
  * @param {number[][]} params.faceUV? - up to 6 face UV (Vector4 components), to map texture on the tile.
  * @param {number} params.x? - initial position along the X axis.
  * @param {number} params.y? - initial position along the Y axis.
@@ -111,17 +107,10 @@ export function createRoundedTile(
   tileCSG.subtractInPlace(makeCornerMesh(cornerParams, false, false))
   const mesh = tileCSG.toMesh('roundedTile', undefined, scene)
   mesh.id = id
-  tileMesh.dispose(false, true)
-
-  mesh.material = new StandardMaterial(id, scene)
-  mesh.material.diffuseTexture = new Texture(adaptTexture(texture), scene)
-  mesh.material.diffuseTexture.hasAlpha = true
-  mesh.material.freeze()
-  attachMaterialError(mesh.material)
-
-  mesh.receiveShadows = true
+  configureMaterial(mesh, texture)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
+  tileMesh.dispose(false, true)
 
   mesh.metadata = {
     serialize: () => ({
@@ -139,9 +128,6 @@ export function createRoundedTile(
       ...serializeBehaviors(mesh.behaviors)
     })
   }
-
-  mesh.overlayColor = new Color3(0, 0.8, 0)
-  mesh.overlayAlpha = 0.2
 
   registerBehaviors(mesh, behaviorStates)
 

--- a/apps/web/src/3d/utils/mesh.js
+++ b/apps/web/src/3d/utils/mesh.js
@@ -1,4 +1,7 @@
 import { Engine } from '@babylonjs/core/Engines/engine'
+import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
+import { Texture } from '@babylonjs/core/Materials/Textures/texture'
+import { Color3, Color4 } from '@babylonjs/core/Maths/math.color'
 
 /**
  * Indicates whether a given container completely contain the tested mesh, using their bounding boxes.
@@ -36,6 +39,31 @@ export function isContaining(container, mesh) {
 export function getDimensions(mesh) {
   const { x, y, z } = mesh.getBoundingInfo().boundingBox.extendSizeWorld
   return { width: x * 2, height: y * 2, depth: z * 2 }
+}
+
+/**
+ * Creates a material from provided texture and attaches it to a mesh.
+ * Configures mesh to receive shadows and to have an overlay color.
+ * @param {import('@babylonjs/core').Mesh} mesh - related mesh.
+ * @param {string} texture - texture url or hexadecimal string color.
+ */
+export function configureMaterial(mesh, texture) {
+  const scene = mesh.getScene()
+  const material = new StandardMaterial(`material-${mesh.id}`, scene)
+  if (texture?.startsWith('#')) {
+    material.diffuseColor = Color4.FromHexString(texture)
+    material.alpha = material.diffuseColor.a
+  } else {
+    material.diffuseTexture = new Texture(adaptTexture(texture), scene)
+    attachMaterialError(material)
+    material.diffuseTexture.hasAlpha = true
+  }
+  material.freeze()
+  mesh.material = material
+  mesh.receiveShadows = true
+
+  mesh.overlayColor = new Color3(0, 0.8, 0)
+  mesh.overlayAlpha = 0.2
 }
 
 /**

--- a/apps/web/tests/3d/meshes/card.test.js
+++ b/apps/web/tests/3d/meshes/card.test.js
@@ -1,3 +1,4 @@
+import { Color4 } from '@babylonjs/core/Maths/math.color'
 import faker from 'faker'
 import { createCard } from '../../../src/3d/meshes'
 import { controlManager } from '../../../src/3d/managers'
@@ -24,6 +25,19 @@ describe('createCard()', () => {
     expect(mesh.getChildren()).toHaveLength(1)
     expect(mesh.getChildren()[0].isPickable).toBe(false)
     expect(mesh.behaviors).toHaveLength(0)
+  })
+
+  it('creates a card with a single color', () => {
+    const color = '#1E282F'
+    const mesh = createCard({ texture: color })
+    const { boundingBox } = mesh.getBoundingInfo()
+    expect(mesh.name).toEqual('card')
+    expect(boundingBox.extendSize.x * 2).toEqual(3)
+    expect(boundingBox.extendSize.z * 2).toEqual(4.25)
+    expect(boundingBox.extendSize.y * 2).toEqual(0.01)
+    expect(mesh.isPickable).toBe(false)
+    const [{ material }] = mesh.getChildren()
+    expect(material.diffuseColor).toEqual(Color4.FromHexString(color))
   })
 
   describe('given a card with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/round-token.test.js
+++ b/apps/web/tests/3d/meshes/round-token.test.js
@@ -1,3 +1,4 @@
+import { Color4 } from '@babylonjs/core/Maths/math.color'
 import faker from 'faker'
 import { createRoundToken } from '../../../src/3d/meshes'
 import { controlManager } from '../../../src/3d/managers'
@@ -21,6 +22,18 @@ describe('createRoundToken()', () => {
       serialize: expect.any(Function)
     })
     expect(mesh.behaviors).toHaveLength(0)
+  })
+
+  it('creates a card with a single color', () => {
+    const color = '#1E282F'
+    const mesh = createRoundToken({ texture: color })
+    const { boundingBox } = mesh.getBoundingInfo()
+    expect(mesh.name).toEqual('roundToken')
+    expect(boundingBox.extendSize.x * 2).toEqual(2)
+    expect(boundingBox.extendSize.z * 2).toEqual(2)
+    expect(boundingBox.extendSize.y * 2).toEqual(0.1)
+    expect(mesh.isPickable).toBe(false)
+    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
   })
 
   describe('given a token with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/rounded-tiles.test.js
+++ b/apps/web/tests/3d/meshes/rounded-tiles.test.js
@@ -1,3 +1,4 @@
+import { Color4 } from '@babylonjs/core/Maths/math.color'
 import faker from 'faker'
 import { createRoundedTile } from '../../../src/3d/meshes'
 import { controlManager } from '../../../src/3d/managers'
@@ -21,6 +22,18 @@ describe('createRoundedTile()', () => {
       serialize: expect.any(Function)
     })
     expect(mesh.behaviors).toHaveLength(0)
+  })
+
+  it('creates a card with a single color', () => {
+    const color = '#1E282F'
+    const mesh = createRoundedTile({ texture: color })
+    const { boundingBox } = mesh.getBoundingInfo()
+    expect(mesh.name).toEqual('roundedTile')
+    expect(boundingBox.extendSize.x * 2).toEqual(3)
+    expect(boundingBox.extendSize.z * 2).toEqual(3)
+    expect(boundingBox.extendSize.y * 2).toEqual(0.05)
+    expect(mesh.isPickable).toBe(false)
+    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
   })
 
   describe('given a tile with initial position, dimension, images and behaviors', () => {


### PR DESCRIPTION
### What's in there?

Some games may want to have colored shapes with no image textures: cylinders, cubes, hexagons...

Are included here:

- feat(web): supports colored meshes
- refactor(web): moves material handling (including shadows, overlay and transparency) in utilities

### How to test?

In any game, replace `texture` property values with an hexastring (starting with `#`). 6 characters for solid colors, 8 for transparent colors.
