### PR TITLE
feat(web): receive game updates from server (for new players)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@ Roadmap
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - click on stack size to select all
 - load player-specific default camera on load (and when joining)
+- collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players'hand
 - zoom in/out on rules
@@ -57,6 +58,7 @@ Roadmap
 
 ## Server
 
+- when game is altered on server side (a player is joining) push game-sync to all connected peers (replaces invite result)
 - per-player default camera position & configurable player position at game level
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)

--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,6 @@ Roadmap
 
 ## Server
 
-- when game is altered on server side (a player is joining) push game-sync to all connected peers (replaces invite result)
 - per-player default camera position & configurable player position at game level
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -333,4 +333,5 @@ extend type Mutation {
 
 extend type Subscription {
   listGames: [Game]
+  receiveGameUpdates(gameId: ID!): Game
 }

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -93,7 +93,6 @@ export function createEngine({
     })
 
   let isLoading = false
-  let gameSpecs = {}
 
   /**
    * @property {boolean} isLoading - true while the loading UI is visible.
@@ -116,7 +115,6 @@ export function createEngine({
     const game = removeNulls(gameData)
     cameraManager.adjustZoomLevels(game.zoomSpec)
     const handsEnabled = hasHandsEnabled(game)
-    gameSpecs = { zoomSpec: game.zoomSpec, tableSpec: game.tableSpec }
     if (initial) {
       isLoading = true
       engine.onLoadingObservable.notifyObservers(isLoading)
@@ -157,8 +155,7 @@ export function createEngine({
   engine.serialize = () => {
     return {
       meshes: serializeMeshes(scene),
-      handMeshes: serializeMeshes(handScene),
-      ...gameSpecs
+      handMeshes: serializeMeshes(handScene)
     }
   }
 

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -157,6 +157,12 @@ subscription listGames {
   }
 }
 
+subscription receiveGameUpdates($gameId: ID!) {
+  receiveGameUpdates(gameId: $gameId) {
+    ...fullGame
+  }
+}
+
 query loadGame($gameId: ID!) {
   loadGame(gameId: $gameId) {
     ...fullGame

--- a/apps/web/src/graphql/index.js
+++ b/apps/web/src/graphql/index.js
@@ -6,6 +6,7 @@ import {
   invite,
   listGames,
   loadGame,
+  receiveGameUpdates,
   saveGame
 } from './games.graphql'
 import {
@@ -29,6 +30,7 @@ export {
   loadGame,
   logIn,
   logOut,
+  receiveGameUpdates,
   saveGame,
   searchPlayers,
   sendSignal

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -117,24 +117,6 @@ describe('createEngine()', () => {
       })
     })
 
-    it('proxies zoom and table specs', async () => {
-      const zoomSpec = { min: 2, initial: 30 }
-      const tableSpec = { width: 100, height: 50 }
-      const foo = { bar: true }
-      await engine.load(
-        { meshes: [], hands: [], tableSpec, zoomSpec, foo },
-        playerId,
-        false
-      )
-      expect(engine.serialize()).toEqual({
-        meshes: [],
-        handMeshes: [],
-        zoomSpec,
-        tableSpec,
-        foo: undefined
-      })
-    })
-
     it('displays loading UI on initial load only', async () => {
       expect(receiveLoading).not.toHaveBeenCalled()
       const mesh = {

--- a/apps/web/tests/integration/game.spec.js
+++ b/apps/web/tests/integration/game.spec.js
@@ -25,7 +25,7 @@ describe('Game page', () => {
   }
 
   it('removes invite option after using the last seats', async ({ page }) => {
-    await mockGraphQL(page, {
+    const { sendToSubscription } = await mockGraphQL(page, {
       getCurrentPlayer: {
         token: faker.datatype.uuid(),
         player,
@@ -37,10 +37,17 @@ describe('Game page', () => {
       loadGame: game,
       saveGame: { id: game.id },
       searchPlayers: [[player2]],
-      invite: {
-        ...game,
-        availableSeats: 0,
-        players: [player, player2]
+      invite: () => {
+        sendToSubscription({
+          data: {
+            receiveGameUpdates: {
+              ...game,
+              availableSeats: 0,
+              players: [player, player2]
+            }
+          }
+        })
+        return game
       }
     })
 


### PR DESCRIPTION
### What's in there?

The previous implementation of game invites was not reliable: since the game data is altered on server side, all connected players (including the host) except the one who is inviting will not receive the game update.

The new implementation is simpler: when taking the host role, a player opens a graphQL subscription to receive updates from server. The invite mutation return is ignored, and the host awaits for the server update before sharing it with connected peers.
This allows propagating the same (and updated) view of the game data when a new players joins, regardless of who invited them.

Are included here:

- feat(server): introduces subscription for a game server updates
- feat(web): host loads game updates from player (allows any player to invite others)
- refactor(web): game engine does not proxy game data any more, since game manager does it. 

### How to test?

Open 3 different browsers/anonymous browsers: A, B and C. On a catalog item that allows has at least 3 seats, and visible changes when a player joins:
1. A creates a new game
2. A invites B
   > A receives a game update showing that B was invited.
4. B joins
5. B invites C
   > B receives a game update showing that C was invited.
   > A receives a game update showing that C was invited.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
