### PR TITLE
feat(cli): introduces tabulous admin CLI!

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run CLI test
+        run: npm run test:cli
+
       - name: Run server test
         run: npm run test:server
 
@@ -73,4 +76,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: apps/server/coverage/clover.xml,apps/web/coverage/clover.xml
+          coverage-reports: apps/cli/coverage/clover.xml,apps/server/coverage/clover.xml,apps/web/coverage/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ scans/
 .eslintcache
 debug.txt
 .env
+.env.*
 .svelte-kit

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 Roadmap
 
+- cli: administrative operations (tests)
 - server: catalog query with and without own games
 - games: generic card game
 - web: publicly accessible catalog

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,18 @@
+# Tabulous Command Line Interface
+
+CLI for managing your Tabulous instance and performing basic administration tasks.
+
+## How to use
+
+To install locally:
+
+```shell
+cd apps/cli
+npm link
+```
+
+From there, you should be able to run:
+
+```sh
+tabulous -h
+```

--- a/apps/cli/jest.config.js
+++ b/apps/cli/jest.config.js
@@ -1,0 +1,15 @@
+export default {
+  rootDir: './',
+  testMatch: ['<rootDir>/tests/**/*.test.js'],
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    /* https://github.com/chalk/chalk/issues/532#issuecomment-1062018375 */
+    '#(.*)': '<rootDir>../../node_modules/$1'
+  },
+  watchPlugins: [
+    'jest-watch-typeahead/filename',
+    'jest-watch-typeahead/testname'
+  ],
+  coverageDirectory: './coverage',
+  collectCoverageFrom: ['<rootDir>/src/**/*.js', '<rootDir>/src/index.mjs']
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@tabulous/cli",
+  "version": "0.0.1",
+  "description": "Tabulous utility Command Line Interface",
+  "type": "module",
+  "bin": {
+    "tabulous": "./src/index.mjs"
+  },
+  "main": "./src/index.mjs",
+  "scripts": {
+    "test": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --coverage --colors",
+    "test:dev": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --watch"
+  },
+  "dependencies": {
+    "@urql/core": "^2.5.0",
+    "add": "^2.0.6",
+    "ajv": "^8.11.0",
+    "arg": "^5.0.2",
+    "chalk": "^5.0.1",
+    "chalk-template": "^0.4.0",
+    "dotenv": "^16.0.1",
+    "es-main": "^1.2.0",
+    "fast-jwt": "^1.6.0",
+    "graphql": "^16.5.0",
+    "lodash.camelcase": "^4.3.0",
+    "undici": "^5.6.0"
+  },
+  "devDependencies": {
+    "jest": "^28.1.2",
+    "jest-watch-typeahead": "^1.1.0",
+    "strip-ansi": "^7.0.1"
+  }
+}

--- a/apps/cli/src/commands/catalog.js
+++ b/apps/cli/src/commands/catalog.js
@@ -1,0 +1,102 @@
+// @ts-check
+import { gql } from '@urql/core'
+import chalkTemplate from 'chalk-template'
+import {
+  attachFormater,
+  findUser,
+  getGraphQLClient,
+  parseArgv,
+  RequiredString,
+  signToken
+} from '../util/index.js'
+
+/**
+ * @typedef {object} CatalogResult game catalog command result
+ * @property {Game[]} games - array of accessible games.
+ */
+
+/**
+ * @typedef {object} Game game details
+ * @property {string} name - game's unique name (id).
+ * @property {string} title - game's friendly title.
+ * @property {string} copyright - copyright mark, if any.
+ */
+
+const listCatalogQuery = gql`
+  query listCatalogQuery {
+    listCatalog {
+      name
+      locales {
+        fr {
+          title
+        }
+      }
+      copyright {
+        authors {
+          name
+        }
+      }
+    }
+  }
+`
+
+/**
+ * Triggers catalog command
+ * @param {string[]} argv - array of parsed arguments (without executable and current file).
+ * @returns {Promise<CatalogResult>} this user catalog of accessible games.
+ */
+export default async function catalogCommand(argv) {
+  return catalog(
+    parseArgv(argv, {
+      '--username': RequiredString,
+      '-u': '--username'
+    })
+  )
+}
+
+/**
+ * @typedef {object} CatalogArgs
+ * @property {string} username - name of the corresponding user.
+ */
+
+/**
+ * List all available games of a given user.
+ * @param {CatalogArgs} args - username
+ * @returns {Promise<CatalogResult>} this user catalog of accessible games.
+ */
+export async function catalog({ username }) {
+  const { id } = await findUser(username)
+  const { listCatalog: catalog } = await getGraphQLClient().query(
+    listCatalogQuery,
+    signToken(id)
+  )
+  const games = []
+  for (const game of catalog.sort((a, b) =>
+    getLocaleName(a).localeCompare(getLocaleName(b))
+  )) {
+    games.push({
+      name: game.name,
+      title: getLocaleName(game),
+      copyright: game.copyright?.authors?.length > 0 ? '©' : ''
+    })
+  }
+  return attachFormater({ games }, formatCatalog)
+}
+
+function getLocaleName({ name, locales }) {
+  return locales?.fr?.title ?? name
+}
+
+function formatCatalog({ games }) {
+  const output = []
+  for (const { name, title, copyright } of games) {
+    output.push(
+      chalkTemplate`{dim -} {cyan.bold ${
+        copyright || ' '
+      }} ${title} {dim ${name}}`
+    )
+  }
+  output.push(chalkTemplate`
+${games.length} {dim accessible game(s)}`)
+  return output.join('\n')
+}

