### PR TITLE
fix(web): stacking the entire selection does not update anchors and other stacks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@
 
 ## Refactor
 
-- bug: stacking all card do not release stack/anchors (no drag start operation)
 - bug: ICE failed message when peer reload their browser??
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: moving card collides with a stack of cards

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -10,8 +10,8 @@ import {
 import { TargetBehavior } from './targetable'
 import {
   controlManager,
-  inputManager,
   indicatorManager,
+  moveManager,
   selectionManager,
   targetManager
 } from '../managers'
@@ -63,7 +63,7 @@ export class StackBehavior extends TargetBehavior {
     this._state = state
     this.stack = []
     // private
-    this.dragObserver = null
+    this.moveObserver = null
     this.dropObserver = null
     this.actionObserver = null
     this.base = null
@@ -101,13 +101,12 @@ export class StackBehavior extends TargetBehavior {
       }
     })
 
-    this.dragObserver = inputManager.onDragObservable.add(({ type, mesh }) => {
+    this.moveObserver = moveManager.onMoveObservable.add(({ mesh }) => {
       // pop the last item if it's dragged, unless:
       // 1. there's only one item
       // 2. the first item is also dragged (we're dragging the whole stack)
       const { stack } = this
       if (
-        type === 'dragStart' &&
         stack.length > 1 &&
         stack[stack.length - 1] === mesh &&
         !selectionManager.meshes.has(stack[0])
@@ -151,7 +150,7 @@ export class StackBehavior extends TargetBehavior {
    */
   detach() {
     controlManager.onActionObservable.remove(this.actionObserver)
-    inputManager.onDragObservable.remove(this.dragObserver)
+    moveManager.onMoveObservable.remove(this.moveObserver)
     this.onDropObservable?.remove(this.dropObserver)
     super.detach()
   }
@@ -199,6 +198,7 @@ export class StackBehavior extends TargetBehavior {
         args: [meshId, immediate],
         duration
       })
+      moveManager.notifyMove(mesh)
     }
     const { x, z } = base.mesh.absolutePosition
     logger.info(

--- a/apps/web/tests/test-utils.js
+++ b/apps/web/tests/test-utils.js
@@ -249,3 +249,10 @@ export async function waitNextRender(scene) {
     scene.getEngine().onEndFrameObservable.addOnce(resolve)
   )
 }
+
+export function expectMoveRecorded(moveRecorded, ...meshes) {
+  expect(moveRecorded).toHaveBeenCalledTimes(meshes.length)
+  for (const [rank, mesh] of meshes.entries()) {
+    expect(moveRecorded.mock.calls[rank][0]).toEqual({ mesh })
+  }
+}


### PR DESCRIPTION
### What's in there?

When selecting several stacked/anchored meshes and stacking them all together, their original stack/anchor are still referencing them

Are included here:

- fix(web): stacking the entire selection does not update anchors and other stacks

### How to reproduce?

On a game with anchors, like Klondike:
1. select several anchored meshes
2. stack them all together with the action menu
3. clear selection, and try to snap a different mesh to any of the original anchors
    > the anchor can't be used as they are still referencing their original mesh

![Peek 21-04-2022 21-11](https://user-images.githubusercontent.com/186268/164537247-f1a61f18-c48e-4c8b-8ca5-fa8e7cdac116.gif)


### Notes to reviewers

Instead of relying on `inputManager.onDragObserver()`, I've introduced a new observable on `moveManager`: `onMoveObservable`.
It is called when starting a drag operation, but also when snapping or pushing meshes, making it easier to call programmatically.
