### PR TITLE
fix(web): indicators appear above radial menu and mesh details

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@ Some context
 
 Are included here:
 
-- [ ] feature A
-- [ ] feature B
+- feature A
+- feature B
 
 ### How to test?
 
@@ -14,6 +14,6 @@ Describe how reviewers can try the feature/fix out on their machine
 <!--
 ### Notes to reviewers
 
-If needed, uncomment and describe here any specific points you'd like to draw your reviewers attention on.
+If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
 Otherwise,
 -->

--- a/apps/web/src/routes/Game.svelte
+++ b/apps/web/src/routes/Game.svelte
@@ -135,11 +135,11 @@
     on:contextmenu|preventDefault
   >
     <canvas bind:this={canvas} />
+    <StackSizes items={$stackSizes} />
     <RadialMenu {...$actionMenuProps || {}} />
   </div>
   <CursorInfo halos={longInputs} />
   <MeshDetails mesh={$meshDetails} on:close={handleCloseDetails} />
-  <StackSizes items={$stackSizes} />
 </main>
 <GameAside
   game={$currentGame}


### PR DESCRIPTION
### What's in there?

Stack indicators are displayed _above_:
- radial menu: 
   <img src="https://user-images.githubusercontent.com/186268/160074626-effc8d8e-b5de-464f-8c1d-b887272820d1.png" width="30%"/>
- mesh details:
   <img src="https://user-images.githubusercontent.com/186268/160074694-90aeffaa-c4ab-487c-b372-23c8188c583f.png" width="30%"/>


Are included here:

- fix(web): indicators appear above radial menu and mesh details

### How to test?

On a Klondike game:
- make 2 stacks, close to each other
- zoom out, and rotate camera to have indicators close to each other
- display radial menu, and select mesh detail action