--- a/apps/cli/src/commands/grant.js
+++ b/apps/cli/src/commands/grant.js
@@ -1,0 +1,72 @@
+// @ts-check
+import { gql } from '@urql/core'
+import chalkTemplate from 'chalk-template'
+import {
+  attachFormater,
+  findUser,
+  getGraphQLClient,
+  parseArgv,
+  RequiredString,
+  signToken
+} from '../util/index.js'
+import { catalog } from './catalog.js'
+
+const grantAccessMutation = gql`
+  mutation grantAccess($id: ID!, $gameName: ID!) {
+    grantAccess(playerId: $id, itemName: $gameName)
+  }
+`
+
+/**
+ * Triggers grant command.
+ * @param {string[]} argv - array of parsed arguments (without executable and current file).
+ * @returns {Promise<Boolean>} whether the operation succeeded.
+ */
+export default async function grantCommand(argv) {
+  const {
+    username,
+    command: [gameName]
+  } = parseArgv(argv, {
+    '--username': RequiredString,
+    '-u': '--username'
+  })
+  if (!gameName) {
+    throw new Error('no game-name provided')
+  }
+  return grant({ username, gameName })
+}
+
+/**
+ * @typedef {object} GrantArgs
+ * @property {string} username - name of the corresponding user.
+ * @property {string} gameName - name of the granted game
+ */
+
+/**
+ * Grant a player access to a copyrighted game.
+ * @param {GrantArgs} args - username and game name.
+ * @returns {Promise<Boolean>} whether the operation succeeded.
+ */
+export async function grant({ username, gameName }) {
+  const client = getGraphQLClient()
+  const { id } = await findUser(username)
+  const { grantAccess } = await client.mutation(
+    grantAccessMutation,
+    { id, gameName },
+    signToken()
+  )
+  return attachFormater(
+    {
+      grantAccess,
+      ...(await catalog({ username }))
+    },
+    formatGrant,
+    true
+  )
+}
+
+function formatGrant({ grantAccess }) {
+  return grantAccess
+    ? chalkTemplate`🛣  access {green granted}\n`
+    : chalkTemplate`🔶 {yellow no changes}\n`
+}

--- a/apps/cli/src/commands/help.js
+++ b/apps/cli/src/commands/help.js
@@ -1,0 +1,20 @@
+// @ts-check
+import chalk from 'chalk'
+import { cliName } from '../util/index.js'
+
+/**
+ * Prints help message on console.
+ */
+export function help() {
+  console.log(`
+  ${chalk.bold(`${cliName}`)} [options] <command>
+  ${chalk.dim('Commands:')}
+    catalog                   List accessible game
+    grant [game-name]         Grant access to a copyright game
+    revoke [game-name]        Revoke access to a copyright game
+  ${chalk.dim('Options:')}
+    --help/-h                 Display help for a given command or subcommand
+    --username/-u             Username for which command is run
+    --production/-p           Load configuration from .env.local
+`)
+}

--- a/apps/cli/src/commands/index.js
+++ b/apps/cli/src/commands/index.js
@@ -1,0 +1,4 @@
+export { default as catalog } from './catalog.js'
+export { default as grant } from './grant.js'
+export { help } from './help.js'
+export { default as revoke } from './revoke.js'

--- a/apps/cli/src/commands/revoke.js
+++ b/apps/cli/src/commands/revoke.js
@@ -1,0 +1,71 @@
+// @ts-check
+import { gql } from '@urql/core'
+import chalkTemplate from 'chalk-template'
+import {
+  attachFormater,
+  findUser,
+  getGraphQLClient,
+  parseArgv,
+  RequiredString,
+  signToken
+} from '../util/index.js'
+import { catalog } from './catalog.js'
+
+const revokeAccessMutation = gql`
+  mutation revokeAccess($id: ID!, $gameName: ID!) {
+    revokeAccess(playerId: $id, itemName: $gameName)
+  }
+`
+/**
+ * Triggers the revoke command.
+ * @param {string[]} argv - array of parsed arguments (without executable and current file).
+ * @returns {Promise<Boolean>} whether the operation succeeded.
+ */
+export default async function revokeCommand(argv) {
+  const {
+    username,
+    command: [gameName]
+  } = parseArgv(argv, {
+    '--username': RequiredString,
+    '-u': '--username'
+  })
+  if (!gameName) {
+    throw new Error('no game-name provided')
+  }
+  return revoke({ username, gameName })
+}
+
+/**
+ * @typedef {object} RevokeArgs
+ * @property {string} username - name of the corresponding user.
+ * @property {string} gameName - name of the granted game
+ */
+
+/**
+ * Revoke game access to a player.
+ * @param {RevokeArgs} args - username and game Name.
+ * @returns {Promise<Boolean>} whether the operation succeeded.
+ */
+export async function revoke({ username, gameName }) {
+  const client = getGraphQLClient()
+  const { id } = await findUser(username)
+  const { revokeAccess } = await client.mutation(
+    revokeAccessMutation,
+    { id, gameName },
+    signToken()
+  )
+  return attachFormater(
+    {
+      revokeAccess,
+      ...(await catalog({ username }))
+    },
+    formatRevokation,
+    true
+  )
+}
+
+function formatRevokation({ revokeAccess }) {
+  return revokeAccess
+    ? chalkTemplate`🚷 access {green revoked}\n`
+    : chalkTemplate`🔶 {yellow no changes}\n`
+}

--- a/apps/cli/src/index.mjs
+++ b/apps/cli/src/index.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S node --no-warnings
+// @ts-check
+// this file is using mjs for istanbul to stop complaining about import.meta
+
+import esMain from 'es-main'
+import { config } from 'dotenv'
+import { resolve } from 'path'
+import { cwd } from 'process'
+import * as commands from './commands/index.js'
+import { parseArgv, shiftCommand } from './util/args.js'
+import chalkTemplate from 'chalk-template'
+import { printWithFormaters } from './util/formaters.js'
+
+/**
+ * Parses provided command line arguments and run the corresponding command.
+ * @param {string[]} argv - array of parsed arguments (without executable and current file).
+ */
+export default async function main(argv) {
+  const args = parseArgv(argv, {
+    '--help': Boolean,
+    '--production': Boolean,
+    '-h': '--help',
+    '-p': '--production'
+  })
+  loadEnv(args)
+  printProductionMessage(args)
+
+  const [name, command] = findCommand(args)
+  if (!command) {
+    commands.help()
+  } else {
+    await invokeCommand(command, argv, name)
+  }
+}
+
+function loadEnv({ production }) {
+  config({ path: resolve(cwd(), production ? '.env.prod' : '.env') })
+}
+
+function printProductionMessage({ production }) {
+  if (production) {
+    console.log(chalkTemplate`🚀 using {underline production}\n`)
+  }
+}
+
+function findCommand(args) {
+  return (
+    Object.entries(commands).find(([name]) => args.command.includes(name)) ?? []
+  )
+}
+
+async function invokeCommand(command, argv, name) {
+  try {
+    const results = await command(shiftCommand(argv, name))
+    printWithFormaters(results)
+  } catch (err) {
+    console.log(chalkTemplate`{bold {redBright error}}: ${err.message}`)
+    commands.help()
+  }
+}
+
+/* istanbul ignore next */
+if (esMain(import.meta)) {
+  main(process.argv.slice(2))
+}

