### PR TITLE
feat(server): reworks game copyright and introduces access model

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 Roadmap
 
-- server: game ownership
 - server: catalog query with and without own games
 - games: generic card game
 - web: publicly accessible catalog

--- a/apps/server/src/graphql/catalog-resolver.js
+++ b/apps/server/src/graphql/catalog-resolver.js
@@ -1,4 +1,4 @@
-import { isAuthenticated } from './utils.js'
+import { isAdmin, isAuthenticated } from './utils.js'
 import services from '../services/index.js'
 
 export default {
@@ -15,5 +15,32 @@ export default {
     listCatalog: isAuthenticated((obj, args, { player }) =>
       services.listCatalog(player)
     )
+  },
+  Mutation: {
+    /**
+     * Grants another player access to a given catalog item.
+     * Requires authentication and elevated privileges.
+     * @async
+     * @param {object} obj - graphQL object.
+     * @param {object} args - query arguments.
+     * @param {object} context - graphQL context.
+     * @returns {Boolean} true if access was granted
+     */
+    grantAccess: isAdmin(async (obj, { playerId, itemName }) => {
+      return (await services.grantAccess(playerId, itemName)) !== null
+    }),
+
+    /**
+     * Revokes access to a given catalog item for another player.
+     * Requires authentication and elevated privileges.
+     * @async
+     * @param {object} obj - graphQL object.
+     * @param {object} args - query arguments.
+     * @param {object} context - graphQL context.
+     * @returns {Boolean} true if access was granted
+     */
+    revokeAccess: isAdmin(async (obj, { playerId, itemName }) => {
+      return (await services.revokeAccess(playerId, itemName)) !== null
+    })
   }
 }

--- a/apps/server/src/graphql/catalog.graphql
+++ b/apps/server/src/graphql/catalog.graphql
@@ -1,6 +1,7 @@
 type CatalogItem {
   name: ID!
   locales: ItemLocales!
+  copyright: Copyright
   # minimum age in years
   minAge: Int
   # minimum time in minutes
@@ -15,6 +16,21 @@ type ItemLocale {
   title: String!
 }
 
+type Copyright {
+  authors: [GameAuthor]!
+  designers: [GameAuthor]
+  publishers: [GameAuthor]
+}
+
+type GameAuthor {
+  name: String!
+}
+
 extend type Query {
   listCatalog: [CatalogItem]
+}
+
+extend type Mutation {
+  grantAccess(playerId: ID!, itemName: ID!): Boolean
+  revokeAccess(playerId: ID!, itemName: ID!): Boolean
 }

--- a/apps/server/src/graphql/utils.js
+++ b/apps/server/src/graphql/utils.js
@@ -17,3 +17,19 @@ export function isAuthenticated(resolver) {
     return resolver(obj, args, context)
   }
 }
+
+/**
+ * Wraps a graphQL resolver with a function checking `isAdmin` property of the player in graphQL context.
+ * The wrapped function can be registered as a graphQL resolver.
+ * It will throws an 403 error when current player is not an admin.
+ * @param {function} resolver - graphQL resolver function
+ * @returns {function} the wrapped graphQL resolver function
+ */
+export function isAdmin(resolver) {
+  return isAuthenticated((obj, args, context) => {
+    if (!context.player.isAdmin) {
+      throw new ErrorWithProps('Forbidden', { code: 403 })
+    }
+    return resolver(obj, args, context)
+  })
+}

--- a/apps/server/src/services/catalog.js
+++ b/apps/server/src/services/catalog.js
@@ -3,7 +3,14 @@ import repositories from '../repositories/index.js'
 /**
  * @typedef {object} CatalogItem a catalog item
  * @property {string} name - item unique name.
- * @property {boolean} restricted - whether this game has restricted access
+ * @property {Copyright} [copyright] - copyright data, meaning this item has restricted access
+ */
+
+/**
+ * @typedef {object} Copyright game copyright data
+ * @property {GameAuthor[]} authors - game authors.
+ * @property {GameAuthor[]} [designer] - game designers.
+ * @property {GameAuthor[]} [publishers] - game publishers.
  */
 
 /**
@@ -29,5 +36,47 @@ export async function listCatalog(player) {
  * @returns {boolean} true when the item is publicly available or if this player was granted access.
  */
 export function canAccess(player, item) {
-  return !item.restricted || player?.catalog?.includes(item.name)
+  return !item.copyright || player?.catalog?.includes(item.name)
+}
+
+/**
+ * Grants access to a catalog item to a given player.
+ * Does nothing when player or item is unknown, or if item is not copyrighted
+ * @param {string} playerId - id of the related player.
+ * @param {string} itemName - catalog item name this player will have access to.
+ * @returns {import('./players').Player|null} saved player, or null
+ */
+export async function grantAccess(playerId, itemName) {
+  const player = await repositories.players.getById(playerId)
+  const item = await repositories.catalogItems.getById(itemName)
+  if (player && item && item.copyright) {
+    if (!player.catalog) {
+      player.catalog = []
+    }
+    if (!player.catalog.includes(itemName)) {
+      player.catalog.push(itemName)
+      return await repositories.players.save(player)
+    }
+  }
+  return null
+}
+
+/**
+ * Revokes access to a catalog item for a given player.
+ * Does nothing when player or item is unknown, or if item is not copyrighted
+ * @param {string} playerId - id of the related player.
+ * @param {string} itemName - catalog item name this player will lost access to.
+ * @returns {import('./players').Player|null} saved player, or null
+ */
+export async function revokeAccess(playerId, itemName) {
+  const player = await repositories.players.getById(playerId)
+  const item = await repositories.catalogItems.getById(itemName)
+  if (player && item && item.copyright) {
+    const index = player.catalog?.indexOf(itemName)
+    if (index >= 0) {
+      player.catalog.splice(index, 1)
+      return await repositories.players.save(player)
+    }
+  }
+  return null
 }

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -6,6 +6,8 @@ import repositories from '../repositories/index.js'
  * @property {string} id - unique id.
  * @property {string} username - player user name.
  * @property {boolean} playing - whether this player has currently joined an active game.
