### PR TITLE
feat(web): supports rules pan and zoom

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,6 @@ Roadmap
 
 ## UI
 
-- bug: delete confirmation message has the wrong term
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: ICE failed message when peer reload their browser??
 - bug: attached, unselected, mesh are not ignored during dragging
@@ -48,7 +47,6 @@ Roadmap
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players'hand
-- zoom in/out on rules
 - shortcuts cheatsheet
 - peer notifications: joining, joined, left, error (stop waiting when navigating away)
 - hand support for quantifiable behavior

--- a/apps/web/src/components/MinimizableSection.svelte
+++ b/apps/web/src/components/MinimizableSection.svelte
@@ -142,7 +142,7 @@
 
 <style lang="postcss">
   section {
-    @apply relative flex items-stretch justify-items-stretch h-full z-10 min-w-min max-w-full;
+    @apply relative flex items-stretch justify-items-stretch h-full z-10 min-w-50 max-w-full;
 
     &:not(.vertical).minimized {
       @apply min-w-0 !w-0;

--- a/apps/web/src/components/RuleViewer.svelte
+++ b/apps/web/src/components/RuleViewer.svelte
@@ -7,12 +7,70 @@
   export let page = 0
   export let lastPage = 0
   export let game = ''
+  export let maxZoom = 1.5
+  export let minZoom = 0.3
 
   const dispatch = createEventDispatcher()
+  let dimension = { width: 0, height: 0 }
+  let zoom = 1
+  let pos = null
+  let container = null
+  let image = null
 
   function handleNavigate(previous = false) {
     page += previous ? -1 : 1
     dispatch('change', { page })
+  }
+
+  function handleImageLoaded({ target }) {
+    container.scrollTop = 0
+    container.scrollLeft = 0
+    setImageZoom(null)
+    const { width, height } = target.getBoundingClientRect()
+    dimension = { width, height }
+    setImageZoom(zoom)
+  }
+
+  function handleDragStart({ clientX, clientY }) {
+    pos = {
+      left: container.scrollLeft,
+      top: container.scrollTop,
+      x: clientX,
+      y: clientY
+    }
+    window.addEventListener('pointermove', handleDrag)
+    window.addEventListener('pointerup', handleDragStop)
+  }
+
+  function handleDrag({ clientX, clientY }) {
+    if (!pos) {
+      return
+    }
+    container.scrollTop = pos.top - (clientY - pos.y)
+    container.scrollLeft = pos.left - (clientX - pos.x)
+  }
+
+  function handleDragStop() {
+    if (!pos) {
+      return
+    }
+    pos = null
+    window.removeEventListener('pointermove', handleDrag)
+    window.removeEventListener('pointerup', handleDragStop)
+  }
+
+  function handleZoom({ deltaY }) {
+    zoom = capZoom(zoom + (deltaY < 0 ? 0.1 : -0.1))
+    setImageZoom(zoom)
+  }
+
+  function capZoom(zoom) {
+    return zoom < minZoom ? minZoom : zoom > maxZoom ? maxZoom : zoom
+  }
+
+  function setImageZoom(zoom) {
+    image.style.width = zoom ? `${dimension.width * zoom}px` : ''
+    image.style.height = zoom ? `${dimension.height * zoom}px` : ''
   }
 </script>
 
@@ -30,11 +88,18 @@
       on:click={() => handleNavigate()}
     />
   </menu>
-  <div class="image-container">
+  <div
+    class="image-container"
+    bind:this={container}
+    on:pointerdown={handleDragStart}
+    on:wheel|preventDefault={handleZoom}
+  >
     {#if game}
       <img
+        bind:this={image}
         alt={$_('tooltips.rule-page', { page: page + 1 })}
         src={`${gameAssetsUrl}/${game}/rules/${page + 1}.webp`}
+        on:load={handleImageLoaded}
       />
     {/if}
   </div>
@@ -42,13 +107,14 @@
 
 <style lang="postcss">
   section {
-    @apply flex flex-col flex-1 max-h-full max-w-full items-center gap-2 p-2;
+    @apply flex flex-col flex-1 max-h-full max-w-full items-center gap-2 p-2 select-none;
   }
   .image-container {
-    @apply max-h-full overflow-hidden text-center;
+    @apply flex-1 w-full overflow-auto text-center;
+    cursor: grab;
   }
   img {
-    @apply inline-block max-h-full;
+    @apply inline-block max-h-none max-w-none pointer-events-none;
   }
   menu {
     @apply flex gap-2 m-0 p-0 items-center;

--- a/apps/web/tests/components/RuleViewer.test.js
+++ b/apps/web/tests/components/RuleViewer.test.js
@@ -104,4 +104,98 @@ describe('RuleViewer component', () => {
     )
     expect(handleChange).toHaveBeenCalledTimes(2)
   })
+
+  it('pans the imagee', async () => {
+    renderComponent({ lastPage: 2 })
+    const image = screen.queryByRole('img')
+    image.getBoundingClientRect = () => ({ width: 300, height: 500 })
+    fireEvent.load(image)
+    const container = image.parentElement
+    expect(container.scrollTop).toBe(0)
+    expect(container.scrollLeft).toBe(0)
+    const downEvent = new Event('pointerdown')
+    Object.assign(downEvent, { clientX: 100, clientY: 100 })
+    fireEvent(container, downEvent)
+    const moveEvent = new Event('pointermove')
+    Object.assign(moveEvent, { clientX: 50, clientY: 75 })
+    fireEvent(window, moveEvent)
+    fireEvent.pointerUp(image)
+    expect(container.scrollTop).toBe(25)
+    expect(container.scrollLeft).toBe(50)
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('zooms the image in', async () => {
+    renderComponent({ lastPage: 2 })
+    const image = screen.queryByRole('img')
+    const width = 300
+    const height = 500
+    image.getBoundingClientRect = () => ({ width, height })
+    fireEvent.load(image)
+    expect(image).toHaveStyle({
+      width: `${width}px`,
+      height: `${height}px`
+    })
+    fireEvent.wheel(image.parentElement, { deltaY: 1 })
+    expect(image).toHaveStyle({
+      width: `${width * 0.9}px`,
+      height: `${height * 0.9}px`
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('zooms the image out', async () => {
+    renderComponent({ lastPage: 2 })
+    const image = screen.queryByRole('img')
+    const width = 300
+    const height = 500
+    image.getBoundingClientRect = () => ({ width, height })
+    fireEvent.load(image)
+    expect(image).toHaveStyle({
+      width: `${width}px`,
+      height: `${height}px`
+    })
+    fireEvent.wheel(image.parentElement, { deltaY: -5 })
+    expect(image).toHaveStyle({
+      width: `${width * 1.1}px`,
+      height: `${height * 1.1}px`
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('can not zoom the image to far', async () => {
+    const minZoom = 0.5
+    renderComponent({ minZoom })
+    const image = screen.queryByRole('img')
+    const width = 300
+    const height = 500
+    image.getBoundingClientRect = () => ({ width, height })
+    fireEvent.load(image)
+    for (let i = 0; i < 20; i++) {
+      fireEvent.wheel(image.parentElement, { deltaY: 1 })
+    }
+    expect(image).toHaveStyle({
+      width: `${width * minZoom}px`,
+      height: `${height * minZoom}px`
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('can not zoom the image to close', async () => {
+    const maxZoom = 1.6
+    renderComponent({ maxZoom })
+    const image = screen.queryByRole('img')
+    const width = 300
+    const height = 500
+    image.getBoundingClientRect = () => ({ width, height })
+    fireEvent.load(image)
+    for (let i = 0; i < 20; i++) {
+      fireEvent.wheel(image.parentElement, { deltaY: -1 })
+    }
+    expect(image).toHaveStyle({
+      width: `${width * maxZoom}px`,
+      height: `${height * maxZoom}px`
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/tests/components/RuleViewer.tools.svelte
+++ b/apps/web/tests/components/RuleViewer.tools.svelte
@@ -10,16 +10,25 @@
     props={{ game: 'splendor', lastPage: 3 }}
     events={['change']}
     layout="centered"
-  />
+    let:props
+    let:handleEvent
+  >
+    <RuleViewer {...props} on:change={handleEvent} />
+  </Tool>
 </div>
 
 <style lang="postcss">
   .rule-viewer {
-    @apply flex h-full overflow-auto;
-    max-width: 100vh;
+    @apply flex overflow-hidden;
+    width: 50vw;
+    height: 100vh;
 
     :global(& .tool-preview) {
-      @apply overflow-auto p-2;
+      @apply p-2;
+    }
+
+    :global(& .tool) {
+      @apply w-full;
     }
   }
 </style>

--- a/apps/web/tests/components/__snapshots__/RuleViewer.tools.shot
+++ b/apps/web/tests/components/__snapshots__/RuleViewer.tools.shot
@@ -1,46 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toolshot components/RuleViewer.tools.svelte: Components/Rule Viewer 1`] = `
-<span>
-  <section>
-    <menu>
-      <button
-        disabled=""
-      >
-        <span
-          class="material-icons"
-        >
-          navigate_before
-        </span>
-        
-        
-        
-      </button>
-       
-      1
-      /
-      4
-       
-      <button>
-        <span
-          class="material-icons"
-        >
-          navigate_next
-        </span>
-        
-        
-        
-      </button>
-    </menu>
-     
-    <div
-      class="image-container"
+<section>
+  <menu>
+    <button
+      disabled=""
     >
-      <img
-        alt="Livre de règles, page 1"
-        src="http://localhost:3001/games/splendor/rules/1.webp"
-      />
-    </div>
-  </section>
-</span>
+      <span
+        class="material-icons"
+      >
+        navigate_before
+      </span>
+      
+      
+      
+    </button>
+     
+    1
+    /
+    4
+     
+    <button>
+      <span
+        class="material-icons"
+      >
+        navigate_next
+      </span>
+      
+      
+      
+    </button>
+  </menu>
+   
+  <div
+    class="image-container"
+  >
+    <img
+      alt="Livre de règles, page 1"
+      src="http://localhost:3001/games/splendor/rules/1.webp"
+    />
+  </div>
+</section>
 `;


### PR DESCRIPTION
### :book: What's in there?

Rules book could be quite large, and image scans not always the best quality.
This PRs adds the ability to pan (drag'n drop) and zoom (mouse wheel) into the rule viewer.

### :test_tube: How to test?

1. creates a new Draught game: https://tabulous-git-feat-rules-viewer-zoom-feugy.vercel.app/game/new?name=draughts
2. opens the rules pane
3. zoom in and out, drag and drop the image
   > the image should zoom and pan
4. navigate to the next or previous rule image
   > pans reset to origin, but zoom remains

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