--- a/apps/cli/src/util/args.js
+++ b/apps/cli/src/util/args.js
@@ -1,0 +1,42 @@
+// @ts-check
+import arg from 'arg'
+import camelCase from 'lodash.camelcase'
+
+const requiredSymbol = Symbol('required')
+
+export const RequiredString = value => String(value)
+RequiredString.required = requiredSymbol
+
+/**
+ * Parse provided command line arguments against spec.
+ * @param {string[]} argv - array of parsed arguments (without executable and current file).
+ * @param {arg.Spec} spec - parser specification.
+ * @returns {object} parsed command line arguments.
+ */
+export function parseArgv(argv = [], spec) {
+  const parsed = arg(spec, { permissive: true, argv })
+  const args = Object.fromEntries(
+    Object.entries(parsed).map(([name, value]) => [
+      name === '_' ? 'command' : camelCase(name),
+      value
+    ])
+  )
+  for (const name in spec) {
+    const friendlyName = camelCase(name)
+    // @ts-ignore
+    if (spec[name].required && !(friendlyName in args)) {
+      throw new Error(`no ${friendlyName} provided`)
+    }
+  }
+  return args
+}
+
+/**
+ * Removes the first command from parsed arguments.
+ * @param {string[]} argv - array of parsed arguments.
+ * @param {string} command - removed command
+ * @returns {string[]} the parsed arguments without stripped command.
+ */
+export function shiftCommand(argv, command) {
+  return argv.filter(arg => arg !== command)
+}

--- a/apps/cli/src/util/configuration.js
+++ b/apps/cli/src/util/configuration.js
@@ -1,0 +1,51 @@
+import Ajv from 'ajv/dist/jtd.js'
+
+const validate = new Ajv({ allErrors: true }).compile({
+  properties: {
+    url: { type: 'string' },
+    jwt: {
+      properties: {
+        key: { type: 'string' }
+      }
+    },
+    adminUserId: { type: 'string' }
+  }
+})
+
+/**
+ * @typedef {object} Configuration loaded configuration, including:
+ * @property {string} url - full url of tabulous server.
+ * @property {object} jwt - configuration for JWT signing:
+ * @property {string} jwt.key - key used for signing JWT.
+ * @property {string} adminUserId - user id used to run elevated graphQL queries.
+ */
+
+/**
+ * Synchronously loads and validates configuration from environment variables:
+ * - URL: full url of the tabulous server.
+ * - JWT_KEY: key used to sign JWT sent to the client.
+ * - ADMIN_USER_ID: user id used to run elevated graphQL queries.
+ *
+ * @returns {Configuration} the loaded configuration.
+ * @throws {Error} when the provided environment variables do not match expected values.
+ */
+export function loadConfiguration() {
+  const { URL, JWT_KEY, ADMIN_USER_ID } = process.env
+
+  const configuration = {
+    url: URL,
+    jwt: { key: JWT_KEY },
+    adminUserId: ADMIN_USER_ID
+  }
+
+  if (!validate(configuration)) {
+    throw new Error(
+      validate.errors.reduce(
+        (message, error) =>
+          `${message}\n${error.instancePath} ${error.message}`,
+        ''
+      )
+    )
+  }
+  return configuration
+}

--- a/apps/cli/src/util/find-user.js
+++ b/apps/cli/src/util/find-user.js
@@ -1,0 +1,32 @@
+// @ts-check
+import { gql } from '@urql/core'
+import { getGraphQLClient } from './graphql-client.js'
+import { signToken } from './jwt.js'
+
+const findUserQuery = gql`
+  query findUserByUsername($username: String!) {
+    searchPlayers(search: $username, includeCurrent: true) {
+      id
+      username
+    }
+  }
+`
+
+/**
+ * Finds user details from their username
+ * @param {string} username - desired username.
+ * @returns {Promise<import('@tabulous/server/src/services/players').Player|null>} corresponding player, or null.
+ */
+export async function findUser(username, failOnNull = true) {
+  const client = getGraphQLClient()
+  const { searchPlayers } = await client.query(
+    findUserQuery,
+    { username },
+    signToken()
+  )
+  const user = searchPlayers?.[0] ?? null
+  if (!user && failOnNull) {
+    throw new Error(`no user found`)
+  }
+  return user
+}

--- a/apps/cli/src/util/formaters.js
+++ b/apps/cli/src/util/formaters.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+const symbol = Symbol('formaters')
+
+/**
+ * Prints on console the provided object with its attached formaters.
+ * If there are none, prints it raw.
+ * @param {any} object - printed object
+ */
+export function printWithFormaters(object) {
+  for (const output of applyFormaters(object)) {
+    console.log(output)
+  }
+}
+
+/**
+ * Invokes formaters of an object.
+ * @param {*} object - printed object.
+ * @returns {Array<object|string>} list of outputs, either strings or raw objects.
+ */
+export function applyFormaters(object) {
+  const output = ['']
+  const formaters = object?.[symbol] ?? []
+  for (const formater of formaters) {
+    output.push(formater(object))
+  }
+  if (formaters.length === 0) {
+    output.push(object)
+  }
+  return output
+}
+
+/**
+ * Adds a formater to an object. The new formater can be added at the beginning of the formater list, or at the end (default)
+ * @param {any} object - object to add this formater to.
+ * @param {function} formater - added formater function.
+ * @param {boolean} [first=false] - whether to add this formater first or last.
+ * @returns {any} the mutated object.
+ */
+export function attachFormater(object, formater, first = false) {
+  let formaters = object[symbol]
+  if (!formaters) {
+    formaters = []
+    object[symbol] = formaters
+  }
+  formaters[first ? 'unshift' : 'push'](formater)
+  return object
+}

