### PR TITLE
feat(web): implements per-player, configurable default camera positions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,6 @@ Roadmap
 - bug: attached, unselected, mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - click on stack size to select all
-- load player-specific default camera on load (and when joining)
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players'hand
@@ -58,7 +57,6 @@ Roadmap
 
 ## Server
 
-- per-player default camera position & configurable player position at game level
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)
 - logging (warning on invalid descriptors)

--- a/apps/games/assets/draughts/index.js
+++ b/apps/games/assets/draughts/index.js
@@ -1,4 +1,5 @@
 export * from './logic/build.js'
+export * from './logic/players.js'
 
 export const locales = {
   fr: {
@@ -22,4 +23,4 @@ export const tableSpec = {
   height: 100
 }
 
-export const zoomSpec = { initial: 40, min: 20 }
+export const zoomSpec = { min: 20 }

--- a/apps/games/assets/draughts/logic/constants.js
+++ b/apps/games/assets/draughts/logic/constants.js
@@ -24,3 +24,15 @@ export const faceUVs = {
     [0, 0, 0, 0]
   ]
 }
+
+export const cameraPositions = {
+  [blackId]: {
+    alpha: Math.PI / 2,
+    target: [0, 0, 2],
+    elevation: 37
+  },
+  [whiteId]: {
+    target: [0, 0, -2],
+    elevation: 37
+  }
+}

--- a/apps/games/assets/draughts/logic/players.js
+++ b/apps/games/assets/draughts/logic/players.js
@@ -1,0 +1,14 @@
+import { buildCameraPosition } from '@tabulous/server/src/utils/index.js'
+import { blackId, cameraPositions, whiteId } from './constants.js'
+
+export function addPlayer(game, player) {
+  const { cameras, playerIds } = game
+  const rank = playerIds.length
+  cameras.push(
+    buildCameraPosition({
+      playerId: player.id,
+      ...cameraPositions[rank === 1 ? whiteId : blackId]
+    })
+  )
+  return game
+}

--- a/apps/games/assets/klondike/index.js
+++ b/apps/games/assets/klondike/index.js
@@ -1,4 +1,5 @@
 export * from './logic/build.js'
+export * from './logic/players.js'
 
 export const locales = {
   fr: {

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -165,7 +165,6 @@ type Hand {
 type ZoomSpec {
   min: Float
   max: Float
-  initial: Float
   hand: Float
 }
 

--- a/apps/server/src/utils/games.js
+++ b/apps/server/src/utils/games.js
@@ -338,3 +338,52 @@ export function decrement(mesh) {
     return clone
   }
 }
+
+/**
+ * @typedef {object} CameraPosition a saved Arc rotate camera position
+ * @property {string} hash - hash for this position, to ease comparisons and change detections.
+ * @property {string} playerId - id of the player for who this camera position is relevant.
+ * @property {number} index - 0-based index for this saved position.
+ * @property {number[]} target - 3D cooordinates of the camera target, as per Babylon's specs.
+ * @property {number} alpha  - the longitudinal rotation, in radians.
+ * @property {number} beta - the longitudinal rotation, in radians.
+ * @property {number} elevation - the distance from the target (Babylon's radius).
+ * @see https://doc.babylonjs.com/divingDeeper/cameras/camera_introduction#arc-rotate-camera
+ */
+
+/**
+ * Builds a camera save for a given player, with default values:
+ * - alpha = PI * 3/2 (south)
+ * - beta = PI / 8 (slightly elevated from ground)
+ * - elevation = 35
+ * - target = [0,0,0] (the origin)
+ * - index = 0 (default camera position)
+ * It adds the hash.
+ * @param {Partial<CameraPosition>} cameraPosition - a partial camera position without hash.
+ * @returns {CameraPosition} the built camera position.
+ */
+export function buildCameraPosition({
+  playerId,
+  index = 0,
+  target = [0, 0, 0],
+  alpha = (3 * Math.PI) / 2,
+  beta = Math.PI / 8,
+  elevation = 35
+} = {}) {
+  if (!playerId) {
+    throw new Error('camera position requires playerId')
+  }
+  return addHash({
+    playerId,
+    index,
+    target,
+    alpha,
+    beta,
+    elevation
+  })
+}
+
+function addHash(camera) {
+  camera.hash = `${camera.target[0]}-${camera.target[1]}-${camera.target[2]}-${camera.alpha}-${camera.beta}-${camera.elevation}`
+  return camera
+}

--- a/apps/server/tests/utils/games.test.js
+++ b/apps/server/tests/utils/games.test.js
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import {
   createMeshes,
+  buildCameraPosition,
   decrement,
   drawInHand,
   findAnchor,
@@ -820,6 +821,51 @@ describe('decrement()', () => {
       quantifiable: { quantity: 1 }
     })
     expect(mesh).toEqual({ id: 'mesh1', foo, quantifiable: { quantity: 5 } })
+  })
+})
+
+describe('buildCameraPosition()', () => {
+  it('applies all defaults', () => {
+    const playerId = faker.datatype.uuid()
+    expect(buildCameraPosition({ playerId })).toEqual({
+      playerId,
+      index: 0,
+      target: [0, 0, 0],
+      alpha: (Math.PI * 3) / 2,
+      beta: Math.PI / 8,
+      elevation: 35,
+      hash: '0-0-0-4.71238898038469-0.39269908169872414-35'
+    })
+  })
+
+  it('throws on missing player id', () => {
+    expect(() => buildCameraPosition({})).toThrow(
+      'camera position requires playerId'
+    )
+  })
+
+  it('uses provided data and computes hash', () => {
+    const playerId = faker.datatype.uuid()
+    const index = faker.datatype.number()
+    const alpha = faker.datatype.number()
+    const beta = faker.datatype.number()
+    const elevation = faker.datatype.number()
+    const target = [
+      faker.datatype.number(),
+      faker.datatype.number(),
+      faker.datatype.number()
+    ]
+    expect(
+      buildCameraPosition({ playerId, index, alpha, beta, elevation, target })
+    ).toEqual({
+      playerId,
+      index,
+      target,
+      alpha,
+      beta,
+      elevation,
+      hash: `${target[0]}-${target[1]}-${target[2]}-${alpha}-${beta}-${elevation}`
+    })
   })
 })
 

