### PR TITLE
feat(web): supports cylindric anchors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,11 +34,16 @@
 
 ## UI
 
-- resizeable/capped to 25% height hand
+- select multiple from any any stack (not just drawable cards)
+- collapsible/resizeable/capped hand
+- lock meshes to avoid moving
 - bug: when stacked, only the last mesh could be picked (drag selection, action menu)
 - bug: no re-ordering animation for stacks of non-card meshes
 - bug: a tall stack of non-card meshes, after re-order, can not be picked any more (fixed on refresh)
 - bug: gravity only considers bounding box edges and center (long vertical meshes are not picked)
+- quatifiable (stackable) behavior
+- use `TouchEvent.scale` to detect pinches https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
+- rework interaction model https://www.unixpapa.com/js/testmouse.html
 - display peer's name when running draw animations + show peer avatar/name instead of pointer
 - allow selecting preferred camera/mic with https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
 - configurable player position at game level
@@ -49,7 +54,7 @@
 - keyboard
 - indicates when remote stream is muted/stopped
 - zoom in/out on rules
-- issue: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
+- bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 
 ## Server
 
@@ -95,7 +100,7 @@
 | fullscreen       | _button_                           | ~/esc                             |
 | save camera      | _button_                           | shift+number, _menu action_       |
 | restore camera   | _button_                           | number, _menu action_             |
-| menu             | _N/A_                              | right click                       |
+| menu             | double left click/tap              | right click                       |
 | toggle hand      | _N/A_                              | _menu action_                     |
 | toggle interface | _N/A_                              | _menu action_                     |
 | help             | _N/A_                              | F1, _button_, _menu action_       |
@@ -111,7 +116,7 @@
 | rotate         | right click, 2 fingers tap, _menu action_ | Ctrl+left drag, Q/E/PgUp/PgDown, _menu action_   |
 | (un)lock       | _N/A_                                     | L, _menu action_                                 |
 | put under      | _N/A_                                     | U, _menu action_                                 |
-| take to hand   | _N/A_                                     | T, _move to screen bottom_, _menu action (draw)_ |
+| take to hand   | drag to hand, menu action                 | T, _move to screen bottom_, _menu action (draw)_ |
 
 | Action on Stacks    | Tabulous      | Tabletopia                              |
 | ------------------- | ------------- | --------------------------------------- |
@@ -283,9 +288,14 @@ Some useful commands:
   ```
   convert in.png -alpha off -fuzz 10% -fill none -draw "matte 1,1 floodfill"  \( +clone -alpha extract -blur 0x2 -level 50x100% \) -alpha off -compose copy_opacity -composite out.png
   ```