--- a/apps/cli/src/util/graphql-client.js
+++ b/apps/cli/src/util/graphql-client.js
@@ -1,0 +1,54 @@
+// @ts-check
+import { createClient } from '@urql/core'
+import { Agent, fetch, setGlobalDispatcher } from 'undici'
+import { loadConfiguration } from './configuration.js'
+
+let client
+let fetchOptions
+
+/**
+ * Builds or returns the existing graphQL client.
+ * @returns {object} graphql client.
+ */
+export function getGraphQLClient() {
+  if (!client) {
+    client = initClient({
+      ...loadConfiguration(),
+      maskTypename: true,
+      fetch,
+      fetchOptions: () => fetchOptions
+    })
+  }
+  return client
+}
+
+function initClient(options) {
+  const client = createClient({
+    ...options,
+    url: `${options.url}/graphql`
+  })
+
+  setGlobalDispatcher(
+    new Agent({
+      connect: {
+        rejectUnauthorized: false
+      }
+    })
+  )
+
+  async function runQuery(type, args) {
+    const jwt = args.pop()
+    fetchOptions = { headers: { cookie: `token=${jwt}` } }
+    const { data, error } = await client[type](...args).toPromise()
+    if (error) {
+      throw error
+    }
+    return data
+  }
+
+  return {
+    ...client,
+    query: (...args) => runQuery('query', args),
+    mutation: (...args) => runQuery('mutation', args)
+  }
+}

--- a/apps/cli/src/util/index.js
+++ b/apps/cli/src/util/index.js
@@ -1,0 +1,12 @@
+export * from './args.js'
+export * from './configuration.js'
+export * from './graphql-client.js'
+export * from './find-user.js'
+export * from './formaters.js'
+export * from './jwt.js'
+
+/**
+ * Name of the Tabulous CLI displayed in help messages
+ * @type {string}
+ */
+export const cliName = 'tabulous'

--- a/apps/cli/src/util/jwt.js
+++ b/apps/cli/src/util/jwt.js
@@ -1,0 +1,13 @@
+// @ts-check
+import { createSigner } from 'fast-jwt'
+import { loadConfiguration } from './configuration.js'
+
+/**
+ * Creates a signed JWT that can be used as authentication token.
+ * @param {string} [userId] - id of the impersonated user. Default to the one from configuration.
+ * @returns {string} the corresponding signed JWT.
+ */
+export function signToken(userId) {
+  const { jwt, adminUserId } = loadConfiguration()
+  return createSigner(jwt)({ id: userId ?? adminUserId })
+}