--- a/apps/web/src/3d/managers/camera.js
+++ b/apps/web/src/3d/managers/camera.js
@@ -54,7 +54,7 @@ class CameraManager {
    * @param {import('@babylonjs/core').Scene} params.scene? - scene to host this card (default to last scene).
    */
   init({
-    y = 25,
+    y = 35,
     beta = Math.PI / 8,
     minY = 5,
     maxY = 70,
@@ -103,15 +103,13 @@ class CameraManager {
 
   /**
    * Adjust the main camera zoom range (when relevant), and the fixed hand zoom (when relevant).
-   * Also adjust default camera position when changing the initial zoom level.
    * @param {object} params - game data, including:
    * @param {number} params.min? - minimum zoom level allowed on the main scene.
    * @param {number} params.max? - maximum zoom level allowed on the main scene.
-   * @param {number} params.initial? - initial zoom level for the main scene.
    * @param {number} params.handZoom? - fixed zoom level for the hand scene.
    * @throws {Error} when called prior to initialization.
    */
-  adjustZoomLevels({ min, max, hand, initial } = {}) {
+  adjustZoomLevels({ min, max, hand } = {}) {
     const { camera, handSceneCamera } = this
     if (!camera) {
       throw new Error(
@@ -123,10 +121,6 @@ class CameraManager {
     }
     if (max) {
       camera.upperRadiusLimit = max
-    }
-    if (initial) {
-      camera.radius = initial
-      this.saves[0] = serialize(camera)
     }
     if (hand) {
       handSceneCamera.position.y = hand
@@ -223,11 +217,13 @@ class CameraManager {
 
   /**
    * Loads saved position and notifies observers.
+   * Restores the first position.
    * @param {CameraSave[]} saves - an array of save position.
    */
-  loadSaves(saves) {
+  async loadSaves(saves) {
     this.saves = saves
     this.onSaveObservable.notifyObservers([...this.saves])
+    await this.restore()
   }
 }
 

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -113,7 +113,6 @@ fragment fullGame on Game {
   zoomSpec {
     min
     max
-    initial
     hand
   }
   tableSpec {

--- a/apps/web/src/stores/game-manager.js
+++ b/apps/web/src/stores/game-manager.js
@@ -265,7 +265,7 @@ async function load(game, firstLoad) {
   if (game.messages) {
     loadThread(game.messages)
   }
-  if (cameras.length) {
+  if (cameras.length && firstLoad) {
     const playerCameras = cameras
       .filter(save => save.playerId === player.id)
       .sort((a, b) => a.index - b.index)

--- a/apps/web/tests/stores/game-manager.test.js
+++ b/apps/web/tests/stores/game-manager.test.js
@@ -315,9 +315,9 @@ describe('given a mocked game engine', () => {
           gameUpdates$.next(game)
           expect(engine.load).toHaveBeenCalledWith(game, player.id, false)
           expect(engine.load).toHaveBeenCalledTimes(1)
-          expect(loadCameraSaves).toHaveBeenCalledTimes(1)
           expect(loadThread).toHaveBeenCalledTimes(1)
           expect(connectWith).not.toHaveBeenCalled()
+          expect(loadCameraSaves).not.toHaveBeenCalled()
           await nextPromise()
           expect(send).toHaveBeenCalledWith(
             {


### PR DESCRIPTION
### What's in there?

While some games like dominoes do not need it, most games require players to have different view points. Draughts and chess are good examples, since opponents must face themselves.

This PR allows to configure the default camera position, when adding a player, in the game descriptors. It replaces the previous mechanism: `zoomSpec.initial` which only controlled the Arc rotate camera radius (elevation).

Are included here:

- feat(server)!: replaces zoomSpec with game utilities when adding player
- feat(web)!: loads per-player default camera position (replaces initial zoom spec) and changes default camera elevation
- feat(draughts): adds per-player camera default position
- feat(klondike): improves camera initial position

### How to test?

1. create a Draughts game
   > you start as whites
2. invite another player
3. connect with the invited player
   > they start as black, on the opposite "seat" position

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
