### PR TITLE
feat(server): allows listing public catalog

### DIFF
--- a/apps/server/src/graphql/catalog-resolver.js
+++ b/apps/server/src/graphql/catalog-resolver.js
@@ -1,4 +1,4 @@
-import { isAdmin, isAuthenticated } from './utils.js'
+import { isAdmin } from './utils.js'
 import services from '../services/index.js'
 
 export default {
@@ -12,9 +12,7 @@ export default {
      * @param {object} context - graphQL context.
      * @returns {import('./catalog.graphql').CatalogItem} list of catalog items.
      */
-    listCatalog: isAuthenticated((obj, args, { player }) =>
-      services.listCatalog(player)
-    )
+    listCatalog: (obj, args, { player }) => services.listCatalog(player)
   },
   Mutation: {
     /**

--- a/apps/server/tests/services/catalog.test.js
+++ b/apps/server/tests/services/catalog.test.js
@@ -17,6 +17,11 @@ describe('Catalog service', () => {
     {
       id: faker.datatype.uuid(),
       username: faker.name.findName()
+    },
+    {
+      id: faker.datatype.uuid(),
+      username: faker.name.findName(),
+      catalog: ['6-takes']
     }
   ]
 
@@ -63,7 +68,11 @@ describe('Catalog service', () => {
     })
 
     it(`omits restricted games`, async () => {
-      expect(await listCatalog(players[1])).toEqual([items[1], items[2]])
+      expect(await listCatalog(players[2])).toEqual(items.slice(0, 3))
+    })
+
+    it(`returns publicly-available games without player`, async () => {
+      expect(await listCatalog(null)).toEqual([items[1], items[2]])
     })
   })
 


### PR DESCRIPTION
### What's in there?

To prepare listing the public catalog, this PR relaxes the graphQL `listCatalog` to access it without a token, and with an invalid token.

### How to test?

With curl: 
- `curl https://localhost:3000/graphql -d '{ "query": "{ listCatalog { name } }" }' -k -H "Content-Type:application/json"`

- `curl https://localhost:3000/graphql -d '{ "query": "{ listCatalog { name } }" }' -k -H "Content-Type:application/json" --cookie "token=invalid"`

- `curl https://localhost:3000/graphql -d '{ "query": "{ listCatalog { name } }" }' -k -H "Content-Type:application/json" --cookie "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjE3ODkiLCJpYXQiOjE2NTcwOTA1MjF9.qMplJF32fngEYpd4-a2dmwGpPo9TqQOaGUxWRZlxcE4"`

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
