### PR TITLE
test(web): prints custom error messages in looped expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Tabulous
 
+[![Vercel](https://vercelbadge.vercel.app/api/feugy/tabulous)][production]
 [![GitHub](https://img.shields.io/github/license/feugy/tabulous)][license]
 [![CI](https://github.com/feugy/tabulous/actions/workflows/CI.yml/badge.svg)](https://github.com/feugy/atelier/tabulous/workflows/CI.yml)
 [![Codacy](https://app.codacy.com/project/badge/Grade/36bc5e1d473746f09656d1ffc8dec813)](https://www.codacy.com/gh/feugy/tabulous/dashboard?utm_source=github.com&utm_medium=referral&utm_content=feugy/tabulous&utm_campaign=Badge_Grade)
 
-Tabulous is virtual table-top game engine: [see it on tabulous.fr](https://tabulous.fr).
+Tabulous is virtual table-top game engine: [see it on tabulous.fr][production].
 
 Meet your friends online to play your favorite games!
 
@@ -49,4 +50,5 @@ All the magic happens during continuous integration/deployment:
 1. Continuous Integration workflow kicks in, running linter, formatter and tests
 1. If it succeeds, Continuous Deployment workflow starts, build the client and server applications, packaging and uploading them to the VPS, then restarting services.
 
+[production]: https://tabulous.fr
 [license]: https://github.com/feugy/tabulous/blob/main/LICENSE

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,6 @@ Roadmap
 - group candidate target per kind for performance
 - keep anchor ids
 - create Animation objects as part of runAnimation() (constant frameRate of 60)
-- custom message on jest expect (game-interaction)
 - jest matchers with mesh (toHaveBeenCalledWith, toHaveBeenNthCalledWith)
 - all manager managing a collection of behaviors should check their capabilities
 - game-manager is just a gigantic mess!!! no single responsibility, global state all over the place

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -339,9 +339,9 @@ describe('HandManager', () => {
       let x = -viewPortDimensions.width / 2 + cardWidth / 2 + horizontalPadding
       let y = 0.005
       const gap = -0.065692902
-      for (const { id } of cards) {
+      for (const [rank, { id }] of cards.entries()) {
         const mesh = handScene.getMeshById(id)
-        expectPosition(mesh, [x, y, z])
+        expectPosition(mesh, [x, y, z], `card #${rank}`)
         x += cardWidth + gap
         y += 0.01
       }

--- a/apps/web/tests/3d/managers/input.test.js
+++ b/apps/web/tests/3d/managers/input.test.js
@@ -1578,9 +1578,7 @@ describe('InputManager', () => {
   }
 
   function expectsDataWithMesh(actual, expected, meshId) {
-    for (const property in expected) {
-      expect(actual).toHaveProperty(property, expected[property])
-    }
+    expect(actual).toMatchObject(expected)
     if (Array.isArray(meshId)) {
       expect(actual.meshes?.map(({ id }) => id)).toEqual(meshId)
     } else {

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -282,11 +282,11 @@ function expectSelection(expectedMeshes) {
   expect([...manager.meshes].map(({ id }) => id)).toEqual(
     expectedMeshes.map(({ id }) => id)
   )
-  for (const mesh of expectedMeshes) {
-    expectSelected(mesh, true)
+  for (const [rank, mesh] of expectedMeshes.entries()) {
+    expectSelected(mesh, true, `mesh #${rank} selection status`)
   }
 }
 
-function expectSelected(mesh, isSelected = true) {
-  expect(mesh.renderOverlay).toBe(isSelected)
+function expectSelected(mesh, isSelected = true, message) {
+  expect(mesh.renderOverlay, message).toBe(isSelected)
 }

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -438,9 +438,15 @@ describe('Indicators store', () => {
       { screenPosition, id, ...otherProps }
     ] of expected.entries()) {
       const actual = visibleIndicators[rank]
-      expect(actual).toHaveProperty('id', id)
-      expect(actual).toEqual(expect.objectContaining(otherProps))
-      expectScreenPosition(actual.screenPosition, screenPosition)
+      expect(actual, `indicator #${rank}`).toHaveProperty('id', id)
+      expect(actual, `indicator #${rank}`).toEqual(
+        expect.objectContaining(otherProps)
+      )
+      expectScreenPosition(
+        actual.screenPosition,
+        screenPosition,
+        `indicator #${rank}`
+      )
     }
   }
 

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -22,7 +22,6 @@ import {
 import { configures3dTestEngine, sleep } from '../test-utils'
 
 jest.mock('../../src/3d/managers/camera')
-const debug = false
 
 describe('Game interaction model', () => {
   let engine
@@ -1456,11 +1455,9 @@ function expectMeshActions(mesh, ...actionNames) {
       name !== 'canIncrement'
     ) {
       if (actionNames.includes(name)) {
-        debug && console.log(`${name} expected on ${mesh.id}`)
-        expect(action).toHaveBeenCalled()
+        expect(action, `${name} on ${mesh.id}`).toHaveBeenCalled()
       } else {
-        debug && console.log(`${name} not expected on ${mesh.id}`)
-        expect(action).not.toHaveBeenCalled()
+        expect(action, `${name} on ${mesh.id}`).not.toHaveBeenCalled()
       }
     }
   }
@@ -1468,16 +1465,11 @@ function expectMeshActions(mesh, ...actionNames) {
 
 async function expectActionItems(menuProps, mesh, items) {
   expect(menuProps.items).toHaveLength(items.length)
-  for (const {
-    functionName,
-    icon,
-    title,
-    badge,
-    triggeredMesh,
-    calls,
-    ...props
-  } of items) {
-    expect(menuProps.items).toEqual(
+  for (const [
+    rank,
+    { functionName, icon, title, badge, triggeredMesh, calls, ...props }
+  ] of items.entries()) {
+    expect(menuProps.items, `for menu item #${rank}`).toEqual(
       expect.arrayContaining([
         {
           icon,
@@ -1490,14 +1482,15 @@ async function expectActionItems(menuProps, mesh, items) {
     )
     await menuProps.items.find(item => item.icon === icon).onClick()
     const checkedMesh = triggeredMesh ?? mesh
-    expect(checkedMesh.metadata[functionName]).toHaveBeenCalledTimes(
-      calls?.length ?? 1
-    )
+    expect(
+      checkedMesh.metadata[functionName],
+      `${functionName} metadata`
+    ).toHaveBeenCalledTimes(calls?.length ?? 1)
     for (const [rank, parameters] of (calls ?? []).entries()) {
-      expect(checkedMesh.metadata[functionName]).toHaveBeenNthCalledWith(
-        rank + 1,
-        ...parameters
-      )
+      expect(
+        checkedMesh.metadata[functionName],
+        `${functionName} metadata`
+      ).toHaveBeenNthCalledWith(rank + 1, ...parameters)
     }
     checkedMesh.metadata[functionName].mockReset()
   }


### PR DESCRIPTION
### :book: What's in there?

I've built a couple of custom test expectations utilities, which have loops.
While being handy during development, they may be confusing when troubleshooting issues, because of the lack of context.

This PR heavily inspires from [Playwright's expect flavour](https://github.com/microsoft/playwright/blob/main/packages/playwright-test/src/expect.ts) which augments Jest's `expect` with a custom error message.

### :test_tube: How to test?

By changing some tests and making them fail.
