### PR TITLE
chore(web): replaces png game assets with webp equivalent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.ktx2 filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text

--- a/TODO.md
+++ b/TODO.md
@@ -291,6 +291,10 @@ Some useful commands:
   ```
   convert in.png -alpha off -fuzz 10% -fill none -draw "matte 1,1 floodfill"  \( +clone -alpha extract -blur 0x2 -level 50x100% \) -alpha off -compose copy_opacity -composite out.png
   ```
+- [convert all pngs to webp](https://stackoverflow.com/a/27784462/1182976);
+  ```
+  convert *.png -set filename:base "%[basename]" -define webp:lossless=true "%[filename:base].webp"
+  ```
 
 There is no built-in way for the remote side of an WebRTC connection to know that video or audio was disabled.
 The mute/unmute events are meant for network issues. Stopping a track is definitive. Adding/removing track from stream only works locally (or would trigger re-negociation)

--- a/apps/games/assets/coinche/catalog/cover.png
+++ b/apps/games/assets/coinche/catalog/cover.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a4feaacceda0dbacd6d934d260e33124b8568d23c744882dbe4d05cefd848c0
-size 18489

--- a/apps/games/assets/french-suited-card/textures/clubs-1.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-1.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ab4d8c2441811f0e8dff3a280fcc462da442feec1974a434f9dc2284d9a6bab
-size 53747

--- a/apps/games/assets/french-suited-card/textures/clubs-1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3134bfd591cab2418496b616f20fcecb49e163b64b5b97f7a2ba68453e02bd5e
-size 53878

--- a/apps/games/assets/french-suited-card/textures/clubs-10.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-10.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77b119aa2128b3d77ae4d0765436cb07d5eac4409bae564731162c44dd9c14dd
-size 62832

--- a/apps/games/assets/french-suited-card/textures/clubs-10.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:804971d0aa9ddb970bb5fca119db9b4885e12eedcaaabdb2db4fcaff4a0f1249
-size 63182

--- a/apps/games/assets/french-suited-card/textures/clubs-11.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-11.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87c55f895c97e41ca4b5e0c9c6ffe0adace3d9b39896f84fcf524006685a7c89
-size 114156

--- a/apps/games/assets/french-suited-card/textures/clubs-11.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea5a8986eb44fa8c5bc1e192c30839c6e58faa503509ecad1ba7308e8b767fc8
-size 114493

--- a/apps/games/assets/french-suited-card/textures/clubs-12.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-12.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:540ec616a2122036f3c90338b0e0cf4746ffd9f91be3f3872e4b3d99d530b2ec
-size 109928

--- a/apps/games/assets/french-suited-card/textures/clubs-12.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cc0c508d75f8dd750f6111ed2986bbb841517ef89f3f8b2c0558ed55f986d53
-size 110116

--- a/apps/games/assets/french-suited-card/textures/clubs-13.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-13.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc36af663effeb9f99f8aeee377529cb8b51ed2134cab7bd4184c95643ab0148
-size 116824

--- a/apps/games/assets/french-suited-card/textures/clubs-13.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ce76bb2db73c67730dfbf7db3d261930e635491314fdf0db5f6ad1559ac44a7
-size 116808

--- a/apps/games/assets/french-suited-card/textures/clubs-2.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-2.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76fe781aa84e4258666393baa1d5bd0975129c68a4623f4ef06033d12c578817
-size 54069

--- a/apps/games/assets/french-suited-card/textures/clubs-2.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d72633a1ea1b0697d57a3cd376b5bccf44c031ad36541f07255f8113d29d310
-size 54126

--- a/apps/games/assets/french-suited-card/textures/clubs-3.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-3.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c73e6c9ac45bb37971a69c9206c095469d0e29d298fe8d4cca0502b020687bce
-size 55437

--- a/apps/games/assets/french-suited-card/textures/clubs-3.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97572f517c0e3a79b9adbcfc1932f8b3598d41a08ca15e14583bf8ecbc5f6e6a
-size 55153

--- a/apps/games/assets/french-suited-card/textures/clubs-4.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-4.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5722b43f339acceea4dc1222807489e37a9aee13275e70507b85cda73feba12
-size 56033

--- a/apps/games/assets/french-suited-card/textures/clubs-4.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f067dff87916b8938156eb9c1b389326fe8e33cede747cbf5e41681dea65c2e2
-size 56032

--- a/apps/games/assets/french-suited-card/textures/clubs-5.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-5.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13c490a36a37fe5d601739d119b75ed2e5d7b58109893820736c68dad5284d95
-size 57176

--- a/apps/games/assets/french-suited-card/textures/clubs-5.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ee903bb93062cf9c0ded642b1fb8d7545cb1881dd274794091eb0a1a075ebab
-size 56849

--- a/apps/games/assets/french-suited-card/textures/clubs-6.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-6.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ace7f262be144ad53d43713f43c6d41782f392c323102b8f65108e11bfea148d
-size 58709

--- a/apps/games/assets/french-suited-card/textures/clubs-6.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd0b546c05a67fb9c2791881ea6a896d480cd29b68925a09e27af3a36176a6a2
-size 58275

--- a/apps/games/assets/french-suited-card/textures/clubs-7.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-7.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48bd8dcdf1815e068af9e8ad72c42c2d708c726ec7644489b353b8b48711b351
-size 59436

--- a/apps/games/assets/french-suited-card/textures/clubs-7.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f072e5dee618e5b8427875a9d73b9921ddbf6cbc948a219f0b80c4fa8eb3b349
-size 59297

--- a/apps/games/assets/french-suited-card/textures/clubs-8.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-8.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc60cab3ceab7e5512af46fb598dc919f3dd9a2287d63e23b5036da205b3d6db
-size 61053

--- a/apps/games/assets/french-suited-card/textures/clubs-8.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0048c14a0cab4d9d00be4f2fa00f99bdec57b06a55ed564079dba33012e99966
-size 60762

--- a/apps/games/assets/french-suited-card/textures/clubs-9.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-9.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:248f08c52c0c70c9f3fef5eb749801c1f72d12f39020672a26822392a1ecbcb4
-size 61422

--- a/apps/games/assets/french-suited-card/textures/clubs-9.png
+++ b/apps/games/assets/french-suited-card/textures/clubs-9.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a70c0fae25fa6e3d3b9e3b05fcea0448388f478a25d608e1a1c0e1c950e0008c
-size 61501

--- a/apps/games/assets/french-suited-card/textures/diamonds-1.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-1.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8386110dbb8632d9c9ae06c6bcdf96c49745e1f1138ab47cc3591901691ec7fa
-size 52838

--- a/apps/games/assets/french-suited-card/textures/diamonds-1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcf28402b134479347e909037ec20708f380611fd6e1d5f3bf18eadd2835af81
-size 52972

--- a/apps/games/assets/french-suited-card/textures/diamonds-10.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-10.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50eefd2a4f993313689bc03c374475749d09c06ff02fdbef13fe2ea6ca89a640
-size 60045

--- a/apps/games/assets/french-suited-card/textures/diamonds-10.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41a47d87c03db8d4c8ffaf7a0e6b63c4cd4649197d55d36af97fbe8ec362943d
-size 59993

--- a/apps/games/assets/french-suited-card/textures/diamonds-11.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-11.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2398bed07c2c81ec79cb32ffcbdb9a54e1a93434bbee40a11a4abdc49dea95fa
-size 103464

--- a/apps/games/assets/french-suited-card/textures/diamonds-11.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdc0696028be3a2db61a7b0abc6828a7ead2757b46b6abab4da2e0bcb9a93b6d
-size 104380

--- a/apps/games/assets/french-suited-card/textures/diamonds-12.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-12.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f210bc3a425a58496096a56d66533d5c80c553d5b115c7443e5e4639c168b42
-size 105495

--- a/apps/games/assets/french-suited-card/textures/diamonds-12.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9047bb72d9d29b52f94d69e68d7b61249e7e732255667a07ddbf3c29dd9cc787
-size 106215

--- a/apps/games/assets/french-suited-card/textures/diamonds-13.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-13.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1e22b8880a20c645166675ac3db99398288ecbf7f17ffa60dd672ea11137ca0
-size 109305

--- a/apps/games/assets/french-suited-card/textures/diamonds-13.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91f36a6882e3ee98efb072f36ca125f370932108a9a84219f4cf517b344de05b
-size 109738

--- a/apps/games/assets/french-suited-card/textures/diamonds-2.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-2.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c5db48b780e6f20fdd69214118e50cc3b47db5102917a2354515fffc2859511
-size 53495

--- a/apps/games/assets/french-suited-card/textures/diamonds-2.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a038871e9b2723f402c6dfa00839c51e343e9db226f9076b8df67ea1bccb97b
-size 53646

--- a/apps/games/assets/french-suited-card/textures/diamonds-3.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-3.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53e513d1c32edecd34ab9a01a6da25b9f9fdcfbc91bdee43ec696ad426af927b
-size 54508

--- a/apps/games/assets/french-suited-card/textures/diamonds-3.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9714fd862b2c51973658316114dd0beddb39a20b2e2cc4663e73644ce644632b
-size 54511

--- a/apps/games/assets/french-suited-card/textures/diamonds-4.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-4.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cdc688fe0722ffb7df78514572dd907d32d013a0eb230e73dfc140d064d88149
-size 54852

--- a/apps/games/assets/french-suited-card/textures/diamonds-4.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:297bdc7b641e3d78277d3f589c1c1ebc78b111087b2c8a78973439905dc777a3
-size 54859

--- a/apps/games/assets/french-suited-card/textures/diamonds-5.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-5.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afb6a20344c0f46351825e6e7e0fe7eb09bbfede4622273266c261adee55a102
-size 55774

--- a/apps/games/assets/french-suited-card/textures/diamonds-5.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eca11b6d8d984e5112c8365a4a2a4f1b584d161cb1e34bcb195b09153bedbf0e
-size 55645

--- a/apps/games/assets/french-suited-card/textures/diamonds-6.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-6.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4150d21e9a9a0407befe551007d68e29a10140c707d6f22d93580a16c96d3a83
-size 56668

--- a/apps/games/assets/french-suited-card/textures/diamonds-6.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b21cb412cc099b09d1f8713226f3c806b54177d58d82843e31185d6b4d9931af
-size 56780

--- a/apps/games/assets/french-suited-card/textures/diamonds-7.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-7.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fe75939ce3dbae7e5bfd7ec23d96b76712832650516c1776911dab53a693dd4
-size 57118

--- a/apps/games/assets/french-suited-card/textures/diamonds-7.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab2a0ea03cc56ec8b7917749265c55f3d67155e7ae1f709e5de0c52a70f6d4f3
-size 57036

--- a/apps/games/assets/french-suited-card/textures/diamonds-8.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-8.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c65c13f13602d5d3fbb3fec8974da477163d7e28d34fe12f336667a22923f78b
-size 58388

--- a/apps/games/assets/french-suited-card/textures/diamonds-8.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b92b1aadde692bbaf6fd5505a6834af1982e2860e1a1f8c02fb9495869f07dc6
-size 58281

--- a/apps/games/assets/french-suited-card/textures/diamonds-9.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-9.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f713175e975fc8a7f1e3a6fa786c15505566432771f92c75dd44dd5c56218c52
-size 59274

--- a/apps/games/assets/french-suited-card/textures/diamonds-9.png
+++ b/apps/games/assets/french-suited-card/textures/diamonds-9.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00261f66933866147ac63aa46af8dec3b9c6b95b640fa4e48524417e3fca4350
-size 59214

--- a/apps/games/assets/french-suited-card/textures/hearts-1.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-1.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d671d1724652b5b4f22af026f7fcf5e6aa103fef16c1e8091d1ddb4d9fd3ac3b
-size 53337

--- a/apps/games/assets/french-suited-card/textures/hearts-1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2005e2fcffae944bc3c3885fcd1143a3ceb72fe63a93258eb2c40d7029b96d2c
-size 53627

--- a/apps/games/assets/french-suited-card/textures/hearts-10.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-10.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b105ad19f16f6ce43bcb80937e41606ee0e6b17da97f950b0839e02c850e9857
-size 61678

--- a/apps/games/assets/french-suited-card/textures/hearts-10.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc3da833cbc2e3b385e130f29822d023fe51bec0e868148a3b9851bb1182da1c
-size 62239

--- a/apps/games/assets/french-suited-card/textures/hearts-11.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-11.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ced5d222076e351791391582bb2d46334464b4b82a6a1970f5be764143dfff2
-size 106721

--- a/apps/games/assets/french-suited-card/textures/hearts-11.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:484acec9207b39ade83b1f65683520b89258a9b35306a267c8efdba4b348301c
-size 106612

--- a/apps/games/assets/french-suited-card/textures/hearts-12.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-12.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c3e1b873125a449adf5efa23e51c686e88dd3e21d5459493364eb3a62058274
-size 112184

--- a/apps/games/assets/french-suited-card/textures/hearts-12.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2065c8bd7532d770690a8ef54ad59ffdf28cd5ea4b20b53149dd8e6dba8159d1
-size 112837

--- a/apps/games/assets/french-suited-card/textures/hearts-13.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-13.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c7a90af8c75b571baee747875d0ef7d9681954696e968475aee00979771ab30
-size 106567

--- a/apps/games/assets/french-suited-card/textures/hearts-13.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af258d44a9402d3b4440fb267fdf3f88d660c64354c008b5827e94a6f2c581a9
-size 107120

--- a/apps/games/assets/french-suited-card/textures/hearts-2.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-2.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8a3eda9f36a25243d2e9b5e89d94faa6470b7227420357318c5c7420e9f9659
-size 53903

--- a/apps/games/assets/french-suited-card/textures/hearts-2.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4850a0215c1d10909ee2dd5a997c92d8b68f549b00935b0d4283602075029d68
-size 53778

--- a/apps/games/assets/french-suited-card/textures/hearts-3.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-3.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ac1f1c344bfc1c744fcfa2f64547e721ec9f68293aee5fd14a1f4a6d8279394
-size 55266

--- a/apps/games/assets/french-suited-card/textures/hearts-3.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eb3c4140146c324b865beec24b205dfa27a67f8619714b3bc3da84767b3b42d
-size 55333

--- a/apps/games/assets/french-suited-card/textures/hearts-4.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-4.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:779da0640473ede166ba2a2da32d6df036d62e8483df770da0cd65fd9ccd72f4
-size 55456

--- a/apps/games/assets/french-suited-card/textures/hearts-4.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e414f97e9a23621fed981ef35acf4d2ba1f8074adb4f31bd3a3d34d38f9c2240
-size 55864

--- a/apps/games/assets/french-suited-card/textures/hearts-5.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-5.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf53842c79cd745bd7ddeac48391815f9263e3f39811b959cf62dda4ef5c9c0b
-size 56621

--- a/apps/games/assets/french-suited-card/textures/hearts-5.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c17d024f230472e6832c4e04e89ecfda782b0dffe1dc2075090365d46c47725
-size 57058

--- a/apps/games/assets/french-suited-card/textures/hearts-6.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-6.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b74750698bb56c7ac0d5402b9aff16337f41061a0ec9e49a16941b6ca6751a29
-size 57956

--- a/apps/games/assets/french-suited-card/textures/hearts-6.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:355293564ff42c988880a23165dd2adcf9fbcf2c587cfacfb7d925047ac19a80
-size 58402

--- a/apps/games/assets/french-suited-card/textures/hearts-7.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-7.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1689594f7dc07a2a5d44fb1cca96ec234ba37f45ff8c844c84b699d88446e05
-size 58301

--- a/apps/games/assets/french-suited-card/textures/hearts-7.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:928675f8be90c6e971f5831e72aae5df89e0d848b59943312877fdefc1204e15
-size 59054

--- a/apps/games/assets/french-suited-card/textures/hearts-8.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-8.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f62d024b287429846bccfbdbfca6f1016ade92eadd5f90338dcf93b5368479c7
-size 60007

--- a/apps/games/assets/french-suited-card/textures/hearts-8.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39c6e77b4d4d36f77ac6dc001f4bb89d5488c68e46ce1e685c65e20a6792a86c
-size 60354

--- a/apps/games/assets/french-suited-card/textures/hearts-9.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-9.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9df9ee65eb2db8549ee68bc0004816ec380de17fdf7c8046b9cc0fb93427bf1
-size 60846

--- a/apps/games/assets/french-suited-card/textures/hearts-9.png
+++ b/apps/games/assets/french-suited-card/textures/hearts-9.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:331538ca6d86da44e8a17c22588c4d4d914fc696a5b3f38f8b32790d337ab168
-size 61597

--- a/apps/games/assets/french-suited-card/textures/spades-1.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-1.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b23ddcebd6fc4df55d9b899384ccd6645f95e9f618b5c8c41d1beaaa08e71d9f
-size 53195

--- a/apps/games/assets/french-suited-card/textures/spades-1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8cbae16faf8d314ac89701315bf47bd55593d11b79b52b974d8b4da179197a2
-size 53151

--- a/apps/games/assets/french-suited-card/textures/spades-10.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-10.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a9e2db5f1e0a7dcb7766e33a767bde287688fa87efde8971347aa9b65fba16c
-size 60721

--- a/apps/games/assets/french-suited-card/textures/spades-10.png
+++ b/apps/games/assets/french-suited-card/textures/spades-10.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5560fcb6c4a8aab017da549dbbbfbf34c0383376c4ccffdfff0401e34d4d9a7
-size 60624

--- a/apps/games/assets/french-suited-card/textures/spades-11.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-11.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f2e2c1abecca3231e03dbd5145059f124515c3e440233ffc689324d2c2e507f
-size 113477

--- a/apps/games/assets/french-suited-card/textures/spades-11.png
+++ b/apps/games/assets/french-suited-card/textures/spades-11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d0cb16301d1020a709c99126515b247e1d622d0027ccf45b5fea98554366c7c
-size 114147

--- a/apps/games/assets/french-suited-card/textures/spades-12.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-12.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66e0263e53651358340557035c463afef4b8fd940493b6535325f241deade47f
-size 107606

--- a/apps/games/assets/french-suited-card/textures/spades-12.png
+++ b/apps/games/assets/french-suited-card/textures/spades-12.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2c1c92d5d9e2482c77d7442dd25884a74de7c350870bab32129f8f679a15508
-size 108370

--- a/apps/games/assets/french-suited-card/textures/spades-13.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-13.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91c07defd41a54554ab7beaec22a1a647990fb242d743854f423f14597963ee9
-size 108157

--- a/apps/games/assets/french-suited-card/textures/spades-13.png
+++ b/apps/games/assets/french-suited-card/textures/spades-13.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57d3e1b17b66e3c5f1f510c5ae5be0747d34655546f1d26df6210f708f67e5e5
-size 108509

--- a/apps/games/assets/french-suited-card/textures/spades-2.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-2.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1f87024123f652ef5f58d04998fd7d7ea5e2240fcc5eeaa85736d8d6b300908
-size 53673

--- a/apps/games/assets/french-suited-card/textures/spades-2.png
+++ b/apps/games/assets/french-suited-card/textures/spades-2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:168ceaebeccd84ce3f8f3c0a72b1ee7a8e6a69d7cfe96398739787c05171ebf0
-size 53849

--- a/apps/games/assets/french-suited-card/textures/spades-3.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-3.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44e0fe40ecedd746d697cb07d915705c0db3aad0b5c453bbce7d0d66216665ea
-size 55107

--- a/apps/games/assets/french-suited-card/textures/spades-3.png
+++ b/apps/games/assets/french-suited-card/textures/spades-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:deaedf5723cb3353dcfa014ac3549cd546c4bbcbe4fcc149ca8b50e652cecf31
-size 54921

--- a/apps/games/assets/french-suited-card/textures/spades-4.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-4.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8160d0fc7a23f84e458beab17e65b1f734dc4eb06be9bb1a5261930951bed3d4
-size 55366

--- a/apps/games/assets/french-suited-card/textures/spades-4.png
+++ b/apps/games/assets/french-suited-card/textures/spades-4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef73f144aaf504de62cc3a08fb7ca79096f8542a80020e0943a5d1e678acd69a
-size 55311

--- a/apps/games/assets/french-suited-card/textures/spades-5.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-5.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f6f84771c6bad7410f342b12f36916fa193fba672b8cb68db4e7560eb6d424b
-size 56712

--- a/apps/games/assets/french-suited-card/textures/spades-5.png
+++ b/apps/games/assets/french-suited-card/textures/spades-5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46b1cddf40cdc1dfb17b1f1bc5cba1e393a99e67ec4779ebd7fd7d27983faf1b
-size 56274

--- a/apps/games/assets/french-suited-card/textures/spades-6.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-6.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:daa74d1767bfbbf08c3366841c06de050dc892540262a79fe0743180072c3df7
-size 57789

--- a/apps/games/assets/french-suited-card/textures/spades-6.png
+++ b/apps/games/assets/french-suited-card/textures/spades-6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:241e87b4d14b38fe340cee17e7cee388b11e3dba2ac83850814880c86510517a
-size 57338

--- a/apps/games/assets/french-suited-card/textures/spades-7.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-7.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a20bbbfdbf6b7bf51c86e372c342d319b218a280d9d9b7e384155ce2ed54729
-size 58084

--- a/apps/games/assets/french-suited-card/textures/spades-7.png
+++ b/apps/games/assets/french-suited-card/textures/spades-7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce097f5295517832bc76b33ed81650900c6aa6c87c1c8eb64f570da5348e9620
-size 57793

--- a/apps/games/assets/french-suited-card/textures/spades-8.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-8.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58204764094e25de65c4b03b42e44b45de2ef9cd2bf004fe8b78e3ff20afce60
-size 59714

--- a/apps/games/assets/french-suited-card/textures/spades-8.png
+++ b/apps/games/assets/french-suited-card/textures/spades-8.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:935490012a68f6ab49ff39fb97b1947af48b8565d51e1043367b67a22b719b15
-size 59094

--- a/apps/games/assets/french-suited-card/textures/spades-9.gl1.png
+++ b/apps/games/assets/french-suited-card/textures/spades-9.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25f9613c3b201d87912cb70c90d4a26aee4b0dd814ec083adfdada8dec52120e
-size 59749

--- a/apps/games/assets/french-suited-card/textures/spades-9.png
+++ b/apps/games/assets/french-suited-card/textures/spades-9.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9544c7e781a0488fabb234aef5380a91df9af30418d0856f0bf61f0c058f768
-size 59781

--- a/apps/games/assets/klondike/catalog/cover.png
+++ b/apps/games/assets/klondike/catalog/cover.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf449a98cb4484efe8d3898ba7f1eafa737a3d9ed9abe7efa3bb2b7b3bb650bb
-size 2339541

--- a/apps/games/assets/klondike/textures/board.gl1.png
+++ b/apps/games/assets/klondike/textures/board.gl1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f26adecbda48a724afec307ac27979fc6208bbf6f082abf41c446c0495f0c5c9
-size 29279

--- a/apps/games/assets/klondike/textures/board.png
+++ b/apps/games/assets/klondike/textures/board.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a85c6c52a77e8cee218cd1b4f82600341ff0256a1b35e362ba61d1fa02df7c74
-size 22856

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -93,6 +93,13 @@ import repositories from '../repositories/index.js'
  */
 
 /**
+ * @typedef {object} DrawableState state for drawable meshes:
+ * @property {boolean} [unflipOnPick=true] - unflip flipped mesh when picking them in hand.
+ * @property {boolean} [flipOnPlay=false] - flip flipable meshes when playing them from hand.
+ * @property {number} [duration=750] - duration (in milliseconds) of the draw animation.
+ */
+
+/**
  * @typedef {object} Message a message in the discussion thread:
  * @property {string} playerId - sender id.
  * @property {string} text - message's textual content.

--- a/apps/web/src/3d/utils/lights.js
+++ b/apps/web/src/3d/utils/lights.js
@@ -47,7 +47,7 @@ export function createLights({ scene, handScene } = {}) {
 
 function makeDirectionalLight(scene) {
   const light = new DirectionalLight('sun', new Vector3(0, -1, 0), scene)
-  light.intensity = 0.8
+  light.intensity = 0.95
   light.specular = Color3.Black()
   return light
 }

--- a/apps/web/src/3d/utils/mesh.js
+++ b/apps/web/src/3d/utils/mesh.js
@@ -74,7 +74,7 @@ export function configureMaterial(mesh, texture) {
  */
 export function adaptTexture(texture) {
   return texture && Engine.LastCreatedEngine.version === 1
-    ? texture.replace('.ktx2', '.gl1.png')
+    ? texture.replace('.ktx2', '.gl1.webp')
     : texture
 }
 

--- a/apps/web/src/3d/utils/mesh.js
+++ b/apps/web/src/3d/utils/mesh.js
@@ -68,9 +68,9 @@ export function configureMaterial(mesh, texture) {
 
 /**
  * Adapts the downloaded texture file based on the current WebGL version.
- * Since WebGL 1 does not support Khronos Texture properly, uses png files instead.
+ * Since WebGL 1 does not support Khronos Texture properly, uses webp files instead.
  * @param {string} texture - the texture file name.
- * @returns {string} if the engine is WebGL 1, the input texture with ktx2 extension replaced with png.
+ * @returns {string} if the engine is WebGL 1, the input texture with ktx2 extension replaced with webp.
  */
 export function adaptTexture(texture) {
   return texture && Engine.LastCreatedEngine.version === 1

--- a/apps/web/src/components/CatalogItem.svelte
+++ b/apps/web/src/components/CatalogItem.svelte
@@ -45,7 +45,7 @@
 </style>
 
 <article on:click={() => dispatch('click', game)}>
-  <img src="games/{game.name}/catalog/cover.png" alt={title} />
+  <img src="games/{game.name}/catalog/cover.webp" alt={title} />
   <div class="content">
     <caption>
       <h3>{title}</h3>

--- a/apps/web/src/components/RuleViewer.svelte
+++ b/apps/web/src/components/RuleViewer.svelte
@@ -48,7 +48,7 @@
     {#if game}
       <img
         alt={$_('tooltips.rule-page', { page: page + 1 })}
-        src={`games/${game}/rules/${page + 1}.png`}
+        src={`games/${game}/rules/${page + 1}.webp`}
       />
     {/if}
   </div>

--- a/apps/web/tests/3d/utils/lights.test.js
+++ b/apps/web/tests/3d/utils/lights.test.js
@@ -13,7 +13,7 @@ describe('createLights() 3D utility', () => {
   it('creates default lights and shadow generator', () => {
     const { light, shadowGenerator } = createLights({ scene, handScene })
     expect(light.name).toEqual('sun')
-    expect(light.intensity).toEqual(0.8)
+    expect(light.intensity).toEqual(0.95)
     expect(light.specular.asArray()).toEqual([0, 0, 0])
     expect(light.direction.x).toEqual(0)
     expect(light.direction.y).toEqual(-1)

--- a/apps/web/tests/3d/utils/mesh.test.js
+++ b/apps/web/tests/3d/utils/mesh.test.js
@@ -90,12 +90,12 @@ describe('isContaining() 3D utility', () => {
 
 describe('adaptTexture() 3D utility', () => {
   const ktx2 = 'some/path/to/texture.ktx2'
-  const png = 'some/path/to/texture.gl1.png'
+  const webp = 'some/path/to/texture.gl1.webp'
 
   describe('given an WebGL 1 engine', () => {
     it.each([
-      ['downgrades KTX2 to PNG', ktx2, png],
-      ['keeps PNG as PNG', png, png],
+      ['downgrades KTX2 to WebP', ktx2, webp],
+      ['keeps WebP as WebP', webp, webp],
       ['handles null', null, null],
       ['handles undefined', undefined, undefined]
     ])('%s', (text, original, result) => {
@@ -115,7 +115,7 @@ describe('adaptTexture() 3D utility', () => {
 
     it.each([
       ['keeps KTX2 as KTX2', ktx2, ktx2],
-      ['keeps PNG as PNG', png, png],
+      ['keeps WebP as WebP', webp, webp],
       ['handles null', null, null],
       ['handles undefined', undefined, undefined]
     ])('%s', (text, original, result) => {

--- a/apps/web/tests/components/CatalogItem.test.js
+++ b/apps/web/tests/components/CatalogItem.test.js
@@ -17,7 +17,7 @@ describe('CatalogItem component', () => {
     renderComponent({ game })
     expect(screen.getByRole('img')).toHaveAttribute(
       'src',
-      `games/${game.name}/catalog/cover.png`
+      `games/${game.name}/catalog/cover.webp`
     )
     expect(screen.getByRole('heading')).toHaveTextContent(title)
     expect(handleClick).not.toHaveBeenCalled()

--- a/apps/web/tests/components/RuleViewer.test.js
+++ b/apps/web/tests/components/RuleViewer.test.js
@@ -19,7 +19,7 @@ describe('RuleViewer component', () => {
     renderComponent({ lastPage: 2 })
     const image = screen.queryByRole('img')
     const [previous, next] = screen.queryAllByRole('button')
-    expect(image).toHaveAttribute('src', `games/${game}/rules/1.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/1.webp`)
     expect(previous).toBeDisabled()
     expect(next).toBeEnabled()
     expect(handleChange).not.toHaveBeenCalled()
@@ -29,12 +29,12 @@ describe('RuleViewer component', () => {
     renderComponent({ lastPage: 2 })
     const image = screen.queryByRole('img')
     const [previous, next] = screen.queryAllByRole('button')
-    expect(image).toHaveAttribute('src', `games/${game}/rules/1.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/1.webp`)
     expect(handleChange).not.toHaveBeenCalled()
 
     fireEvent.click(next)
     await tick()
-    expect(image).toHaveAttribute('src', `games/${game}/rules/2.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/2.webp`)
     expect(previous).toBeEnabled()
     expect(next).toBeEnabled()
     expect(handleChange).toHaveBeenNthCalledWith(
@@ -44,7 +44,7 @@ describe('RuleViewer component', () => {
 
     fireEvent.click(next)
     await tick()
-    expect(image).toHaveAttribute('src', `games/${game}/rules/3.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/3.webp`)
     expect(previous).toBeEnabled()
     expect(next).toBeDisabled()
     expect(handleChange).toHaveBeenNthCalledWith(
@@ -58,12 +58,12 @@ describe('RuleViewer component', () => {
     renderComponent({ lastPage: 2 })
     const image = screen.queryByRole('img')
     const [previous, next] = screen.queryAllByRole('button')
-    expect(image).toHaveAttribute('src', `games/${game}/rules/1.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/1.webp`)
     expect(handleChange).not.toHaveBeenCalled()
 
     fireEvent.click(next)
     await tick()
-    expect(image).toHaveAttribute('src', `games/${game}/rules/2.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/2.webp`)
     expect(previous).toBeEnabled()
     expect(next).toBeEnabled()
     expect(handleChange).toHaveBeenNthCalledWith(
@@ -73,7 +73,7 @@ describe('RuleViewer component', () => {
 
     fireEvent.click(previous)
     await tick()
-    expect(image).toHaveAttribute('src', `games/${game}/rules/1.png`)
+    expect(image).toHaveAttribute('src', `games/${game}/rules/1.webp`)
     expect(previous).toBeDisabled()
     expect(next).toBeEnabled()
     expect(handleChange).toHaveBeenNthCalledWith(

--- a/apps/web/tests/components/__snapshots__/CatalogItem.tools.shot
+++ b/apps/web/tests/components/__snapshots__/CatalogItem.tools.shot
@@ -7,7 +7,7 @@ exports[`Toolshot components/CatalogItem.tools.svelte: No age nor time 1`] = `
   <article>
     <img
       alt="Solitaire"
-      src="games/klondike/catalog/cover.png"
+      src="games/klondike/catalog/cover.webp"
     />
      
     <div
@@ -36,7 +36,7 @@ exports[`Toolshot components/CatalogItem.tools.svelte: With Age and time 1`] = `
   <article>
     <img
       alt="Solitaire"
-      src="games/klondike/catalog/cover.png"
+      src="games/klondike/catalog/cover.webp"
     />
      
     <div

--- a/apps/web/tests/components/__snapshots__/RuleViewer.tools.shot
+++ b/apps/web/tests/components/__snapshots__/RuleViewer.tools.shot
@@ -38,7 +38,7 @@ exports[`Toolshot components/RuleViewer.tools.svelte: Components/Rule Viewer 1`]
     >
       <img
         alt="Livre de règles, page 1"
-        src="games/klondike/rules/1.png"
+        src="games/klondike/rules/1.webp"
       />
     </div>
   </section>


### PR DESCRIPTION
### What's in there?

PNG files are ok when authoring images, but too heavy for data at rest and in transit.
Let's use webp equivalent, which offers great performances for smaller file sizes.

Are included here:

- chore(web): uses webp format for game rules and covers
- chore(games): replaces png images with wepb equivalent
- chore(web): use brighter lights

### How to test?

**Get rid of existing games, by deleting `apps/server/data/games.json`**
Then restart your server, and create new Klondike and Coinche games. Webp is in use:
- in the game catalog
- as GL1 textures (usually on mobiles)
- as card detailed image (Klondike only)