+ * @property {boolean} [isAdmin] - whether this player has elevated priviledges or not.
+ * @property {string[]} [catalog] - list of copyrighted games this player has accessed to.
  */
 
 /**

--- a/apps/server/tests/fixtures/games/6-takes/index.js
+++ b/apps/server/tests/fixtures/games/6-takes/index.js
@@ -1,0 +1,9 @@
+export function build() {
+  return {
+    meshes: [],
+    bags: new Map(),
+    slots: []
+  }
+}
+
+export const copyright = { authors: [{ name: 'Wolfgang Kramer' }] }

--- a/apps/server/tests/fixtures/games/splendor/index.js
+++ b/apps/server/tests/fixtures/games/splendor/index.js
@@ -1,5 +1,3 @@
-export const restricted = true
-export const rulesBookPageCount = 4
 export function build() {
   return {
     meshes: [],
@@ -7,3 +5,7 @@ export function build() {
     slots: []
   }
 }
+
+export const rulesBookPageCount = 4
+
+export const copyright = { authors: [{ name: 'Marc André' }] }

--- a/apps/server/tests/repositories/catalog-items.test.js
+++ b/apps/server/tests/repositories/catalog-items.test.js
@@ -5,6 +5,13 @@ import { catalogItems } from '../../src/repositories/catalog-items.js'
 describe('Catalog Items repository', () => {
   const items = [
     {
+      name: '6-takes',
+      build: expect.any(Function),
+      copyright: {
+        authors: [{ name: 'Wolfgang Kramer' }]
+      }
+    },
+    {
       name: 'belote',
       build: expect.any(Function),
       addPlayer: expect.any(Function),
@@ -13,9 +20,11 @@ describe('Catalog Items repository', () => {
     { name: 'klondike', build: expect.any(Function) },
     {
       name: 'splendor',
-      restricted: true,
       rulesBookPageCount: 4,
-      build: expect.any(Function)
+      build: expect.any(Function),
+      copyright: {
+        authors: [{ name: 'Marc André' }]
+      }
     }
   ]
 
@@ -62,7 +71,7 @@ describe('Catalog Items repository', () => {
       describe('list()', () => {
         it('lists all items within folder', async () => {
           expect(await catalogItems.list()).toEqual({
-            total: 3,
+            total: 4,
             from: 0,
             size: Number.POSITIVE_INFINITY,
             results: items

--- a/apps/server/tests/services/catalog.test.js
+++ b/apps/server/tests/services/catalog.test.js
@@ -1,20 +1,33 @@
 import { faker } from '@faker-js/faker'
 import { join } from 'path'
 import repositories from '../../src/repositories/index.js'
-import { listCatalog } from '../../src/services/catalog.js'
+import {
+  grantAccess,
+  listCatalog,
+  revokeAccess
+} from '../../src/services/catalog.js'
 
-describe('listCatalog()', () => {
+describe('Catalog service', () => {
   const players = [
     {
       id: faker.datatype.uuid(),
-      catalog: ['splendor']
+      username: faker.name.findName(),
+      catalog: ['splendor', '6-takes']
     },
     {
-      id: faker.datatype.uuid()
+      id: faker.datatype.uuid(),
+      username: faker.name.findName()
     }
   ]
 
   const items = [
+    {
+      name: '6-takes',
+      build: expect.any(Function),
+      copyright: {
+        authors: [{ name: 'Wolfgang Kramer' }]
+      }
+    },
     {
       name: 'belote',
       build: expect.any(Function),
@@ -24,27 +37,172 @@ describe('listCatalog()', () => {
     { name: 'klondike', build: expect.any(Function) },
     {
       name: 'splendor',
-      restricted: true,
       rulesBookPageCount: 4,
-      build: expect.any(Function)
+      build: expect.any(Function),
+      copyright: {
+        authors: [{ name: 'Marc André' }]
+      }
     }
   ]
 
-  beforeAll(async () => {
-    await repositories.catalogItems.connect({
+  beforeAll(() =>
+    repositories.catalogItems.connect({
       path: join('tests', 'fixtures', 'games')
+    })
+  )
+
+  beforeEach(() => repositories.players.connect({}))
+
+  afterEach(() => repositories.players.release())
+
+  afterAll(() => repositories.catalogItems.release())
+
+  describe('listCatalog()', () => {
+    it(`returns a player's catalog`, async () => {
+      expect(await listCatalog(players[0])).toEqual(items)
+    })
+
+    it(`omits restricted games`, async () => {
+      expect(await listCatalog(players[1])).toEqual([items[1], items[2]])
     })
   })
 
-  afterAll(async () => {
-    await repositories.catalogItems.release()
+  describe('grantAccess()', () => {
+    it(`grants access to a given item`, async () => {
+      const gameName = items[3].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [items[2].name]
+      })
+      expect(await grantAccess(player.id, gameName)).toEqual({
+        ...player,
+        catalog: [items[2].name, gameName]
+      })
+      expect(await repositories.players.getById(player.id)).toEqual(player)
+    })
+
+    it(`creates user catalog on demand`, async () => {
+      const gameName = items[0].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName()
+      })
+      expect(await grantAccess(player.id, gameName)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+      expect(await repositories.players.getById(player.id)).toEqual(player)
+    })
+
+    it(`does not grant the same game twice`, async () => {
+      const gameName = items[3].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [gameName]
+      })
+      expect(await grantAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+    })
+
+    it(`ignores non-copyrighted games`, async () => {
+      const gameName = items[1].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [gameName]
+      })
+      expect(await grantAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+    })
+
+    it(`ignores unknnown games`, async () => {
+      const gameName = faker.datatype.uuid()
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [gameName]
+      })
+      expect(await grantAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+    })
+
+    it(`ignores unknnown player`, async () => {
+      expect(await grantAccess(faker.datatype.uuid(), items[0].name)).toBeNull()
+    })
   })
 
-  it(`returns a player's catalog`, async () => {
-    expect(await listCatalog(players[0])).toEqual(items)
-  })
+  describe('revokeAccess()', () => {
+    it(`revokes access to a given item`, async () => {
+      const gameName = items[3].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [items[2].name, gameName]
+      })
+      expect(await revokeAccess(player.id, gameName)).toEqual({
+        ...player,
+        catalog: [items[2].name]
+      })
+      expect(await repositories.players.getById(player.id)).toEqual(player)
+    })
 
-  it(`omits restricted games`, async () => {
-    expect(await listCatalog(players[1])).toEqual(items.slice(0, 2))
+    it(`does not revokes a games not granted`, async () => {
+      const gameName = items[3].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [items[0].name]
+      })
+      expect(await revokeAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [items[0].name]
+      })
+    })
+
+    it(`ignores non-copyrighted games`, async () => {
+      const gameName = items[1].name
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [gameName]
+      })
+      expect(await revokeAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+    })
+
+    it(`ignores unknnown games`, async () => {
+      const gameName = faker.datatype.uuid()
+      const player = await repositories.players.save({
+        id: faker.datatype.uuid(),
+        name: faker.name.findName(),
+        catalog: [gameName]
+      })
+      expect(await revokeAccess(player.id, gameName)).toBeNull()
+      expect(await repositories.players.getById(player.id)).toEqual({
+        ...player,
+        catalog: [gameName]
+      })
+    })
+
+    it(`ignores unknnown player`, async () => {
+      expect(
+        await revokeAccess(faker.datatype.uuid(), items[0].name)
+      ).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
### What's in there?

Some games have copyrights, which we'll use to distinguish publicly-accessible from restricted games.
This PR includes 2 new GraphQL mutations to grant and revokes individual game access to another player.
These requires a new privilege: player can have `admin` rights.

Are included here:

- feat(server): replaces `Game.restricted` with `Game.copyright`
- feat(server): introduces GraphQL mutation `grantAccess(playerId, itemName)`
- feat(server): introduces GraphQL mutation `revokeAccess(playerId, itemName)`
- feat(server): introduces `Player.isAdmin` boolean for admin privilege.

### How to test?

Manually assigns `isAdmin` boolean to one player, and make yourself a JWT.
Then issue graphQL requests to try out `grantAccess` and `revokeAccess`
Stay tuned for more convenient ways to manage catalog item access!

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
