### PR TITLE
fix(web): when the host player leaves the game, new host election does not happen

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -285,6 +285,13 @@ done
 2. convert to ktx2
 3. make a png equivalent for WebGL1 engines, rotated so it match meshes's UV
 
+Some useful commands:
+
+- [remove background color](https://stackoverflow.com/a/69875689/1182976):
+  ```
+  convert in.png -alpha off -fuzz 10% -fill none -draw "matte 1,1 floodfill"  \( +clone -alpha extract -blur 0x2 -level 50x100% \) -alpha off -compose copy_opacity -composite out.png
+  ```
+
 There is no built-in way for the remote side of an WebRTC connection to know that video or audio was disabled.
 The mute/unmute events are meant for network issues. Stopping a track is definitive. Adding/removing track from stream only works locally (or would trigger re-negociation)
 

--- a/apps/web/src/stores/game-manager.js
+++ b/apps/web/src/stores/game-manager.js
@@ -260,7 +260,6 @@ export async function loadGame(gameId, engine) {
     for (const subscription of subscriptions) {
       subscription.unsubscribe()
     }
-    closeChannels()
   }
 
   logger.info({ gameId }, `entering game ${gameId}`)

--- a/apps/web/tests/stores/game-manager.test.js
+++ b/apps/web/tests/stores/game-manager.test.js
@@ -21,6 +21,7 @@ import {
   runSubscription
 } from '../../src/stores/graphql-client'
 import {
+  closeChannels,
   connectWith,
   lastConnectedId,
   lastDisconnectedId,
@@ -448,6 +449,7 @@ describe('given a mocked game engine', () => {
           expect(loadThread).not.toHaveBeenCalled()
           expect(runMutation).not.toHaveBeenCalled()
           expect(send).not.toHaveBeenCalled()
+          expect(closeChannels).toHaveBeenCalledTimes(1)
         })
 
         it('loads game data from online players', async () => {
@@ -525,6 +527,7 @@ describe('given a mocked game engine', () => {
               partner2.id
             )
             expect(send).toHaveBeenCalledTimes(1)
+            expect(closeChannels).not.toHaveBeenCalled()
           })
 
           it('does not take host role when not being the first online', async () => {


### PR DESCRIPTION
### What's in there?

It appears that when the host disconnects (for example by refreshing its page), the remaining players are not electing a new host. This was due to a refactoring issue.

- fix(web): when the host player leaves the game, new host election does not happen

### How to test?

To reproduce the issue:
1. Player A creates a game
2. Player A invites player B
3. Player B connects to the game
4. Player A refresh their page
   > Player B should be elected as host, which is visible as the video connection should eventually be established.
