### PR TITLE
fix(web): multiple pointers to pan, rotate and zoom camera

### DIFF
--- a/apps/web/src/3d/managers/input.js
+++ b/apps/web/src/3d/managers/input.js
@@ -208,8 +208,8 @@ class InputManager {
         }
 
         case PointerEventTypes.POINTERMOVE: {
-          if (event.movementX === 0 && event.movementY === 0) {
-            break
+          if (!hasMoved(pointers, event)) {
+            return
           }
           clearLong()
 
@@ -417,4 +417,9 @@ function isDifferenceEnough(eventA, eventB, threshold) {
     Math.abs(eventA.x, eventB.x) >= threshold ||
     Math.abs(eventA.y, eventB.y) >= threshold
   )
+}
+
+function hasMoved(pointers, event) {
+  const { x, y } = pointers.get(event?.pointerId)?.event ?? { x: 0, y: 0 }
+  return event?.x - x !== 0 || event?.y - y !== 0
 }

--- a/apps/web/tests/3d/managers/input.test.js
+++ b/apps/web/tests/3d/managers/input.test.js
@@ -1397,9 +1397,7 @@ describe('InputManager', () => {
       triggerEvent(POINTERMOVE, {
         x: 1000,
         y: 500,
-        pointerId: 1,
-        movementX: 10,
-        movementY: -50
+        pointerId: 1
       })
       expectEvents()
     })
@@ -1425,10 +1423,10 @@ describe('InputManager', () => {
     expect(longs).toHaveLength(counts.longs ?? 0)
   }
 
-  function move(pointer, movementX, movementY) {
-    pointer.x += movementX
-    pointer.y += movementY
-    return { ...pointer, movementX, movementY }
+  function move(pointer, x, y) {
+    pointer.x += x
+    pointer.y += y
+    return { ...pointer }
   }
 
   function expectsDataWithMesh(actual, expected, meshId) {


### PR DESCRIPTION
### What's in there?

Multi-fingers operations do not work anymore! Panning, rotating and zooming camera on a tactile device is not possible.

- fix(web): multiple pointers to pan and zoom camera

### How to test?

Open any of the games with a tactile device:
- panning with 2 fingers does not work
- zooming with a pinch does not work
- rotating with 3 fingers does not work

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
