### PR TITLE
fix(web): moving card collides with a tall stack

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,6 @@
 
 - bug: ICE failed message when peer reload their browser??
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
-- bug: moving card collides with a stack of cards
 - selection manager should remove disposed meshes
 - create Animation objects as part of runAnimation() (constant frameRate of 60)
 - custom message on jest expect (game-interaction)

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -237,6 +237,25 @@ describe('MoveManager', () => {
         ])
       })
 
+      it('elevates moved mesh above stacked obstacles', () => {
+        const obstacle1 = CreateBox('obstacle1', {})
+        obstacle1.setAbsolutePosition(1, 0.5, 1)
+        obstacle1.computeWorldMatrix()
+        const obstacle2 = CreateBox('obstacle2', {})
+        obstacle2.setAbsolutePosition(1, 2, 1)
+        obstacle2.computeWorldMatrix()
+        const obstacle3 = CreateBox('obstacle3', {})
+        obstacle3.setAbsolutePosition(1, 3.5, 1)
+        obstacle3.computeWorldMatrix()
+
+        manager.continue({ x: centerX + 20, y: centerY })
+        expectPosition(moved, [
+          1.8257662057876587,
+          getAltitudeOnCollision(moved, obstacle3),
+          1
+        ])
+      })
+
       it('stops when pointer is leaving table', async () => {
         manager.continue({ x: centerX * 100, y: centerY * 100 })
         await sleep()
@@ -580,12 +599,12 @@ describe('MoveManager', () => {
         manager.continue({ x: centerX + 20, y: centerY })
         expectPosition(moved[0], [
           1 + deltaX,
-          getAltitudeOnCollision(moved[0], obstacle1),
+          getAltitudeOnCollision(moved[0], obstacle1, 1),
           1
         ])
         expectPosition(moved[1], [
           deltaX,
-          getAltitudeOnCollision(moved[1], obstacle1),
+          getAltitudeOnCollision(moved[1], obstacle1, 5),
           0
         ])
         expectPosition(moved[2], [
@@ -826,11 +845,12 @@ function expectZoneForMeshes(targetId, meshes) {
   )
 }
 
-function getAltitudeOnCollision(moved, obstacle) {
+function getAltitudeOnCollision(moved, obstacle, offset = 0) {
   return (
-    moved.getBoundingInfo().boundingBox.minimumWorld.y -
-    getDimensions(moved).height +
-    obstacle.getBoundingInfo().boundingBox.maximumWorld.y
+    obstacle.getBoundingInfo().boundingBox.maximumWorld.y +
+    getDimensions(moved).height * 0.5 +
+    offset +
+    manager.elevation
   )
 }
 


### PR DESCRIPTION
### What's in there?

The dragged meshes may not always elevate as expected when colliding with a tall stack of meshes.
This is because we only evaluate once the colliding mesh. When elevating the dragged meshes, they may collide with a _different_ set of meshes, and so on.
Colliding meshes must be evaluated every time we elevate the moved selection.

### How to reproduce?

1. On a Klondike game, stack _all the available cards_ to obtain a stack of 52 cards.
2. Pop one card, then slowly drag it towards the stack
   > At some point, the dragged mesh collides instead of being elevated.

![Peek 23-04-2022 10-17](https://user-images.githubusercontent.com/186268/164886498-ba8a5319-6e7d-457e-a931-1c6f4e66115d.gif)

