### PR TITLE
feat(server): adds a maximum number of seats to games

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,6 @@ Roadmap
 ## Server
 
 - per-player default camera position & configurable player position at game level
-- maximum number of players per game
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)
 - logging (warning on invalid descriptors)

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -11,6 +11,7 @@ type Game {
   cameras: [CameraPosition]
   hands: [Hand]
   rulesBookPageCount: Int
+  maxSeats: Int
   zoomSpec: ZoomSpec
   tableSpec: TableSpec
 }

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -267,18 +267,23 @@ export async function saveGame(game, playerId) {
  * - the inviting player does not own the game
  * - the guest is already part of the game players
  * - the guest id is invalid
+ * The operation will abort and throws when this game has no more availabe seats.
  * Updates game lists of all related players.
  * @async
  * @param {string} gameId - shared game id.
  * @param {string} guestId - invited player id.
  * @param {string} hostId - inviting player id.
  * @returns {Game|null} updated game, or null if the player can not be invited.
+ * @throws {Error} when there are no available seats
  */
 export async function invite(gameId, guestId, hostId) {
   const guest = await repositories.players.getById(guestId)
   let game = await loadGame(gameId, hostId)
   if (!game || !guest || game.playerIds.includes(guest.id)) {
     return null
+  }
+  if (game.maxSeats && game.playerIds.length >= game.maxSeats) {
+    throw new Error('no more available seats')
   }
   game.playerIds.push(guest.id)
   const descriptor = await repositories.catalogItems.getById(game.kind)

--- a/apps/server/tests/fixtures/games/splendor/index.js
+++ b/apps/server/tests/fixtures/games/splendor/index.js
@@ -8,4 +8,6 @@ export function build() {
 
 export const rulesBookPageCount = 4
 
+export const maxSeats = 4
+
 export const copyright = { authors: [{ name: 'Marc André' }] }

--- a/apps/server/tests/repositories/catalog-items.test.js
+++ b/apps/server/tests/repositories/catalog-items.test.js
@@ -21,6 +21,7 @@ describe('Catalog Items repository', () => {
     {
       name: 'splendor',
       rulesBookPageCount: 4,
+      maxSeats: 4,
       build: expect.any(Function),
       copyright: {
         authors: [{ name: 'Marc André' }]

--- a/apps/server/tests/services/catalog.test.js
+++ b/apps/server/tests/services/catalog.test.js
@@ -43,6 +43,7 @@ describe('Catalog service', () => {
     {
       name: 'splendor',
       rulesBookPageCount: 4,
+      maxSeats: 4,
       build: expect.any(Function),
       copyright: {
         authors: [{ name: 'Marc André' }]


### PR DESCRIPTION
### What's in there?

Before inviting anonymous players to a created game, we need a limit of seats to prevent crowds from joining.
This limitation is optional, and enforced on server side, when inviting a new player to an existing game.
This new field on Game is names `maxSeats` and is accessible in GraphQL.

Are included here:

- feat(server): adds a maximum number of seats to games

### How to test?

Through unit test for now, next PR will bring the UI counterpart of it.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
