### PR TITLE
fix(server): can not connect WS due to invalid configuration

### DIFF
--- a/apps/server/src/services/configuration.js
+++ b/apps/server/src/services/configuration.js
@@ -134,38 +134,38 @@ function makeAbsolute(path) {
 export function loadConfiguration() {
   const {
     DATA_PATH,
-    GAMES_PATH,
-    HOST,
-    HTTPS_CERT,
-    HTTPS_KEY,
-    LOG_LEVEL,
-    NODE_ENV,
-    PORT,
-    JWT_KEY,
-    TURN_SECRET,
     DOMAIN_URL,
+    GAMES_PATH,
     GITHUB_ID,
     GITHUB_SECRET,
     GOOGLE_ID,
-    GOOGLE_SECRET
+    GOOGLE_SECRET,
+    HOST,
+    HTTPS_CERT,
+    HTTPS_KEY,
+    JWT_KEY,
+    LOG_LEVEL,
+    NODE_ENV,
+    PORT,
+    TURN_SECRET
   } = process.env
 
   const isProduction = /^\w*production\w*$/i.test(NODE_ENV)
-  const publicDomain = isProduction
-    ? 'https://tabulous.fr'
-    : 'https://localhost:3000'
+  const publicDomain =
+    DOMAIN_URL ??
+    (isProduction ? 'https://www.tabulous.fr' : 'https://localhost:3000')
 
   const configuration = {
     isProduction,
     serverUrl: {
       host: HOST ?? (isProduction ? '0.0.0.0' : undefined),
-      port: PORT ? Number(PORT) : isProduction ? 443 : 3001
+      port: PORT ? Number(PORT) : 3001
     },
     https:
-      (HTTPS_KEY && HTTPS_CERT) || isProduction
+      HTTPS_KEY && HTTPS_CERT
         ? {
-            key: HTTPS_KEY ?? join('keys', 'privkey.pem'),
-            cert: HTTPS_CERT ?? join('keys', 'cert.pem')
+            key: HTTPS_KEY,
+            cert: HTTPS_CERT
           }
         : null,
     logger: { level: LOG_LEVEL ?? 'debug' },
@@ -191,7 +191,7 @@ export function loadConfiguration() {
       jwt: {
         key: JWT_KEY ?? (isProduction ? undefined : 'dummy-test-key')
       },
-      domain: DOMAIN_URL ?? publicDomain
+      domain: publicDomain
     }
   }
   if (GITHUB_ID && GITHUB_SECRET) {

--- a/apps/server/tests/services/configuration.test.js
+++ b/apps/server/tests/services/configuration.test.js
@@ -35,20 +35,20 @@ describe('loadConfiguration()', () => {
 
     process.env = {
       ...process.env,
-      PORT: port,
-      HOST: host,
-      LOG_LEVEL: level,
-      GAMES_PATH: gamesPath,
       DATA_PATH: dataPath,
-      HTTPS_CERT: cert,
-      HTTPS_KEY: key,
-      TURN_SECRET: turnSecret,
-      JWT_KEY: jwtKey,
+      DOMAIN_URL: domain,
+      GAMES_PATH: gamesPath,
       GITHUB_ID: githubId,
       GITHUB_SECRET: githubSecret,
       GOOGLE_ID: googleId,
       GOOGLE_SECRET: googleSecret,
-      DOMAIN_URL: domain
+      HOST: host,
+      HTTPS_CERT: cert,
+      HTTPS_KEY: key,
+      JWT_KEY: jwtKey,
+      LOG_LEVEL: level,
+      PORT: port,
+      TURN_SECRET: turnSecret
     }
 
     expect(loadConfiguration()).toEqual({
@@ -59,7 +59,7 @@ describe('loadConfiguration()', () => {
       plugins: {
         graphql: {
           graphiql: 'playground',
-          allowedOrigin: 'https://localhost:3000'
+          allowedOrigin: domain
         },
         static: { path: gamesPath, pathPrefix: '/games' }
       },
@@ -91,15 +91,12 @@ describe('loadConfiguration()', () => {
       isProduction: true,
       serverUrl: {
         host: '0.0.0.0',
-        port: 443
+        port: 3001
       },
       logger: { level: 'debug' },
-      https: {
-        cert: 'keys/cert.pem',
-        key: 'keys/privkey.pem'
-      },
+      https: null,
       plugins: {
-        graphql: { graphiql: null, allowedOrigin: 'https://tabulous.fr' },
+        graphql: { graphiql: null, allowedOrigin: 'https://www.tabulous.fr' },
         static: {
           path: resolve(cwd(), '..', 'games', 'assets'),
           pathPrefix: '/games'
@@ -109,7 +106,7 @@ describe('loadConfiguration()', () => {
       data: { path: resolve(cwd(), 'data') },
       turn: { secret: turnSecret },
       auth: {
-        domain: 'https://tabulous.fr',
+        domain: 'https://www.tabulous.fr',
         jwt: { key: jwtKey },
         github: { id: githubId, secret: githubSecret },
         google: { id: googleId, secret: googleSecret }

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -149,8 +149,11 @@ Because such configuration should not be commited on Github, it is stored in an 
   - add `export NODE_ENV=production` at the end
   - save and reload: `source ~/.bashrc`
 
+- generate some random secret value (save it somewhere): `openssl rand -base64 32`
 - edit configuration file: `vi ~/server/.env`
 
+  - add `NODE_ENV=production`
+  - add `JWT_KEY=[SECRET]` with the secret you just generated
   - add `TURN_SECRET=[SECRET]` with the same secret value as coTURN's `static-auth-secret`
 
 ## Maintenance


### PR DESCRIPTION
### What's in there?

Since #69 we can't connect WebSocket because of configuration issue.
First of all, `NODE_ENV` in production was not properly set.
The domain used must be configurable, and its production default value must include `www.` sub-domain.
Finally, https cert are not used in production (neither in dev).