### PR TITLE
feat(web, server)!: authenticate and uses our TURN server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 scans/
 .eslintcache
 debug.txt
+.env

--- a/TODO.md
+++ b/TODO.md
@@ -51,11 +51,11 @@
 - use JWT as authentication token (stores player id and username)
 - allows a single connection per player (discards other JWTs)
 - logging (warning on invalid descriptors)
+- better coTURN integration (password management and rotation)
 
 ## Hosting
 
 - where to store secrets?
-- use an env file
 - deploy in a folder named after the commit SHA
 - use symlink to switch between deployments (including conf files)
 - rotates log files

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -37,8 +37,16 @@ export default {
      * @param {object} args - mutation arguments, including:
      * @param {string} data.username - username.
      * @param {string} data.password - clear password.
-     * @returns {import('../services/authentication').Player|null} authentified player or null.
+     * @param {object} context - graphQL context.
+     * @returns {import('./players.graphqk').PlayerWithTurnCredentials|null} authentified player or null.
      */
-    logIn: (obj, { username, password }) => services.logIn(username, password)
+    logIn: async (obj, { username, password }, { conf }) => {
+      const player = await services.logIn(username, password)
+      if (!player) {
+        return null
+      }
+      const turnCredentials = services.generateTurnCredentials(conf.turn.secret)
+      return { player, turnCredentials }
+    }
   }
 }

--- a/apps/server/src/graphql/players.graphql
+++ b/apps/server/src/graphql/players.graphql
@@ -4,11 +4,21 @@ type Player {
   playing: Boolean!
 }
 
+type TurnCredentials {
+  username: String!
+  credentials: String!
+}
+
+type PlayerWithTurnCredentials {
+  player: Player!
+  turnCredentials: TurnCredentials!
+}
+
 type Query {
   getCurrentPlayer: Player
   searchPlayers(search: String!): [Player]
 }
 
 type Mutation {
-  logIn(username: String!, password: String!): Player
+  logIn(username: String!, password: String!): PlayerWithTurnCredentials
 }

--- a/apps/server/src/services/configuration.js
+++ b/apps/server/src/services/configuration.js
@@ -49,6 +49,11 @@ const validate = new Ajv({ allErrors: true }).compile({
           }
         }
       }
+    },
+    turn: {
+      properties: {
+        secret: { type: 'string' }
+      }
     }
   }
 })
@@ -89,6 +94,7 @@ function makeAbsolute(path) {
  * - NODE_ENV: 'production' indicates production mode.
  * - PORT: server listening port (must be a number). Defaults to 443 in production, and 3001 otherwise.
  * - WS_ENDPOINT: url of the web socket endpoint. Defaults to '/ws'.
+ * - TURN_SECRET: secret used to generate turn credentials. Must be the same as coTURN static-auth-secret
  *
  * @returns {Configuration} the loaded configuration.
  * @throws {Error} when the provided environment variables do not match expected values.
@@ -102,7 +108,8 @@ export function loadConfiguration() {
     HTTPS_KEY,
     LOG_LEVEL,
     NODE_ENV,
-    PORT
+    PORT,
+    TURN_SECRET
   } = process.env
 
   const isProduction = /^\w*production\w*$/i.test(NODE_ENV)
@@ -132,6 +139,9 @@ export function loadConfiguration() {
     },
     data: {
       path: DATA_PATH ?? 'data'
+    },
+    turn: {
+      secret: TURN_SECRET
     }
   }
   configuration.data.path = makeAbsolute(configuration.data.path)

--- a/apps/server/src/services/index.js
+++ b/apps/server/src/services/index.js
@@ -2,7 +2,8 @@ import * as conf from './configuration.js'
 import * as catalog from './catalog.js'
 import * as games from './games.js'
 import * as players from './players.js'
+import * as turnCredentials from './turn-credentials.js'
 
 // because Jest can not mock ESM modules, exports an object that can be monkey-patched
 // it prevents from destructuring imported object
-export default { ...conf, ...games, ...players, ...catalog }
+export default { ...conf, ...games, ...players, ...catalog, ...turnCredentials }

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -8,10 +8,6 @@ import repositories from '../repositories/index.js'
  * @property {boolean} playing - whether this player has currently joined an active game.
  */
 
