### PR TITLE
fix(web): un-drawable mesh can be dragged to hand

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,6 @@
 
 ## UI
 
-- only allow draw for drawable meshes (indicator)
 - apply action on entire selection
 - multiple stack actions (draw, flip, rotate)
 - display peer's name when running draw animations + show peer avatar/name instead of pointer

--- a/apps/web/src/3d/managers/hand.js
+++ b/apps/web/src/3d/managers/hand.js
@@ -273,8 +273,10 @@ function handleAction(manager, action) {
 
 function handDrag(manager, { type, mesh, event }) {
   const { extent, handScene, overlay } = manager
-
   overlay.classList.remove('visible')
+  if (!hasSelectedDrawableMeshes(mesh)) {
+    return
+  }
   if (type !== 'dragStop') {
     manager.overlay.style.top = `${manager.extent.screenHeight}px`
     overlay.classList.add('visible')
@@ -317,6 +319,9 @@ function handDrag(manager, { type, mesh, event }) {
           `pick mesh ${newMesh.id} in hand by dragging`
         )
         recordDraw(newMesh)
+      }
+      // dispose at the end to avoid disposing children along with their stacks/anchors
+      for (const mesh of drawn) {
         mesh.dispose(false, true)
       }
     }
@@ -480,4 +485,13 @@ function buildOverlay(parent) {
   parent.append(overlay)
   overlay.classList.add('hand-overlay')
   return overlay
+}
+
+function hasSelectedDrawableMeshes(mesh) {
+  return (
+    Boolean(mesh) &&
+    selectionManager
+      .getSelection(mesh)
+      .some(mesh => mesh.getBehaviorByName(DrawBehaviorName))
+  )
 }


### PR DESCRIPTION
### What's in there?

I omitted some cases when dragging meshes to hand:
1. meshes that don't have `Drawable` behavior should not be moved to hand
2. the overlay indicator should not appear when dragging non-drawable meshes
3. the overlay indicator should not appear when dragging the table (panning or turning the camera)

Finally, the recent rework of stacks broke the action of drawing an entire stack.

- fix(web): un-drawable mesh can be dragged to hand
- fix(web): can not draw a stack by dragging

### How to reproduce?

The first two cases require altering a game on the server-side and making some of the meshes un-drawable. 
They are covered with unit tests.

The third case can be tried by panning and moving the camera: whilst the hand overlay used to appear, it should not anymore.