--- a/apps/cli/tests/commands/catalog.test.js
+++ b/apps/cli/tests/commands/catalog.test.js
@@ -1,0 +1,77 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import stripAnsi from 'strip-ansi'
+import { applyFormaters } from '../../src/util/formaters.js'
+import { signToken } from '../../src/util/jwt.js'
+
+const mockQuery = jest.fn()
+
+jest.unstable_mockModule('../../src/util/graphql-client.js', () => ({
+  getGraphQLClient: jest.fn().mockReturnValue({ query: mockQuery })
+}))
+
+describe('User catalog command', () => {
+  let catalog
+  const adminUserId = faker.datatype.uuid()
+  const jwtKey = faker.datatype.uuid()
+
+  beforeAll(async () => {
+    process.env.URL = faker.internet.url()
+    process.env.ADMIN_USER_ID = adminUserId
+    process.env.JWT_KEY = jwtKey
+    catalog = (await import('../../src/commands/catalog.js')).default
+  })
+
+  beforeEach(jest.clearAllMocks)
+
+  it('throws on missing username', async () => {
+    await expect(catalog([])).rejects.toThrow('no username provided')
+  })
+
+  it('returns a serializable list of games', async () => {
+    const player = {
+      id: faker.datatype.uuid(),
+      username: faker.name.findName()
+    }
+    const games = [
+      { name: 'chess', title: 'Echecs', copyright: '' },
+      {
+        name: 'prima-ballerina',
+        title: 'Petite danseuse étoile',
+        copyright: '©'
+      },
+      { name: 'splendor', title: 'splendor', copyright: '©' }
+    ]
+    mockQuery.mockResolvedValueOnce({ searchPlayers: [player] })
+    mockQuery.mockResolvedValueOnce({
+      listCatalog: games.map(({ name, title, copyright }) => ({
+        name,
+        locales: name === 'splendor' ? {} : { fr: { title } },
+        copyright:
+          copyright !== ''
+            ? { authors: [{ name: faker.name.findName() }] }
+            : undefined
+      }))
+    })
+    const result = await catalog(['--username', player.username])
+    expect(result).toMatchObject({ games })
+    expect(stripAnsi(applyFormaters(result).join('\n'))).toBe(`
+-   Echecs chess
+- © Petite danseuse étoile prima-ballerina
+- © splendor splendor
+
+3 accessible game(s)`)
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      { username: player.username },
+      signToken()
+    )
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      signToken(player.id)
+    )
+    expect(mockQuery).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/cli/tests/commands/grant.test.js
+++ b/apps/cli/tests/commands/grant.test.js
@@ -1,0 +1,128 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import stripAnsi from 'strip-ansi'
+import { applyFormaters } from '../../src/util/formaters.js'
+import { signToken } from '../../src/util/jwt.js'
+
+const mockQuery = jest.fn()
+const mockMutation = jest.fn()
+
+jest.unstable_mockModule('../../src/util/graphql-client.js', () => ({
+  getGraphQLClient: jest
+    .fn()
+    .mockReturnValue({ query: mockQuery, mutation: mockMutation })
+}))
+
+describe('User grant command', () => {
+  let grant
+  const adminUserId = faker.datatype.uuid()
+  const jwtKey = faker.datatype.uuid()
+
+  beforeAll(async () => {
+    process.env.URL = faker.internet.url()
+    process.env.ADMIN_USER_ID = adminUserId
+    process.env.JWT_KEY = jwtKey
+    grant = (await import('../../src/commands/grant.js')).default
+  })
+
+  beforeEach(jest.clearAllMocks)
+
+  it('throws on missing username', async () => {
+    await expect(grant([])).rejects.toThrow('no username provided')
+  })
+
+  it('throws on missing game name', async () => {
+    await expect(grant(['-u', 'someone'])).rejects.toThrow(
+      'no game-name provided'
+    )
+  })
+
+  describe('given existing players', () => {
+    const player = {
+      id: faker.datatype.uuid(),
+      username: faker.name.findName()
+    }
+    const gameName = faker.commerce.productName()
+
+    beforeEach(() => {
+      mockQuery.mockImplementation(
+        async ({
+          definitions: [
+            {
+              name: { value }
+            }
+          ]
+        }) =>
+          value === 'findUserByUsername'
+            ? { searchPlayers: [player] }
+            : { listCatalog: [] }
+      )
+    })
+
+    it('returns true when access was granted', async () => {
+      mockMutation.mockResolvedValueOnce({ grantAccess: true })
+      const result = await grant(['-u', player.username, gameName])
+      expect(result).toMatchObject({ grantAccess: true })
+      expect(stripAnsi(applyFormaters(result).join('\n'))).toContain(
+        'access granted'
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.anything(),
+        signToken(player.id)
+      )
+      expect(mockQuery).toHaveBeenCalledTimes(3)
+      expect(mockMutation).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: player.id, gameName },
+        signToken()
+      )
+      expect(mockMutation).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns false when access was not granted', async () => {
+      mockMutation.mockResolvedValueOnce({ grantAccess: false })
+      const result = await grant(['--username', player.username, gameName])
+      expect(result).toMatchObject({ grantAccess: false })
+      expect(stripAnsi(applyFormaters(result).join('\n'))).toContain(
+        'no changes'
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.anything(),
+        signToken(player.id)
+      )
+      expect(mockQuery).toHaveBeenCalledTimes(3)
+      expect(mockMutation).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: player.id, gameName },
+        signToken()
+      )
+      expect(mockMutation).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/cli/tests/commands/help.test.js
+++ b/apps/cli/tests/commands/help.test.js
@@ -1,0 +1,21 @@
+import { help } from '../../src/commands/help.js'
+import { mockConsole } from '../test-util.js'
+
+describe('help command', () => {
+  const output = mockConsole()
+
+  it('prints help on console', () => {
+    help()
+    expect(output.stdout).toContain(`
+  tabulous [options] <command>
+  Commands:
+    catalog                   List accessible game
+    grant [game-name]         Grant access to a copyright game
+    revoke [game-name]        Revoke access to a copyright game
+  Options:
+    --help/-h                 Display help for a given command or subcommand
+    --username/-u             Username for which command is run
+    --production/-p           Load configuration from .env.local
+`)
+  })
+})

--- a/apps/cli/tests/commands/revoke.test.js
+++ b/apps/cli/tests/commands/revoke.test.js
@@ -1,0 +1,128 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import stripAnsi from 'strip-ansi'
+import { applyFormaters } from '../../src/util/formaters.js'
+import { signToken } from '../../src/util/jwt.js'
+
+const mockQuery = jest.fn()
+const mockMutation = jest.fn()
+
+jest.unstable_mockModule('../../src/util/graphql-client.js', () => ({
+  getGraphQLClient: jest
+    .fn()
+    .mockReturnValue({ query: mockQuery, mutation: mockMutation })
+}))
+
+describe('User revokes command', () => {
+  let revoke
+  const adminUserId = faker.datatype.uuid()
+  const jwtKey = faker.datatype.uuid()
+
+  beforeAll(async () => {
+    process.env.URL = faker.internet.url()
+    process.env.ADMIN_USER_ID = adminUserId
+    process.env.JWT_KEY = jwtKey
+    revoke = (await import('../../src/commands/revoke.js')).default
+  })
+
+  beforeEach(jest.clearAllMocks)
+
+  it('throws on missing username', async () => {
+    await expect(revoke([])).rejects.toThrow('no username provided')
+  })
+
+  it('throws on missing game name', async () => {
+    await expect(revoke(['-u', 'someone'])).rejects.toThrow(
+      'no game-name provided'
+    )
+  })
+
+  describe('given existing players', () => {
+    const player = {
+      id: faker.datatype.uuid(),
+      username: faker.name.findName()
+    }
+    const gameName = faker.commerce.productName()
+
+    beforeEach(() => {
+      mockQuery.mockImplementation(
+        async ({
+          definitions: [
+            {
+              name: { value }
+            }
+          ]
+        }) =>
+          value === 'findUserByUsername'
+            ? { searchPlayers: [player] }
+            : { listCatalog: [] }
+      )
+    })
+
+    it('returns true when access was revoked', async () => {
+      mockMutation.mockResolvedValueOnce({ revokeAccess: true })
+      const result = await revoke(['-u', player.username, gameName])
+      expect(result).toMatchObject({ revokeAccess: true })
+      expect(stripAnsi(applyFormaters(result).join('\n'))).toContain(
+        'access revoked'
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.anything(),
+        signToken(player.id)
+      )
+      expect(mockQuery).toHaveBeenCalledTimes(3)
+      expect(mockMutation).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: player.id, gameName },
+        signToken()
+      )
+      expect(mockMutation).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns false when access was not granted', async () => {
+      mockMutation.mockResolvedValueOnce({ revokeAccess: false })
+      const result = await revoke(['--username', player.username, gameName])
+      expect(result).toMatchObject({ revokeAccess: false })
+      expect(stripAnsi(applyFormaters(result).join('\n'))).toContain(
+        'no changes'
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { username: player.username },
+        signToken()
+      )
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.anything(),
+        signToken(player.id)
+      )
+      expect(mockQuery).toHaveBeenCalledTimes(3)
+      expect(mockMutation).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: player.id, gameName },
+        signToken()
+      )
+      expect(mockMutation).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/cli/tests/index.test.js
+++ b/apps/cli/tests/index.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals'
+import { inspect } from 'util'
+import { attachFormater } from '../src/util/formaters.js'
+import { mockConsole } from './test-util.js'
+
+const mockCatalog = jest.fn()
+
+jest.unstable_mockModule('../src/commands/catalog.js', () => ({
+  default: mockCatalog,
+  catalog: jest.fn()
+}))
+
+describe('Tabulous CLI', () => {
+  const output = mockConsole()
+  let cli
+
+  beforeAll(async () => {
+    cli = (await import('../src/index.mjs')).default
+  })
+
+  it('prints help on unknown command', () => {
+    cli(['unknown'])
+    expect(output.stdout).toContain('tabulous [options] <command>')
+  })
+
+  it('prints help by default', () => {
+    cli([])
+    expect(output.stdout).toContain('tabulous [options] <command>')
+  })
+
+  it('displays error and help', async () => {
+    const error = new Error('no username provided')
+    mockCatalog.mockRejectedValue(error)
+    await cli(['catalog'])
+    expect(output.stdout).toContain(`error: ${error.message}`)
+    expect(output.stdout).toContain('tabulous [options] <command>')
+  })
+
+  it('prints production message when relevant', async () => {
+    await cli(['catalog', '--production'])
+    expect(output.stdout).toContain(`using production`)
+  })
+
+  it('prints command raw result', async () => {
+    const result = { foo: 'bar' }
+    mockCatalog.mockResolvedValue(result)
+    await cli(['catalog'])
+    expect(output.stdout).toContain(inspect(result))
+  })
+
+  it('prints command result with formaters', async () => {
+    const result = { foo: 'bar' }
+    const formatedResult = 'this result was formated'
+    const formater = jest.fn().mockReturnValue(formatedResult)
+    mockCatalog.mockResolvedValue(attachFormater(result, formater))
+    await cli(['catalog'])
+    expect(output.stdout).toContain(formatedResult)
+    expect(output.stdout).not.toContain(inspect(result))
+    expect(formater).toHaveBeenCalledWith(result)
+    expect(formater).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cli/tests/test-util.js
+++ b/apps/cli/tests/test-util.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals'
+import stripAnsi from 'strip-ansi'
+import { inspect } from 'util'
+
+const debug = false
+
+export function mockConsole() {
+  const output = {
+    stdout: ''
+  }
+
+  beforeEach(() => {
+    output.stdout = ''
+    jest.spyOn(console, 'log').mockImplementation((...args) => {
+      output.stdout += args
+        .map(obj => {
+          const content =
+            typeof obj === 'string' ? stripAnsi(obj) : inspect(obj)
+          debug && process.stdout.write(`${content}\n`)
+          return content
+        })
+        .join(' ')
+    })
+  })
+
+  afterEach(jest.resetAllMocks)
+
+  return output
+}

--- a/apps/cli/tests/util/configuration.test.js
+++ b/apps/cli/tests/util/configuration.test.js
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import { loadConfiguration } from '../../src/util/configuration.js'
+
+describe('loadConfiguration()', () => {
+  const { ...envSave } = process.env
+  const jwtKey = faker.internet.password()
+
+  beforeEach(() => {
+    process.env = { ...envSave }
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('loads values from environment variables', () => {
+    const url = faker.internet.ip()
+    const adminUserId = faker.datatype.uuid()
+
+    process.env = {
+      ...process.env,
+      URL: url,
+      JWT_KEY: jwtKey,
+      ADMIN_USER_ID: adminUserId
+    }
+
+    expect(loadConfiguration()).toEqual({
+      url,
+      jwt: { key: jwtKey },
+      adminUserId
+    })
+  })
+
+  it('reports missing variables', () => {
+    expect(loadConfiguration).toThrow(`must have property 'url'`)
+    expect(loadConfiguration).toThrow(`must have property 'adminUserId'`)
+    expect(loadConfiguration).toThrow(`/jwt must have property 'key'`)
+  })
+})

--- a/apps/cli/tests/util/find-user.test.js
+++ b/apps/cli/tests/util/find-user.test.js
@@ -1,0 +1,56 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import { signToken } from '../../src/util/jwt.js'
+
+const mockQuery = jest.fn()
+const mockMutation = jest.fn()
+
+jest.unstable_mockModule('../../src/util/graphql-client.js', () => ({
+  getGraphQLClient: jest
+    .fn()
+    .mockReturnValue({ query: mockQuery, mockMutation })
+}))
+
+describe('getGraphQLClient()', () => {
+  let findUser
+  const adminUserId = faker.datatype.uuid()
+  const jwtKey = faker.datatype.uuid()
+
+  beforeAll(async () => {
+    process.env.URL = faker.internet.url()
+    process.env.ADMIN_USER_ID = adminUserId
+    process.env.JWT_KEY = jwtKey
+    ;({ findUser } = await import('../../src/util/find-user.js'))
+  })
+
+  beforeEach(jest.clearAllMocks)
+
+  it('returns existing user', async () => {
+    const player = {
+      id: faker.datatype.uuid(),
+      username: faker.name.findName()
+    }
+    mockQuery.mockResolvedValue({ searchPlayers: [player] })
+
+    expect(await findUser(player.username)).toEqual(player)
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      { username: player.username },
+      signToken(adminUserId)
+    )
+  })
+
+  it('throws on user not found', async () => {
+    const username = faker.name.findName()
+    mockQuery.mockResolvedValue({ searchPlayers: [] })
+
+    await expect(findUser(username)).rejects.toThrow('no user found')
+  })
+
+  it('can return null on demand', async () => {
+    const username = faker.name.findName()
+    mockQuery.mockResolvedValue({ searchPlayers: [] })
+
+    expect(await findUser(username, false)).toBeNull()
+  })
+})

--- a/apps/cli/tests/util/graphql-client.test.js
+++ b/apps/cli/tests/util/graphql-client.test.js
@@ -1,0 +1,180 @@
+import { faker } from '@faker-js/faker'
+import { jest } from '@jest/globals'
+import { MockAgent, setGlobalDispatcher } from 'undici'
+
+jest.unstable_mockModule('../../src/util/configuration.js', () => ({
+  loadConfiguration: jest.fn()
+}))
+
+describe('getGraphQLClient()', () => {
+  let loadConfiguration
+  let getGraphQLClient
+  const url = faker.internet.url()
+  const jwtKey = faker.datatype.uuid()
+
+  beforeAll(async () => {
+    ;({ loadConfiguration } = await import('../../src/util/configuration.js'))
+    ;({ getGraphQLClient } = await import('../../src/util/graphql-client.js'))
+  })
+
+  beforeEach(jest.clearAllMocks)
+
+  it('builds client from configuration', () => {
+    loadConfiguration.mockReturnValue({ url, jwt: { key: jwtKey } })
+
+    const client = getGraphQLClient()
+    expect(client).toBeDefined()
+    expect(client.url).toEqual(`${url}/graphql`)
+    expect(loadConfiguration).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses existing client', () => {
+    const client = getGraphQLClient()
+    expect(client).toBeDefined()
+    expect(client.url).toEqual(`${url}/graphql`)
+    expect(loadConfiguration).not.toHaveBeenCalled()
+  })
+
+  describe('given a client', () => {
+    let client
+    let mockAgent
+    let networkMock
+    const graphQLRequest = jest.fn()
+
+    beforeAll(() => {
+      client = getGraphQLClient()
+      mockAgent = new MockAgent()
+      mockAgent.disableNetConnect()
+      setGlobalDispatcher(mockAgent)
+      networkMock = mockAgent.get(url)
+    })
+
+    beforeEach(jest.clearAllMocks)
+
+    it('throws returned errors', async () => {
+      const error = new Error('boom')
+      const username = faker.name.findName()
+      const jwt = faker.datatype.uuid()
+
+      networkMock
+        .intercept({ method: 'POST', path: '/graphql' })
+        .reply(200, ({ headers, body }) => {
+          graphQLRequest({ body: JSON.parse(body), headers })
+          return { errors: [{ message: error.message }], data: null }
+        })
+
+      await expect(
+        client.query(
+          `query findUserByUsername($username: String!) {
+          searchPlayers(search: $username) { id, username }
+        }`,
+          { username },
+          jwt
+        )
+      ).rejects.toThrow(error.message)
+    })
+
+    it('runs query', async () => {
+      const username = faker.name.findName()
+      const jwt = faker.datatype.uuid()
+      const data = {
+        searchPlayers: [
+          { id: faker.datatype.uuid(), name: faker.name.findName() }
+        ]
+      }
+
+      networkMock
+        .intercept({ method: 'POST', path: '/graphql' })
+        .reply(200, ({ headers, body }) => {
+          graphQLRequest({
+            body: JSON.parse(body),
+            headers: parseHeaders(headers)
+          })
+          return { data }
+        })
+
+      expect(
+        await client.query(
+          `query findUserByUsername($username: String!) {
+          searchPlayers(search: $username) { id, username }
+        }`,
+          { username },
+          jwt
+        )
+      ).toEqual(data)
+      expect(graphQLRequest).toHaveBeenCalledWith({
+        body: {
+          operationName: 'findUserByUsername',
+          query: `query findUserByUsername($username: String!) {
+  searchPlayers(search: $username) {
+    id
+    username
+    __typename
+  }
+}`,
+          variables: { username }
+        },
+        headers: expect.objectContaining({
+          cookie: `token=${jwt}`
+        })
+      })
+    })
+
+    it('runs mutation', async () => {
+      const username = faker.name.findName()
+      const jwt = faker.datatype.uuid()
+      const data = {
+        addNewUser: [{ id: faker.datatype.uuid(), name: faker.name.findName() }]
+      }
+
+      networkMock
+        .intercept({ method: 'POST', path: '/graphql' })
+        .reply(200, ({ headers, body }) => {
+          graphQLRequest({
+            body: JSON.parse(body),
+            headers: parseHeaders(headers)
+          })
+          return { data }
+        })
+
+      expect(
+        await client.mutation(
+          `mutation addNewUser($username: String!) {
+          addUser(search: $username) { id, username }
+        }`,
+          { username },
+          jwt
+        )
+      ).toEqual(data)
+      expect(graphQLRequest).toHaveBeenCalledWith({
+        body: {
+          operationName: 'addNewUser',
+          query: `mutation addNewUser($username: String!) {
+  addUser(search: $username) {
+    id
+    username
+    __typename
+  }
+}`,
+          variables: { username }
+        },
+        headers: expect.objectContaining({
+          cookie: `token=${jwt}`
+        })
+      })
+    })
+  })
+})
+
+function parseHeaders(headers) {
+  let headerName = null
+  return headers.reduce((headers, value) => {
+    if (headerName) {
+      headers[headerName] = value
+      headerName = null
+    } else {
+      headerName = value
+    }
+    return headers
+  }, {})
+}

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -31,8 +31,9 @@ export default {
      * @param {object} context - graphQL context.
      * @returns {import('../services/authentication').Player[]} list (potentially empty) of matching players.
      */
-    searchPlayers: isAuthenticated((obj, { search }, { player }) =>
-      services.searchPlayers(search, player.id)
+    searchPlayers: isAuthenticated(
+      (obj, { search, includeCurrent }, { player }) =>
+        services.searchPlayers(search, player.id, !includeCurrent)
     )
   },
 

--- a/apps/server/src/graphql/players.graphql
+++ b/apps/server/src/graphql/players.graphql
@@ -17,7 +17,7 @@ type PlayerWithTurnCredentials {
 
 type Query {
   getCurrentPlayer: PlayerWithTurnCredentials
-  searchPlayers(search: String!): [Player]
+  searchPlayers(search: String!, includeCurrent: Boolean): [Player]
 }
 
 type Mutation {

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -64,13 +64,14 @@ export async function setPlaying(playerId, playing) {
  * Excludes current player from results, and returns nothing unless search text is at least 2 characters
  * @param {string} search - searched text.
  * @param {string} playerId - the current player id.
+ * @param {boolean} [excludeCurrent=true] - whether to exclude current player from results.
  * @returns {Player[]} list of matching players.
  */
-export async function searchPlayers(search, playerId) {
+export async function searchPlayers(search, playerId, excludeCurrent = true) {
   if ((search ?? '').trim().length < 2) return []
   const { results } = await repositories.players.searchByUsername({
     search,
     size: 50
   })
-  return results.filter(({ id }) => id !== playerId)
+  return excludeCurrent ? results.filter(({ id }) => id !== playerId) : results
 }

--- a/apps/server/tests/graphql/players-resolver.test.js
+++ b/apps/server/tests/graphql/players-resolver.test.js
@@ -234,7 +234,8 @@ describe('given a started server', () => {
         expect(response.statusCode).toEqual(200)
         expect(services.searchPlayers).toHaveBeenCalledWith(
           search,
-          players[0].id
+          players[0].id,
+          true
         )
         expect(services.searchPlayers).toHaveBeenCalledTimes(1)
       })

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -102,8 +102,12 @@ describe('given initialized repository', () => {
         ])
       })
 
-      it('excludes current player from results', async () => {
+      it('excludes current player from results, on demand', async () => {
         expect(await searchPlayers('man', players[3].id)).toEqual([players[1]])
+        expect(await searchPlayers('man', players[3].id, false)).toEqual([
+          players[1],
+          players[3]
+        ])
       })
 
       it('excludes nothing bellow 2 characters', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,85 @@
         "prettier-plugin-svelte": "^2.7.0"
       }
     },
+    "apps/cli": {
+      "name": "@tabulous/cli",
+      "version": "0.0.1",
+      "dependencies": {
+        "@urql/core": "^2.5.0",
+        "add": "^2.0.6",
+        "ajv": "^8.11.0",
+        "arg": "^5.0.2",
+        "chalk": "^5.0.1",
+        "chalk-template": "^0.4.0",
+        "dotenv": "^16.0.1",
+        "es-main": "^1.2.0",
+        "fast-jwt": "^1.6.0",
+        "graphql": "^16.5.0",
+        "lodash.camelcase": "^4.3.0",
+        "undici": "^5.6.0"
+      },
+      "bin": {
+        "tabulous": "bin/tabulous.sh"
+      },
+      "devDependencies": {
+        "jest": "^28.1.2",
+        "jest-watch-typeahead": "^1.1.0",
+        "strip-ansi": "^7.0.1"
+      }
+    },
+    "apps/cli/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "apps/cli/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "apps/cli/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "apps/cli/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "apps/games": {
       "name": "@tabulous/games",
       "version": "0.0.1",
@@ -2914,6 +2993,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/@tabulous/cli": {
+      "resolved": "apps/cli",
+      "link": true
+    },
     "node_modules/@tabulous/games": {
       "resolved": "apps/games",
       "link": true
@@ -3281,7 +3364,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.5.0.tgz",
       "integrity": "sha512-xXdcgb0H3nNTP4OfC+5T3CHJ0iz7Jj0QQYSYhN/hvKrzFnisPz2n6WXmvsHmMXk5bJHsr39kx4eOHcpsJuyCew==",
-      "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "wonka": "^4.0.14"
@@ -3410,6 +3492,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/add": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/add/-/add-2.0.6.tgz",
+      "integrity": "sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -3564,7 +3651,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3592,6 +3678,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4160,7 +4251,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4170,6 +4260,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -4385,7 +4489,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4396,8 +4499,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "2.0.19",
@@ -5117,6 +5219,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-main": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-main/-/es-main-1.2.0.tgz",
+      "integrity": "sha512-A4tCSY43O/mH4rHjG1n0mI4DhK2BmKDr8Lk8PXK/GBB6zxGFGmIW4bbkbTQ2Gi9iNamMZ9vbGrwjZOIeiM7vMw=="
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -6600,7 +6707,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9313,6 +9419,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11995,7 +12106,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12870,8 +12980,7 @@
     "node_modules/wonka": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
-      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==",
-      "dev": true
+      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -15133,6 +15242,59 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tabulous/cli": {
+      "version": "file:apps/cli",
+      "requires": {
+        "@urql/core": "^2.5.0",
+        "add": "^2.0.6",
+        "ajv": "^8.11.0",
+        "arg": "^5.0.2",
+        "chalk": "^5.0.1",
+        "chalk-template": "^0.4.0",
+        "dotenv": "^16.0.1",
+        "es-main": "^1.2.0",
+        "fast-jwt": "^1.6.0",
+        "graphql": "^16.5.0",
+        "jest": "^28.1.2",
+        "jest-watch-typeahead": "^1.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "strip-ansi": "^7.0.1",
+        "undici": "^5.6.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
+    },
     "@tabulous/games": {
       "version": "file:apps/games",
       "requires": {
@@ -15556,7 +15718,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.5.0.tgz",
       "integrity": "sha512-xXdcgb0H3nNTP4OfC+5T3CHJ0iz7Jj0QQYSYhN/hvKrzFnisPz2n6WXmvsHmMXk5bJHsr39kx4eOHcpsJuyCew==",
-      "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "wonka": "^4.0.14"
@@ -15655,6 +15816,11 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "add": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/add/-/add-2.0.6.tgz",
+      "integrity": "sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -15774,7 +15940,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -15793,6 +15958,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+    },
+    "arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -16202,10 +16372,17 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "requires": {
+        "chalk": "^4.1.2"
       }
     },
     "char-regex": {
@@ -16368,7 +16545,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -16376,8 +16552,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colorette": {
       "version": "2.0.19",
@@ -16936,6 +17111,11 @@
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
       }
+    },
+    "es-main": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-main/-/es-main-1.2.0.tgz",
+      "integrity": "sha512-A4tCSY43O/mH4rHjG1n0mI4DhK2BmKDr8Lk8PXK/GBB6zxGFGmIW4bbkbTQ2Gi9iNamMZ9vbGrwjZOIeiM7vMw=="
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -17974,8 +18154,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -20002,6 +20181,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -22024,7 +22208,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -22666,8 +22849,7 @@
     "wonka": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
-      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==",
-      "dev": true
+      "integrity": "sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "apps/*"
   ],
   "scripts": {
+    "dev:cli": "npm run test:dev -w apps/cli",
     "dev:server": "npm run test:dev -w apps/server",
     "dev:web": "npm run test:dev -w apps/web",
     "format": "prettier --write .",
@@ -23,6 +24,7 @@
     "start:server": "npm start -w apps/server",
     "start:web": "npm start -w apps/web",
     "test": "run-s -ncs test:**",
+    "test:cli": "npm t -w apps/cli",
     "test:server": "npm t -w apps/server",
     "test:web": "npm t -w apps/web"
   },


### PR DESCRIPTION
### What's in there?

Administrative tasks are cumbersome. Here is a simple CLI tool to performs them!

Are included here:
- feat(server): includes current player in search results when desired
- feat(cli): implements games catalog
- feat(cli): implements game access grant
- feat(cli): implements game access revokation

### How to test?

1. Start your local server
2. Install the CLI:
   ```shell
   cd apps/cli
   npm link
   ```
3. Creates `.env` file with:
   ```shell
   URL=https://localhost:3000
   JWT_KEY=dummy-test-key
   ADMIN_USER_ID=XYZ  # <--- find a user in your apps/server/data/player.json
   ```
5. Adds `"isAdmin": true` to your player account
6. Run the CLI: `tabulous -u Dams catalog`

To run it in production, make a copy of your `.env` file and name it `.env.prod`. Adjust the values, and run `tabulous -p -u Dams catalog`