-function hash(value) {
-  return createHash('sha256').update(value).digest('hex')
-}
-
 const masterPassword = hash('ehfada')
 
 /**
@@ -35,6 +31,10 @@ export async function logIn(username, password) {
     })
   }
   return player
+}
+
+function hash(value) {
+  return createHash('sha256').update(value).digest('hex')
 }
 
 /**

--- a/apps/server/src/services/turn-credentials.js
+++ b/apps/server/src/services/turn-credentials.js
@@ -1,0 +1,25 @@
+import { createHmac } from 'crypto'
+
+/**
+ * @typedef {object} TurnCredentials used to connect to the turn server
+ * @property {string} username - unix timestamp representing the expiry date.
+ * @property {string} credentials - required to connect.
+ */
+
+/**
+ * Generates valid credentials for using the turn server.
+ * @param {string} secret - secret configured in coTurn server as `static-auth-secret`.
+ * @returns {TurnCredentials} credentials for using the turn server.
+ */
+export function generateTurnCredentials(secret) {
+  // credits to https://medium.com/@helderjbe/setting-up-a-turn-server-with-node-production-ready-8f4a4c36e64d
+  const username = (Math.floor(Date.now() / 1000) + 12 * 3600).toString()
+  return {
+    username,
+    credentials: hash(secret, username)
+  }
+}
+
+function hash(secret, value) {
+  return createHmac('sha1', secret).update(value).digest('base64')
+}

