### PR TITLE
feat(server): removes meshes dangling in bags upon creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,8 +53,6 @@
 
 ## Server
 
-- drop unused meshes in bags which are not used in any slot
-- stack meshes of different slots using the same anchor
 - use JWT as authentication token (stores player id and username)
 - allows a single connection per player (discards other JWTs)
 - logging (warning on invalid descriptors)

--- a/apps/server/nodemon.json
+++ b/apps/server/nodemon.json
@@ -1,3 +1,4 @@
 {
-  "ignore": ["data/*"]
+  "ignore": ["data/*"],
+  "watch": ["src", "../games/assets"]
 }

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -80,7 +80,7 @@ import repositories from '../repositories/index.js'
  */
 
 /**
- * @typedef {object} Anchorable a rectangular anchor definition:
+ * @typedef {object} Anchor a rectangular anchor definition:
  * @property {string} snappedId? - id of the mesh currently snapped to this anchor.
  * @property {number} x? - 3D coordinate (relative to the parent mesh) along the X axis (horizontal).
  * @property {number} z? - 3D coordinate (relative to the parent mesh) along the Z axis (vertical).

--- a/apps/server/src/utils/collections.js
+++ b/apps/server/src/utils/collections.js
@@ -1,7 +1,7 @@
 /**
  * Shuffle an array, several times, using Fisher–Yates algorithm.
  * @param {any[]} source - source array.
- * @param {number} [iterations=3] - how many times the array is shuffled.
+ * @param {number} [iterations=5] - how many times the array is shuffled.
  * @returns {any[]} a randomized copy of the source array.
  * @see {@link https://bost.ocks.org/mike/shuffle/}
  */

--- a/apps/server/tests/fixtures/invalid-games/throwing/index.js
+++ b/apps/server/tests/fixtures/invalid-games/throwing/index.js
@@ -1,0 +1,3 @@
+export function build() {
+  throw new Error('internal build error')
+}

--- a/apps/server/tests/services/games.test.js
+++ b/apps/server/tests/services/games.test.js
@@ -24,9 +24,6 @@ describe('given a subscription to game lists and an initialized repository', () 
     subscription = gameListsUpdate.subscribe(update => updates.push(update))
     await repositories.games.connect({})
     await repositories.players.connect({})
-    await repositories.catalogItems.connect({
-      path: join('tests', 'fixtures', 'games')
-    })
     await repositories.players.save(player)
     await repositories.players.save(peer)
   })
@@ -38,7 +35,10 @@ describe('given a subscription to game lists and an initialized repository', () 
     await repositories.catalogItems.release()
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await repositories.catalogItems.connect({
+      path: join('tests', 'fixtures', 'games')
+    })
     jest.restoreAllMocks()
     updates.splice(0, updates.length)
   })
@@ -98,6 +98,17 @@ describe('given a subscription to game lists and an initialized repository', () 
       expect(updates).toEqual([
         { playerId: player.id, games: expect.arrayContaining([game]) }
       ])
+    })
+
+    it('throws errors from descriptor builer function', async () => {
+      jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+      await repositories.catalogItems.connect({
+        path: join('tests', 'fixtures', 'invalid-games')
+      })
+      await expect(
+        createGame('throwing', faker.datatype.uuid())
+      ).rejects.toThrow(`internal build error`)
+      expect(updates).toHaveLength(0)
     })
   })
 

--- a/apps/server/tests/test-utils.js
+++ b/apps/server/tests/test-utils.js
@@ -88,3 +88,13 @@ export function mockMethods(object) {
   }
   return () => Object.assign(object, original)
 }
+
+/**
+ * Performs a deep clone, using JSON parse and stringify
+ * This is a slow, destructive (functions, Date and Regex are lost) method, only suitable in tests
+ * @param {object} object - cloned object
+ * @returns {object} a clone
+ */
+export function cloneAsJSON(object) {
+  return JSON.parse(JSON.stringify(object))
+}

--- a/apps/web/src/3d/meshes/round-token.js
+++ b/apps/web/src/3d/meshes/round-token.js
@@ -29,9 +29,9 @@ export function createRoundToken(
     height = 0.1,
     texture,
     faceUV = [
-      [0, 0, 0.5, 1],
+      [0, 1, 0.5, 0],
       [0, 0, 0, 0],
-      [0.5, 0, 1, 1]
+      [0.5, 1, 1, 0]
     ],
     ...behaviorStates
   } = {},


### PR DESCRIPTION
### What's in there?

More complex game descriptors need more utilities. 
Are included here:

- feat(server)!: removes meshes dangling in bags upon creation
- feat(server): supports stacking meshes of different slots that use the same anchor
- feat(server): exposes utilities to find, snap and stack meshes upon creation
- chore(server): logs errors upon game creation
- chore(server): reloads on game asset changes
- chore(web): changes default faceUVs for round token

### How to test?

All this can be tested on the last private game implemented.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
