### PR TITLE
feat(server): introduces game descriptor utilities

### DIFF
--- a/apps/games/package.json
+++ b/apps/games/package.json
@@ -2,5 +2,8 @@
   "name": "@tabulous/games",
   "version": "0.0.1",
   "description": "Tabulous game descriptors and assets",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@tabulous/server": "^0.0.1"
+  }
 }

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -1,7 +1,7 @@
 import { Subject } from 'rxjs'
 import { concatMap, mergeMap } from 'rxjs/operators'
 import { canAccess } from './catalog.js'
-import { createMeshes } from './utils.js'
+import { createMeshes } from '../utils/index.js'
 import repositories from '../repositories/index.js'
 
 /**

--- a/apps/server/src/utils/index.js
+++ b/apps/server/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './collections.js'
+export * from './games.js'
 export * from './time.js'

--- a/apps/server/tests/fixtures/broken-games/broken/index.js
+++ b/apps/server/tests/fixtures/broken-games/broken/index.js
@@ -1,0 +1,9 @@
+import 'invalid-package'
+
+export function build() {
+  return {
+    meshes: [{ shape: 'card', id: 'one-of-diamonds' }],
+    bags: new Map(),
+    slots: []
+  }
+}

--- a/apps/server/tests/repositories/catalog-items.test.js
+++ b/apps/server/tests/repositories/catalog-items.test.js
@@ -35,8 +35,16 @@ describe('Catalog Items repository', () => {
       ).rejects.toThrow('Failed to connect Catalog Items repository')
     })
 
+    it('throws an invalid game descriptor', async () => {
+      await expect(
+        catalogItems.connect({
+          path: join('tests', 'fixtures', 'broken-games')
+        })
+      ).rejects.toThrow(`Cannot find module 'invalid-package'`)
+    })
+
     it('handles an folder without game descriptors', async () => {
-      await catalogItems.connect({ path: join('..', '..', 'drawings') })
+      await catalogItems.connect({ path: join('tests', 'fixtures') })
       expect(await catalogItems.list()).toEqual({
         total: 0,
         from: 0,

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -143,8 +143,14 @@ Tabulous server runs with sensible defaults, but still needs some configuration 
 Because such configuration should not be commited on Github, it is stored in an `.env` file
 
 - open an SSH connection to the VPS _as tabulous_: `ssh tabulous@vps-XYZ.vps.ovh.net`
-- generate some random
+
+- edit profile: `vi ~/?bashrc`
+
+  - add `export NODE_ENV=production` at the end
+  - save and reload: `source ~/.bashrc`
+
 - edit configuration file: `vi ~/server/.env`
+
   - add `TURN_SECRET=[SECRET]` with the same secret value as coTURN's `static-auth-secret`
 
 ## Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,10 @@
     },
     "apps/games": {
       "name": "@tabulous/games",
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dependencies": {
+        "@tabulous/server": "^0.0.1"
+      }
     },
     "apps/server": {
       "name": "@tabulous/server",
@@ -14000,7 +14003,10 @@
       }
     },
     "@tabulous/games": {
-      "version": "file:apps/games"
+      "version": "file:apps/games",
+      "requires": {
+        "@tabulous/server": "^0.0.1"
+      }
     },
     "@tabulous/server": {
       "version": "file:apps/server",


### PR DESCRIPTION
### What's in there?

Game descriptors need a set of common functions to alter the game data, like finding (and creating) a player's hand, or drawing meshes into it.
This PRs revamps `src/services/utils.js` into `src/utils/game.js` and adds 2 more utilities.

Are included here:

- feat(server): introduces game descriptor utilities

### How to test?

This can be tested through 6 Takes private implementation.