### PR TITLE
fix(cli): grant and revoke commands are broken in production

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 Roadmap
 
-- cli: administrative operations (tests)
 - server: catalog query with and without own games
 - games: generic card game
 - web: publicly accessible catalog

--- a/apps/cli/src/commands/catalog.js
+++ b/apps/cli/src/commands/catalog.js
@@ -3,6 +3,8 @@ import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 import {
   attachFormater,
+  cliName,
+  commonArgSpec,
   findUser,
   getGraphQLClient,
   parseArgv,
@@ -43,15 +45,18 @@ const listCatalogQuery = gql`
 /**
  * Triggers catalog command
  * @param {string[]} argv - array of parsed arguments (without executable and current file).
- * @returns {Promise<CatalogResult>} this user catalog of accessible games.
+ * @returns {Promise<CatalogResult|string>} this user catalog of accessible games.
  */
 export default async function catalogCommand(argv) {
-  return catalog(
-    parseArgv(argv, {
-      '--username': RequiredString,
-      '-u': '--username'
-    })
-  )
+  const args = parseArgv(argv, {
+    ...commonArgSpec,
+    '--username': RequiredString,
+    '-u': '--username'
+  })
+  if (args.help) {
+    return help()
+  }
+  return catalog(args)
 }
 
 /**
@@ -99,4 +104,15 @@ function formatCatalog({ games }) {
   output.push(chalkTemplate`
 ${games.length} {dim accessible game(s)}`)
   return output.join('\n')
+}
+
+function help() {
+  return chalkTemplate`
+  {bold ${cliName}} [options] catalog
+  Lists accessible games
+  {dim Options:}
+    --username/-u             Username for which catalog is fetched
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Display help for this command
+`
 }

--- a/apps/cli/src/commands/grant.js
+++ b/apps/cli/src/commands/grant.js
@@ -3,6 +3,8 @@ import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 import {
   attachFormater,
+  cliName,
+  commonArgSpec,
   findUser,
   getGraphQLClient,
   parseArgv,
@@ -20,20 +22,22 @@ const grantAccessMutation = gql`
 /**
  * Triggers grant command.
  * @param {string[]} argv - array of parsed arguments (without executable and current file).
- * @returns {Promise<Boolean>} whether the operation succeeded.
+ * @returns {Promise<Boolean|string>} whether the operation succeeded.
  */
 export default async function grantCommand(argv) {
-  const {
-    username,
-    command: [gameName]
-  } = parseArgv(argv, {
+  const args = parseArgv(argv, {
+    ...commonArgSpec,
     '--username': RequiredString,
     '-u': '--username'
   })
+  const gameName = args.command?.[0]
   if (!gameName) {
     throw new Error('no game-name provided')
   }
-  return grant({ username, gameName })
+  if (args.help) {
+    return help()
+  }
+  return grant({ username: args.username, gameName })
 }
 
 /**
@@ -69,4 +73,17 @@ function formatGrant({ grantAccess }) {
   return grantAccess
     ? chalkTemplate`🛣  access {green granted}\n`
     : chalkTemplate`🔶 {yellow no changes}\n`
+}
+
+function help() {
+  return chalkTemplate`
+  {bold ${cliName}} [options] grant [game-name]
+  Grants access to a copyrighted game
+  {dim Commands:}
+    [game-name]               Name of the granted game
+  {dim Options:}
+    --username/-u             Username for which catalog is fetched
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Display help for this command
+`
 }

--- a/apps/cli/src/commands/help.js
+++ b/apps/cli/src/commands/help.js
@@ -1,20 +1,21 @@
 // @ts-check
-import chalk from 'chalk'
+import chalkTemplate from 'chalk-template'
 import { cliName } from '../util/index.js'
 
 /**
- * Prints help message on console.
+ * Returns general help message.
+ * @return {string} the general help message
  */
 export function help() {
-  console.log(`
-  ${chalk.bold(`${cliName}`)} [options] <command>
-  ${chalk.dim('Commands:')}
-    catalog                   List accessible game
-    grant [game-name]         Grant access to a copyright game
-    revoke [game-name]        Revoke access to a copyright game
-  ${chalk.dim('Options:')}
-    --help/-h                 Display help for a given command or subcommand
+  return chalkTemplate`
+  {bold ${cliName}} [options] <command>
+  {dim Commands:}
+    catalog                   Lists accessible games
+    grant [game-name]         Grants access to a copyrighted game
+    revoke [game-name]        Revokes access to a copyrighted game
+  {dim Options:}
     --username/-u             Username for which command is run
-    --production/-p           Load configuration from .env.local
-`)
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Displays help for a given command
+`
 }

--- a/apps/cli/src/commands/revoke.js
+++ b/apps/cli/src/commands/revoke.js
@@ -3,6 +3,7 @@ import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 import {
   attachFormater,
+  commonArgSpec,
   findUser,
   getGraphQLClient,
   parseArgv,
@@ -26,6 +27,7 @@ export default async function revokeCommand(argv) {
     username,
     command: [gameName]
   } = parseArgv(argv, {
+    ...commonArgSpec,
     '--username': RequiredString,
     '-u': '--username'
   })

--- a/apps/cli/src/index.mjs
+++ b/apps/cli/src/index.mjs
@@ -7,7 +7,7 @@ import { config } from 'dotenv'
 import { resolve } from 'path'
 import { cwd } from 'process'
 import * as commands from './commands/index.js'
-import { parseArgv, shiftCommand } from './util/args.js'
+import { commonArgSpec, parseArgv, shiftCommand } from './util/args.js'
 import chalkTemplate from 'chalk-template'
 import { printWithFormaters } from './util/formaters.js'
 
@@ -16,18 +16,13 @@ import { printWithFormaters } from './util/formaters.js'
  * @param {string[]} argv - array of parsed arguments (without executable and current file).
  */
 export default async function main(argv) {
-  const args = parseArgv(argv, {
-    '--help': Boolean,
-    '--production': Boolean,
-    '-h': '--help',
-    '-p': '--production'
-  })
+  const args = parseArgv(argv, commonArgSpec)
   loadEnv(args)
   printProductionMessage(args)
 
   const [name, command] = findCommand(args)
   if (!command) {
-    commands.help()
+    await invokeCommand(commands.help, [], '')
   } else {
     await invokeCommand(command, argv, name)
   }
@@ -55,7 +50,7 @@ async function invokeCommand(command, argv, name) {
     printWithFormaters(results)
   } catch (err) {
     console.log(chalkTemplate`{bold {redBright error}}: ${err.message}`)
-    commands.help()
+    console.log(commands.help())
   }
 }
 

--- a/apps/cli/src/util/args.js
+++ b/apps/cli/src/util/args.js
@@ -40,3 +40,14 @@ export function parseArgv(argv = [], spec) {
 export function shiftCommand(argv, command) {
   return argv.filter(arg => arg !== command)
 }
+
+/**
+ * Spec for common arguments.
+ * @typedef {object}
+ */
+export const commonArgSpec = {
+  '--help': Boolean,
+  '--production': Boolean,
+  '-h': '--help',
+  '-p': '--production'
+}

--- a/apps/cli/tests/commands/catalog.test.js
+++ b/apps/cli/tests/commands/catalog.test.js
@@ -28,6 +28,19 @@ describe('User catalog command', () => {
     await expect(catalog([])).rejects.toThrow('no username provided')
   })
 
+  it('displays help and support common options', async () => {
+    const username = faker.name.findName()
+    expect(stripAnsi(await catalog(['-h', '-u', username, '-p']))).toEqual(`
+  tabulous [options] catalog
+  Lists accessible games
+  Options:
+    --username/-u             Username for which catalog is fetched
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Display help for this command
+`)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
   it('returns a serializable list of games', async () => {
     const player = {
       id: faker.datatype.uuid(),

--- a/apps/cli/tests/commands/grant.test.js
+++ b/apps/cli/tests/commands/grant.test.js
@@ -37,6 +37,23 @@ describe('User grant command', () => {
     )
   })
 
+  it('displays help and support common options', async () => {
+    const username = faker.name.findName()
+    const gameName = faker.commerce.productName()
+    expect(stripAnsi(await grant(['-h', '-u', username, '-p', gameName])))
+      .toEqual(`
+  tabulous [options] grant [game-name]
+  Grants access to a copyrighted game
+  Commands:
+    [game-name]               Name of the granted game
+  Options:
+    --username/-u             Username for which catalog is fetched
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Display help for this command
+`)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
   describe('given existing players', () => {
     const player = {
       id: faker.datatype.uuid(),

--- a/apps/cli/tests/commands/help.test.js
+++ b/apps/cli/tests/commands/help.test.js
@@ -1,21 +1,18 @@
+import stripAnsi from 'strip-ansi'
 import { help } from '../../src/commands/help.js'
-import { mockConsole } from '../test-util.js'
 
 describe('help command', () => {
-  const output = mockConsole()
-
   it('prints help on console', () => {
-    help()
-    expect(output.stdout).toContain(`
+    expect(stripAnsi(help())).toContain(`
   tabulous [options] <command>
   Commands:
-    catalog                   List accessible game
-    grant [game-name]         Grant access to a copyright game
-    revoke [game-name]        Revoke access to a copyright game
+    catalog                   Lists accessible games
+    grant [game-name]         Grants access to a copyrighted game
+    revoke [game-name]        Revokes access to a copyrighted game
   Options:
-    --help/-h                 Display help for a given command or subcommand
     --username/-u             Username for which command is run
-    --production/-p           Load configuration from .env.local
+    --production/-p           Loads configuration from .env.local
+    --help/-h                 Displays help for a given command
 `)
   })
 })

--- a/apps/cli/tests/index.test.js
+++ b/apps/cli/tests/index.test.js
@@ -18,13 +18,13 @@ describe('Tabulous CLI', () => {
     cli = (await import('../src/index.mjs')).default
   })
 
-  it('prints help on unknown command', () => {
-    cli(['unknown'])
+  it('prints help on unknown command', async () => {
+    await cli(['unknown'])
     expect(output.stdout).toContain('tabulous [options] <command>')
   })
 
-  it('prints help by default', () => {
-    cli([])
+  it('prints help by default', async () => {
+    await cli([])
     expect(output.stdout).toContain('tabulous [options] <command>')
   })
 


### PR DESCRIPTION
### How to reproduce?

On an existing player that **does not** have access to a given game
1. `tabulous -p -u Dams grant 6-takes`
   > no changes 

On an existing player that **has** access to a given game
1. `tabulous -p -u Dams revoke 6-takes`
   > no changes 