-- [convert all pngs to webp](https://stackoverflow.com/a/27784462/1182976);
+- [convert all pngs to webp](https://stackoverflow.com/a/27784462/1182976):
   ```
   convert *.png -set filename:base "%[basename]" -define webp:lossless=true "%[filename:base].webp"
+  ```
+- [extract a given polygon from an image](https://stackoverflow.com/a/18992215/1182976):
+  ```
+  convert -size 100x100 xc:none -draw "roundrectangle 0,0,100,100,15,15" mask.png
+  convert in.png -matte mask.png -compose DstIn -composite out.png
   ```
 
 There is no built-in way for the remote side of an WebRTC connection to know that video or audio was disabled.

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -61,6 +61,8 @@ type Anchor {
   width: Float
   height: Float
   depth: Float
+  diameter: Float
+  extent: Float
   priority: Float
   kinds: [String]
   snappedId: ID
@@ -198,6 +200,8 @@ input AnchorInput {
   width: Float
   height: Float
   depth: Float
+  diameter: Float
+  extent: Float
   priority: Float
   kinds: [String]
   snappedId: ID

--- a/apps/web/src/3d/behaviors/anchorable.js
+++ b/apps/web/src/3d/behaviors/anchorable.js
@@ -1,4 +1,3 @@
-import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { AnchorBehaviorName } from './names'
 import { TargetBehavior } from './targetable'
@@ -6,6 +5,7 @@ import {
   animateMove,
   attachFunctions,
   attachProperty,
+  buildTargetMesh,
   getPositionAboveZone,
   getTargetableBehavior
 } from '../utils'
@@ -252,17 +252,25 @@ export class AnchorBehavior extends TargetBehavior {
     this.state = { anchors, duration }
     for (const [
       i,
-      { x, y, z, width, depth, height, snappedId, ...zoneProps }
+      { x, y, z, width, depth, height, diameter, snappedId, ...zoneProps }
     ] of this.state.anchors.entries()) {
-      const scene = this.mesh.getScene()
-      const dropZone = CreateBox(`anchor-${i}`, { width, depth, height }, scene)
-      dropZone.parent = this.mesh
+      const dropZone = buildTargetMesh(
+        `anchor-${i}`,
+        this.mesh,
+        diameter
+          ? { diameter, height }
+          : {
+              width,
+              depth,
+              height
+            }
+      )
       dropZone.position = new Vector3(x ?? 0, y ?? 0, z ?? 0)
       dropZone.computeWorldMatrix(true)
       const zone = this.addZone(dropZone, {
-        extent: 0.6,
         enabled: true,
-        ...zoneProps
+        ...zoneProps,
+        extent: zoneProps.extent || 0.6
       })
       // relates the created zone with the anchor
       zone.anchorIndex = i

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -1,7 +1,5 @@
 import { Animation } from '@babylonjs/core/Animations/animation'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
-import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
-import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import {
   AnchorBehaviorName,
   MoveBehaviorName,
@@ -20,6 +18,7 @@ import {
   applyGravity,
   attachFunctions,
   attachProperty,
+  buildTargetMesh,
   getAnimatableBehavior,
   getCenterAltitudeAbove,
   getDimensions,
@@ -520,19 +519,10 @@ export class StackBehavior extends TargetBehavior {
     if (this.dropZone) {
       this.removeZone(this.dropZone)
     }
-    // builds a drop zone from the mesh's dimensions
-    const { x, y, z } = this.mesh.getBoundingInfo().boundingBox.extendSizeWorld
-    const scene = this.mesh.getScene()
-    const dropZone =
-      this.mesh.name === 'roundToken'
-        ? CreateCylinder('drop-zone', { diameter: x * 2, height: y * 2 }, scene)
-        : CreateBox(
-            'drop-zone',
-            { width: x * 2, height: y * 2, depth: z * 2 },
-            scene
-          )
-    dropZone.parent = this.mesh
-    this.dropZone = this.addZone(dropZone, this._state)
+    this.dropZone = this.addZone(
+      buildTargetMesh('drop-zone', this.mesh),
+      this._state
+    )
 
     this.inhibitControl = true
     for (const id of stackIds) {

--- a/apps/web/src/3d/utils/behaviors.js
+++ b/apps/web/src/3d/utils/behaviors.js
@@ -1,5 +1,7 @@
 import { Animation } from '@babylonjs/core/Animations/animation'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
+import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
+import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import {
   AnchorBehavior,
   DetailBehavior,
@@ -326,4 +328,37 @@ function parseFloat(
     outTangent,
     interpolation
   }
+}
+
+/**
+ * Builds a "target" mesh that can be used as a targetable zone.
+ * It'll be assigned as a child or the provided parent.
+ * Creates a cylinder when the mesh's name is 'roundToken' or when providing dimension's diameter.
+ * Otherwise, creates a box.
+ * @param {string} name - new mesh's name
+ * @param {import('@babel/core').Mesh} parent - mesh to copy dimensions and shape from.
+ * @param {object} dimensions? - target dimensions. When specified, prevail on parent's shape:
+ * @param {number} dimensions.width - target's width.
+ * @param {number} dimensions.height - target's height.
+ * @param {number} dimensions.depth - target's depth.
+ * @param {number} dimensions.diameter - target's diameter.
+ * @returns {import('@babel/core').Mesh} created target mesh.
+ */
+export function buildTargetMesh(name, parent, dimensions) {
+  const { x, y, z } = parent.getBoundingInfo().boundingBox.extendSizeWorld
+  const scene = parent.getScene()
+  const created =
+    dimensions?.diameter || parent.name === 'roundToken'
+      ? CreateCylinder(
+          name,
+          dimensions ?? { diameter: x * 2, height: y * 2 },
+          scene
+        )
+      : CreateBox(
+          name,
+          dimensions ?? { width: x * 2, height: y * 2, depth: z * 2 },
+          scene
+        )
+  created.parent = parent
+  return created
 }

--- a/apps/web/src/components/Indicators.svelte
+++ b/apps/web/src/components/Indicators.svelte
@@ -4,10 +4,10 @@
 
 <style lang="postcss">
   .indicator {
-    @apply absolute transform-gpu -translate-y-1/2 -translate-x-1/2
+    @apply absolute transform-gpu -translate-y-1/2 -translate-x-1
             pointer-events-none 
             font-bold text-lg text-$primary-lightest
-            bg-$primary
+            bg-$primary opacity-85
             py-1 pr-2 pl-5 rounded;
     clip-path: polygon(1rem 0%, 100% 0, 100% 100%, 1rem 100%, 0% 50%);
   }

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -52,6 +52,8 @@ fragment mesh on Mesh {
       width
       height
       depth
+      diameter
+      extent
       kinds
       priority
       snappedId

--- a/apps/web/tests/3d/behaviors/anchorable.test.js
+++ b/apps/web/tests/3d/behaviors/anchorable.test.js
@@ -185,6 +185,23 @@ describe('AnchorBehavior', () => {
       expectMoveRecorded(moveRecorded)
     })
 
+    it('can hydrate cylindric anchors', () => {
+      behavior.fromState({
+        anchors: [
+          { x: 1, y: 1, z: 0, diameter: 4, height: 0.5, extent: 1.2 },
+          { x: 1, y: 1, z: 0, diameter: 2, height: 0.1, extent: null }
+        ]
+      })
+      expect(behavior.state.anchors).toEqual([
+        { x: 1, y: 1, z: 0, diameter: 4, height: 0.5, extent: 1.2 },
+        { x: 1, y: 1, z: 0, diameter: 2, height: 0.1, extent: null }
+      ])
+      expectAnchor(0, behavior.state.anchors[0])
+      expectAnchor(1, behavior.state.anchors[1])
+      expect(recordSpy).not.toHaveBeenCalled()
+      expectMoveRecorded(moveRecorded)
+    })
+
     it('disposes previous anchors when hydrating', () => {
       expect(behavior.zones).toHaveLength(2)
       expect(behavior.state.anchors).toHaveLength(2)
@@ -703,7 +720,7 @@ describe('AnchorBehavior', () => {
 
     function expectAnchor(
       rank,
-      { width, height, depth, x = 0, y = 0, z = 0 },
+      { width, height, depth, diameter, x = 0, y = 0, z = 0 },
       isEnabled = true,
       kinds = undefined,
       priority = 0
@@ -714,9 +731,9 @@ describe('AnchorBehavior', () => {
       expect(zone.kinds).toEqual(kinds)
       expect(zone.priority).toEqual(priority)
       const { boundingBox } = zone.mesh.getBoundingInfo()
-      expect(boundingBox.extendSize.x * 2).toEqual(width)
-      expect(boundingBox.extendSize.y * 2).toEqual(height)
-      expect(boundingBox.extendSize.z * 2).toEqual(depth)
+      expect(boundingBox.extendSize.x * 2).toBeCloseTo(diameter ?? width)
+      expect(boundingBox.extendSize.y * 2).toBeCloseTo(height)
+      expect(boundingBox.extendSize.z * 2).toBeCloseTo(diameter ?? depth)
       expect(zone.mesh.absolutePosition.asArray()).toEqual([x, y, z])
     }
   })

--- a/apps/web/tests/3d/behaviors/stackable.test.js
+++ b/apps/web/tests/3d/behaviors/stackable.test.js
@@ -1,5 +1,6 @@
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
+import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import { faker } from '@faker-js/faker'
 import {
   configures3dTestEngine,
@@ -158,6 +159,39 @@ describe('StackBehavior', () => {
 
       behavior.fromState({ duration, extent, stackIds, kinds, priority })
       expectZone(behavior, extent, false, kinds, priority)
+      expectStacked([mesh, meshes[0], meshes[2]])
+      expect(behavior.state.duration).toEqual(duration)
+      expect(behavior.state.extent).toEqual(extent)
+      expect(mesh.metadata).toEqual(
+        expect.objectContaining({
+          push: expect.any(Function),
+          pop: expect.any(Function),
+          reorder: expect.any(Function),
+          flipAll: expect.any(Function),
+          canPush: expect.any(Function)
+        })
+      )
+      expect(recordSpy).not.toHaveBeenCalled()
+    })
+
+    it('can hydrate with cylindric zone', async () => {
+      const extent = faker.datatype.number()
+      const stackIds = [meshes[0].id, meshes[2].id]
+      const duration = faker.datatype.number()
+      const kinds = ['tokens']
+      const priority = faker.datatype.number()
+      const diameter = 5
+      expect(meshes[0].absolutePosition).toEqual(Vector3.FromArray([1, 1, 1]))
+      expect(meshes[2].absolutePosition).toEqual(Vector3.FromArray([3, 3, 3]))
+      mesh.removeBehavior(behavior)
+      mesh = CreateCylinder('roundToken', { diameter })
+      mesh.addBehavior(behavior, true)
+
+      behavior.fromState({ duration, extent, stackIds, kinds, priority })
+      expectZone(behavior, extent, false, kinds, priority)
+      const { boundingBox } = behavior.zones[0].mesh.getBoundingInfo()
+      expect(boundingBox.extendSize.x * 2).toBeCloseTo(diameter)
+      expect(boundingBox.extendSize.z * 2).toBeCloseTo(diameter)
       expectStacked([mesh, meshes[0], meshes[2]])
       expect(behavior.state.duration).toEqual(duration)
       expect(behavior.state.extent).toEqual(extent)


### PR DESCRIPTION
### What's in there?

Up to now, we could only have rectangular anchors. This PR supports cylindric ones.

Are included here:

- feat(web): supports cylindric anchors
- feat(web): makes indicators slightly transparent

### How to test?

In our latest private game

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