--- a/apps/server/tests/graphql/signals-resolver.test.js
+++ b/apps/server/tests/graphql/signals-resolver.test.js
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { jest } from '@jest/globals'
 import fastify from 'fastify'
 import {
+  mockMethods,
   openGraphQLWebSocket,
   startSubscription,
   stopSubscription,
@@ -14,7 +15,7 @@ import graphQL from '../../src/plugins/graphql.js'
 describe('given a started server', () => {
   let server
   let ws
-  let originalServices = { ...services }
+  let restoreServices
   const playerId = faker.datatype.uuid()
 
   beforeAll(async () => {
@@ -22,16 +23,13 @@ describe('given a started server', () => {
     server.register(graphQL)
     await server.listen()
     ws = await openGraphQLWebSocket(server)
-    // monkey patch services
-    for (const method in services) {
-      services[method] = jest.fn()
-    }
+    restoreServices = mockMethods(services)
   })
 
   beforeEach(jest.resetAllMocks)
 
   afterAll(async () => {
-    Object.assign(services, originalServices)
+    restoreServices()
     try {
       ws?.close()
     } catch {

--- a/apps/server/tests/server.test.js
+++ b/apps/server/tests/server.test.js
@@ -43,13 +43,14 @@ describe('startServer()', () => {
         }
       },
       data: { path: 'data' },
-      games: { path: 'games' }
+      games: { path: 'games' },
+      turn: { secret: 'blabla' }
     })
 
     let response = await app.inject({
       method: 'POST',
       url: 'graphql',
-      payload: { query: 'mutation { logIn { id } }' }
+      payload: { query: 'mutation { logIn { player { id } } }' }
     })
     expect(response.json()?.errors?.[0]?.message).toMatch(
       /argument "username" of type "String!" is required/

--- a/apps/server/tests/services/configuration.test.js
+++ b/apps/server/tests/services/configuration.test.js
@@ -20,6 +20,7 @@ describe('loadConfiguration()', () => {
     const dataPath = faker.system.directoryPath()
     const key = faker.system.filePath()
     const cert = faker.system.filePath()
+    const secret = faker.lorem.words()
 
     process.env = {
       ...process.env,
@@ -29,7 +30,8 @@ describe('loadConfiguration()', () => {
       GAMES_PATH: gamesPath,
       DATA_PATH: dataPath,
       HTTPS_CERT: cert,
-      HTTPS_KEY: key
+      HTTPS_KEY: key,
+      TURN_SECRET: secret
     }
 
     expect(loadConfiguration()).toEqual({
@@ -42,12 +44,16 @@ describe('loadConfiguration()', () => {
         static: { path: gamesPath, pathPrefix: '/games' }
       },
       games: { path: gamesPath },
-      data: { path: dataPath }
+      data: { path: dataPath },
+      turn: { secret }
     })
   })
 
   it('loads production default values', () => {
+    const secret = faker.lorem.words()
     process.env.NODE_ENV = 'production'
+    process.env.TURN_SECRET = secret
+
     expect(loadConfiguration()).toEqual({
       isProduction: true,
       serverUrl: {
@@ -67,11 +73,15 @@ describe('loadConfiguration()', () => {
         }
       },
       games: { path: resolve(cwd(), '..', 'games', 'assets') },
-      data: { path: resolve(cwd(), 'data') }
+      data: { path: resolve(cwd(), 'data') },
+      turn: { secret }
     })
   })
 
   it('loads development default values', () => {
+    const secret = faker.lorem.words()
+    process.env.TURN_SECRET = secret
+
     expect(loadConfiguration()).toEqual({
       isProduction: false,
       serverUrl: {
@@ -87,7 +97,8 @@ describe('loadConfiguration()', () => {
         }
       },
       games: { path: resolve(cwd(), '..', 'games', 'assets') },
-      data: { path: resolve(cwd(), 'data') }
+      data: { path: resolve(cwd(), 'data') },
+      turn: { secret }
     })
   })
 
@@ -110,6 +121,7 @@ describe('loadConfiguration()', () => {
   })
 
   it('considers GAMES_PATH relatively to current working directory', () => {
+    process.env.TURN_SECRET = faker.lorem.words()
     process.env.CLIENT_ROOT = join('.', 'test')
     process.env.GAMES_PATH = join('.', 'test2')
     expect(loadConfiguration().plugins.static.path).toEqual(
@@ -119,6 +131,7 @@ describe('loadConfiguration()', () => {
   })
 
   it('considers DATA_PATH relatively to current working directory', () => {
+    process.env.TURN_SECRET = faker.lorem.words()
     process.env.DATA_PATH = './test'
     expect(loadConfiguration().data.path).toEqual(join(cwd(), 'test'))
   })

--- a/apps/server/tests/services/turn-credentials.test.js
+++ b/apps/server/tests/services/turn-credentials.test.js
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker'
+import { createHmac } from 'crypto'
+import { generateTurnCredentials } from '../../src/services/turn-credentials'
+
+describe('generateTurnCredentials()', () => {
+  it('generates compliant credentials for the next 12 hours', async () => {
+    const secret = faker.lorem.word()
+    const now = Math.floor(new Date().getTime() / 1000)
+
+    // see https://github.com/coturn/coturn/blob/upstream/4.5.2/README.turnserver#L180-L193
+    const username = `${now + 12 * 60 * 60}`
+    const credentials = Buffer.from(
+      createHmac('sha1', secret).update(username).digest()
+    ).toString('base64')
+
+    expect(await generateTurnCredentials(secret)).toEqual({
+      username,
+      credentials
+    })
+  })
+})

--- a/apps/server/tests/test-utils.js
+++ b/apps/server/tests/test-utils.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals'
 import WebSocket from 'ws'
 
 /**
@@ -70,4 +71,20 @@ export function stopSubscription(ws, id = 1) {
  */
 export function toGraphQLArg(object) {
   return JSON.stringify(object).replace(/"(\w+)":/g, '$1:')
+}
+
+/**
+ * Monkey patch all methods, replacing them with Jest mocks.
+ * Does not modify getters, setters and plain attributes
+ * @param {object} object - hash containing all service methods.
+ * @returns {function} revert patching when called.
+ */
+export function mockMethods(object) {
+  const original = { ...object }
+  for (const method in object) {
+    if (typeof object[method] === 'function') {
+      object[method] = jest.fn()
+    }
+  }
+  return () => Object.assign(object, original)
 }

--- a/apps/web/src/graphql/players.graphql
+++ b/apps/web/src/graphql/players.graphql
@@ -5,7 +5,13 @@ fragment player on Player {
 
 mutation logIn($username: String!, $password: String!) {
   logIn(username: $username, password: $password) {
-    ...player
+    player {
+      ...player
+    }
+    turnCredentials {
+      username
+      credentials
+    }
   }
 }
 

--- a/apps/web/tests/stores/players.test.js
+++ b/apps/web/tests/stores/players.test.js
@@ -1,11 +1,12 @@
 import { faker } from '@faker-js/faker'
 import * as graphQL from '../../src/graphql'
 import {
-  currentPlayer,
+  currentPlayer as currentPlayer$,
   logIn,
   logOut,
   recoverSession,
-  searchPlayers
+  searchPlayers,
+  turnCredentials as turnCredentials$
 } from '../../src/stores/players'
 import { runMutation, runQuery } from '../../src/stores/graphql-client'
 import { mockLogger } from '../utils'
@@ -25,31 +26,41 @@ describe('searchPlayers()', () => {
 
 describe('given a subscription to current player', () => {
   const logger = mockLogger('players')
-  let subscription
-  let loggedPlayer
+  let subscriptions
+  const playerChanged = jest.fn()
+  const turnCredentialsChanged = jest.fn()
   const username = faker.name.firstName()
   const password = faker.internet.password()
   const player = { id: faker.datatype.uuid(), username }
+  const turnCredentials = {
+    username: faker.lorem.words(),
+    credentials: faker.datatype.uuid()
+  }
 
   beforeAll(() => {
-    subscription = currentPlayer.subscribe(player => (loggedPlayer = player))
+    subscriptions = [
+      currentPlayer$.subscribe(playerChanged),
+      turnCredentials$.subscribe(turnCredentialsChanged)
+    ]
   })
 
   beforeEach(jest.resetAllMocks)
 
-  afterAll(() => subscription?.unsubscribe())
+  afterAll(() => subscriptions.forEach(sub => sub.unsubscribe()))
 
   describe('logIn()', () => {
-    it('sets current player on success', async () => {
-      runMutation.mockResolvedValueOnce(player)
-      expect(loggedPlayer).not.toEqual(player)
+    it('sets current player and turn credentials on success', async () => {
+      runMutation.mockResolvedValueOnce({ player, turnCredentials })
       expect(await logIn(username, password)).toEqual(player)
       expect(runMutation).toHaveBeenCalledWith(graphQL.logIn, {
         username,
         password
       })
       expect(runMutation).toHaveBeenCalledTimes(1)
-      expect(loggedPlayer).toEqual(player)
+      expect(playerChanged).toHaveBeenCalledWith(player)
+      expect(playerChanged).toHaveBeenCalledTimes(1)
+      expect(turnCredentialsChanged).toHaveBeenCalledWith(turnCredentials)
+      expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
     })
 
     it('reset current player on failure', async () => {
@@ -60,23 +71,30 @@ describe('given a subscription to current player', () => {
         password
       })
       expect(runMutation).toHaveBeenCalledTimes(1)
-      expect(loggedPlayer).toBeNull()
+      expect(playerChanged).toHaveBeenCalledWith(null)
+      expect(playerChanged).toHaveBeenCalledTimes(1)
+      expect(turnCredentialsChanged).toHaveBeenCalledWith(null)
+      expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('given an authenticated player', () => {
     beforeEach(async () => {
-      runMutation.mockResolvedValueOnce(player)
+      runMutation.mockResolvedValueOnce({ player, turnCredentials })
       expect(await logIn(username, password)).toEqual(player)
-      expect(loggedPlayer).toEqual(player)
       runMutation.mockReset()
+      playerChanged.mockReset()
+      turnCredentialsChanged.mockReset()
     })
 
     describe('logOut()', () => {
       it('clears current player', async () => {
         await logOut()
-        expect(loggedPlayer).toBeNull()
         expect(runMutation).not.toHaveBeenCalled()
+        expect(playerChanged).toHaveBeenCalledWith(null)
+        expect(playerChanged).toHaveBeenCalledTimes(1)
+        expect(turnCredentialsChanged).toHaveBeenCalledWith(null)
+        expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -84,30 +102,48 @@ describe('given a subscription to current player', () => {
       it('logs player out on missing data', async () => {
         sessionStorage.clear()
         expect(await recoverSession()).toBeNull()
-        expect(loggedPlayer).toBeNull()
+        expect(playerChanged).toHaveBeenCalledWith(null)
+        expect(playerChanged).toHaveBeenCalledTimes(1)
+        expect(turnCredentialsChanged).toHaveBeenCalledWith(null)
+        expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
         expect(logger.warn).not.toHaveBeenCalled()
       })
 
       it('logs player out on invalid data', async () => {
-        sessionStorage.setItem('player', '{"invalid": true')
+        sessionStorage.setItem('session', '{"invalid": true')
         expect(await recoverSession()).toBeNull()
-        expect(loggedPlayer).toBeNull()
+        expect(playerChanged).toHaveBeenCalledWith(null)
+        expect(playerChanged).toHaveBeenCalledTimes(1)
+        expect(turnCredentialsChanged).toHaveBeenCalledWith(null)
+        expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
         expect(logger.warn).toHaveBeenCalledTimes(1)
       })
 
       it('logs player out on outdated data', async () => {
-        sessionStorage.setItem('player', JSON.stringify(player))
+        sessionStorage.setItem(
+          'session',
+          JSON.stringify({ player, turnCredentials })
+        )
         runQuery.mockRejectedValueOnce(new Error('outdated!'))
         expect(await recoverSession()).toBeNull()
-        expect(loggedPlayer).toBeNull()
+        expect(playerChanged).toHaveBeenCalledWith(null)
+        expect(playerChanged).toHaveBeenCalledTimes(1)
+        expect(turnCredentialsChanged).toHaveBeenCalledWith(null)
+        expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
         expect(logger.warn).toHaveBeenCalledTimes(1)
       })
 
       it('authenticates player with valid data', async () => {
-        sessionStorage.setItem('player', JSON.stringify(player))
+        sessionStorage.setItem(
+          'session',
+          JSON.stringify({ player, turnCredentials })
+        )
         runQuery.mockResolvedValueOnce(player)
         expect(await recoverSession()).toEqual(player)
-        expect(loggedPlayer).toEqual(player)
+        expect(playerChanged).toHaveBeenCalledWith(player)
+        expect(playerChanged).toHaveBeenCalledTimes(1)
+        expect(turnCredentialsChanged).toHaveBeenCalledWith(turnCredentials)
+        expect(turnCredentialsChanged).toHaveBeenCalledTimes(1)
         expect(logger.warn).not.toHaveBeenCalled()
       })
     })

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -68,7 +68,7 @@ First commands will need to connect with IPv4 (hence the `-4` flag) in the meant
   - open an SSH connection to the VPS: `ssh ubuntu@vps-XYZ.vps.ovh.net`
   - get Nginx: `sudo apt install nginx-full -y`
   - stop it: `sudo nginx -s quit`
-  - edits its configuration: `sudo vi /etc/nginx/nginx.conf`:
+  - edits its configuration: `sudo vi /etc/nginx/nginx.conf`
     - change `user www-data` to `user tabulous`
   - removes default NGINX site: `sudo rm /etc/nginx/sites-enabled/default`
   - creates a symbolic link for tabulous NGINX site: `sudo ln -s /home/tabulous/nginx/tabulous /etc/nginx/sites-enabled/tabulous`
@@ -97,6 +97,23 @@ First commands will need to connect with IPv4 (hence the `-4` flag) in the meant
     1.  decline sharing email address
     1.  allow all domains
 
+- install coTurn ([source](https://medium.com/@helderjbe/setting-up-a-turn-server-with-node-production-ready-8f4a4c36e64d)):
+
+  - open an SSH connection to the VPS: `ssh ubuntu@vps-XYZ.vps.ovh.net`
+  - update apt and install coTurn: `sudo apt-get -y update` & `sudo apt-get -y install coturn`
+  - enable as a service: `echo 'TURNSERVER_ENABLED=1' | sudo tee /etc/default/coturn`
+  - generate some random secret value (save it somewhere): `openssl rand -base64 32`
+  - edits its configuration: `sudo vi /etc/turnserver.conf`
+    - uncomment `#fingerprint`
+    - uncomment `#use-auth-secret`
+    - provide your new secret value for `static-auth-secret=[SECRET]`
+    - uncomment `#realm=[DOMAIN]` and change domain value for `tabulous.fr`
+    - uncomment `#total-quota=0` and change value for `100`
+    - uncomment `#no-multicast-peers`
+    - uncomment `#cert=[PATH]` and change path value for `/home/tabulous/certbot/live/tabulous.fr/fullchain.pem`
+    - uncomment `#pkey=[PATH]` and change path value for `/home/tabulous/certbot/live/tabulous.fr/privkey.pem`
+  - restart service: `sudo systemctl restart coturn`
+
 ## Continuous deployment
 
 [Inspiration](https://coderflex.com/blog/2-easy-steps-to-automate-a-deployment-in-a-vps-with-github-actions)
@@ -119,6 +136,16 @@ _Hints_
 
 Tail server logs: `journalctl -f -u tabulous`
 Tail nginx logs: `tail -f /var/log/nginx/access.log`
+
+## Tabulous Configuration
+
+Tabulous server runs with sensible defaults, but still needs some configuration through environment variables.
+Because such configuration should not be commited on Github, it is stored in an `.env` file
+
+- open an SSH connection to the VPS _as tabulous_: `ssh tabulous@vps-XYZ.vps.ovh.net`
+- generate some random
+- edit configuration file: `vi ~/server/.env`
+  - add `TURN_SECRET=[SECRET]` with the same secret value as coTURN's `static-auth-secret`
 
 ## Maintenance
 


### PR DESCRIPTION
### What's in there?

Establishing WebRTC connection has always been a hassle. Deploying and using our own TURN server is good mitigation.
I chose to use [coTURN](https://github.com/coturn/coturn/), and applied instructions from [this very good article](https://medium.com/@helderjbe/setting-up-a-turn-server-with-node-production-ready-8f4a4c36e64d).

The simplest way to use it involves generating some credentials on the server-side. For the sake of simplicity, they are retrieved as part of the authentication data.

Are included here:

- feat(web): retrieves turn credentials during the authentication
- feat(server)!: generates turn credentials upon authentication. Requires a new `TURN_SECRET` env variable.
-  docs: how to configure coTURN

### How to test?

1. Create a `.env` file in the `apps/server` folder, and configure the new `TURN_SECRET` variable with our coTURN's `static-auth-secret` parameter.
2. Start your server and client
3. Launch a game, and invite another player. The connection should go smoothly now.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
