### PR TITLE
feat(web,server)!: loads home page data on both sides

### DIFF
--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -27,6 +27,18 @@ export default {
 
   Query: {
     /**
+     * Returns the list of current games.
+     * Requires valid authentication.
+     * @param {object} obj - graphQL object.
+     * @param {object} args - subscription arguments.
+     * @param {object} context - graphQL context.
+     * @returns {import('../services/games').Game[]} list of current games.
+     */
+    listGames: isAuthenticated(async (obj, args, { player }) =>
+      services.listGames(player.id)
+    ),
+
+    /**
      * Returns details for a current player's game.
      * Requires valid authentication.
      * @async
@@ -102,29 +114,26 @@ export default {
 
   Subscription: {
     /**
-     * Sends the full list of games to a given player when they change.
-     * The list is immediately sent on subscription.
+     * Sends the full list of current games to a given player when they change.
      * Requires valid authentication.
      * @param {object} obj - graphQL object.
      * @param {object} args - subscription arguments.
      * @param {object} context - graphQL context.
      */
-    listGames: {
+    receiveGameListUpdates: {
       subscribe: isAuthenticated(async (obj, args, { player, pubsub }) => {
         const topic = `listGames-${player.id}`
         const subscription = services.gameListsUpdate
           .pipe(filter(({ playerId }) => playerId === player.id))
           .subscribe(({ games }) =>
-            pubsub.publish({ topic, payload: { listGames: games } })
+            pubsub.publish({
+              topic,
+              payload: { receiveGameListUpdates: games }
+            })
           )
 
         const queue = await pubsub.subscribe(topic)
         queue.once('close', () => subscription.unsubscribe())
-        services
-          .listGames(player.id)
-          .then(games =>
-            pubsub.publish({ topic, payload: { listGames: games } })
-          )
         return queue
       })
     },

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -320,6 +320,7 @@ input HandInput {
 }
 
 extend type Query {
+  listGames: [Game]
   loadGame(gameId: ID!): Game
 }
 
@@ -331,6 +332,6 @@ extend type Mutation {
 }
 
 extend type Subscription {
-  listGames: [Game]
+  receiveGameListUpdates: [Game]
   receiveGameUpdates(gameId: ID!): Game
 }

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -122,6 +122,20 @@ fragment fullGame on Game {
   }
 }
 
+fragment currentGame on Game {
+  id
+  created
+  kind
+  players {
+    ...lightPlayer
+  }
+  locales {
+    fr {
+      title
+    }
+  }
+}
+
 mutation createGame($kind: String!) {
   createGame(kind: $kind) {
     id
@@ -140,19 +154,15 @@ mutation invite($gameId: ID!, $playerId: ID!) {
   }
 }
 
-subscription listGames {
+query listGames {
   listGames {
-    id
-    created
-    kind
-    players {
-      ...lightPlayer
-    }
-    locales {
-      fr {
-        title
-      }
-    }
+    ...currentGame
+  }
+}
+
+subscription receiveGameListUpdates {
+  receiveGameListUpdates {
+    ...currentGame
   }
 }
 

--- a/apps/web/src/graphql/index.js
+++ b/apps/web/src/graphql/index.js
@@ -6,6 +6,7 @@ import {
   invite,
   listGames,
   loadGame,
+  receiveGameListUpdates,
   receiveGameUpdates,
   saveGame
 } from './games.graphql'
@@ -24,6 +25,7 @@ export {
   listGames,
   loadGame,
   logIn,
+  receiveGameListUpdates,
   receiveGameUpdates,
   saveGame,
   searchPlayers,

--- a/apps/web/src/routes/+layout.js
+++ b/apps/web/src/routes/+layout.js
@@ -1,0 +1,14 @@
+import { browser } from '$app/env'
+import { initGraphQlClient } from '../stores'
+import { graphQlUrl } from '../utils'
+
+/** @type {import('./$types').LayoutLoad} */
+export function load({ data }) {
+  initGraphQlClient({
+    graphQlUrl,
+    fetch,
+    bearer: data.bearer,
+    subscriptionSupport: browser
+  })
+  return data
+}

--- a/apps/web/src/routes/+layout.server.js
+++ b/apps/web/src/routes/+layout.server.js
@@ -1,4 +1,5 @@
-/** @type {import('./$types').LayoutServerData} */
-export function load({ locals: { bearer = null, session = null } }) {
+/** @type {import('./$types').LayoutServerLoad} */
+export function load({ locals }) {
+  const { bearer = null, session = null } = locals
   return { bearer, session }
 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,18 +1,5 @@
 <script>
-  import { browser } from '$app/env'
   import '../common'
-  import { initGraphQlClient } from '../stores'
-  import { graphQlUrl } from '../utils'
-
-  /** @type {import('./$types').LayoutData} */
-  export let data
-
-  initGraphQlClient({
-    graphQlUrl,
-    fetch,
-    bearer: data.bearer,
-    subscriptionSupport: browser
-  })
 </script>
 
 <slot />

--- a/apps/web/src/routes/home/+page.js
+++ b/apps/web/src/routes/home/+page.js
@@ -1,0 +1,11 @@
+import { listCatalog, listGames } from '../../stores'
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ parent }) {
+  const data = await parent()
+  const [catalog, currentGames] = await Promise.all([
+    listCatalog(),
+    data.session?.player ? listGames() : Promise.resolve(null)
+  ])
+  return { catalog, currentGames }
+}

--- a/apps/web/src/stores/catalog.js
+++ b/apps/web/src/stores/catalog.js
@@ -11,8 +11,7 @@ const logger = makeLogger('players')
 
 /**
  * List all catalog items.
- * @async
- * @returns {CatalogItem[]} a list of catalog items.
+ * @returns {Promise<CatalogItem[]>} a list of catalog items.
  */
 export async function listCatalog() {
   logger.info('list catalog')

--- a/apps/web/tests/integration/home.spec.js
+++ b/apps/web/tests/integration/home.spec.js
@@ -71,8 +71,9 @@ describe('Home page', () => {
         credentials: faker.internet.password()
       }
     }
-    const { onSubscription, sendToSubscription } = await mockGraphQl(page, {
+    await mockGraphQl(page, {
       listCatalog: [publicCatalog, publicCatalog, catalog],
+      listGames: [games],
       getCurrentPlayer: authentication,
       logIn: authentication
     })
@@ -90,7 +91,6 @@ describe('Home page', () => {
     const loginPage = new LoginPage(page)
     await loginPage.getStarted()
     await loginPage.logInWithPassword({ username: player.username, password })
-    onSubscription(() => sendToSubscription({ data: { listGames: games } }))
 
     await homePage.isAuthenticated(player.username)
     await expect(homePage.catalogItemHeadings).toHaveText(
@@ -104,19 +104,18 @@ describe('Home page', () => {
   it('displays private catalog and games when already authenticated', async ({
     page
   }) => {
-    const { onSubscription, sendToSubscription, setTokenCookie } =
-      await mockGraphQl(page, {
-        listCatalog: [catalog],
-        getCurrentPlayer: {
-          token: faker.datatype.uuid(),
-          player,
-          turnCredentials: {
-            username: 'bob',
-            credentials: faker.internet.password()
-          }
+    const { setTokenCookie } = await mockGraphQl(page, {
+      listCatalog: [catalog],
+      listGames: [games],
+      getCurrentPlayer: {
+        token: faker.datatype.uuid(),
+        player,
+        turnCredentials: {
+          username: 'bob',
+          credentials: faker.internet.password()
         }
-      })
-    onSubscription(() => sendToSubscription({ data: { listGames: games } }))
+      }
+    })
     await setTokenCookie()
 
     const homePage = new HomePage(page)
@@ -131,10 +130,45 @@ describe('Home page', () => {
     )
   })
 
+  it('updates current games on received update', async ({ page }) => {
+    const initialGames = games.slice(0, 1)
+    const { setTokenCookie, sendToSubscription } = await mockGraphQl(page, {
+      listCatalog: [publicCatalog, publicCatalog, catalog],
+      listGames: [initialGames],
+      getCurrentPlayer: {
+        token: faker.datatype.uuid(),
+        player,
+        turnCredentials: {
+          username: 'bob',
+          credentials: faker.internet.password()
+        }
+      }
+    })
+    await setTokenCookie()
+
+    const homePage = new HomePage(page)
+    await homePage.goTo()
+    await homePage.goTo()
+    await homePage.getStarted()
+    await homePage.isAuthenticated(player.username)
+    await expect(homePage.catalogItemHeadings).toHaveText(
+      catalog.map(({ locales }) => new RegExp(locales.fr.title))
+    )
+    await expect(homePage.games).toHaveText(
+      initialGames.map(({ locales }) => new RegExp(locales.fr.title))
+    )
+
+    sendToSubscription({ data: { receiveGameListUpdates: games } })
+    await expect(homePage.games).toHaveText(
+      games.map(({ locales }) => new RegExp(locales.fr.title))
+    )
+  })
+
   it('displays public catalog after log out', async ({ page }) => {
     const { onSubscription, sendToSubscription, setTokenCookie } =
       await mockGraphQl(page, {
         listCatalog: [catalog, publicCatalog],
+        listGames: [games],
         getCurrentPlayer: {
           token: faker.datatype.uuid(),
           player,
@@ -154,6 +188,7 @@ describe('Home page', () => {
     await new Promise(resolve => setTimeout(resolve, 500)) // TODO remove
 
     await homePage.logOut()
+    await homePage.isAnonymous()
     await expect(homePage.catalogItemHeadings).toHaveText(
       publicCatalog.map(({ locales }) => new RegExp(locales.fr.title))
     )
@@ -164,6 +199,8 @@ describe('Home page', () => {
     const { onQuery, onSubscription, sendToSubscription, setTokenCookie } =
       await mockGraphQl(page, {
         listCatalog: [catalog],
+        listGames: [games],
+        deleteGame: null,
         getCurrentPlayer: {
           token: faker.datatype.uuid(),
           player,

--- a/apps/web/tests/integration/pages/home.js
+++ b/apps/web/tests/integration/pages/home.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { expect } from '@playwright/test'
+import { sleep } from '../../../src/utils/time.js'
 import { translate } from '../utils/index.js'
 
 export class HomePage {
@@ -112,6 +113,7 @@ export class HomePage {
    * Navigates to login by clicking on the header button
    */
   async goToLogin() {
+    await sleep(500)
     await this.loginButton.click()
     await this.page.waitForLoadState()
     await expect(this.page).toHaveURL('/login')
@@ -142,6 +144,7 @@ export class HomePage {
       game,
       `no game link with title "${title}" and rank #${rank} found`
     ).toBeDefined()
+    await sleep(500)
     await game.locator('role=button >> text=delete').click()
     await expect(this.deleteGameDialogue).toBeVisible()
   }

--- a/apps/web/tests/integration/utils/server.js
+++ b/apps/web/tests/integration/utils/server.js
@@ -59,7 +59,7 @@ export async function mockGraphQl(page, mocks) {
         ...args
       )
     const logError = (reqId, ...args) =>
-      console.log(chalk`{red.bold red mock-server [${reqId}]} -`, ...args)
+      console.log(chalk`{red.bold mock-server [${reqId}]} -`, ...args)
 
     server = fastify()
     server.register(cors, {

--- a/apps/web/tests/routes/home/+page.test.js
+++ b/apps/web/tests/routes/home/+page.test.js
@@ -1,18 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/svelte'
 import html from 'svelte-htm'
+import { load } from '../../../src/routes/home/+page'
 import HomePage from '../../../src/routes/home/+page.svelte'
-import { runQuery } from '../../../src/stores/graphql-client'
+import { listGames, listCatalog } from '../../../src/stores'
 
-jest.mock('../../../src/stores/graphql-client', () => {
-  const { jest } = require('@jest/globals')
-  const { BehaviorSubject } = require('rxjs')
-  const sub = new BehaviorSubject([])
-  return {
-    initGraphQlClient: jest.fn(),
-    runQuery: jest.fn(),
-    runSubscription: jest.fn().mockReturnValue(sub)
-  }
-})
+jest.mock('../../../src/stores', () => ({
+  receiveGameListUpdates: jest.fn(),
+  listCatalog: jest.fn(),
+  listGames: jest.fn()
+}))
 
 describe('/home route', () => {
   const games = [
@@ -37,8 +33,9 @@ describe('/home route', () => {
   ]
 
   it('displays anonymous catalog', async () => {
-    runQuery.mockResolvedValue(games.slice(0, 2))
-    const { container } = render(html`<${HomePage} data=${{}} />`)
+    const { container } = render(
+      html`<${HomePage} data=${{ catalog: games.slice(0, 2) }} />`
+    )
     await waitFor(() =>
       expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     )
@@ -46,14 +43,56 @@ describe('/home route', () => {
   })
 
   it('displays connected catalog', async () => {
-    runQuery.mockResolvedValueOnce(games)
     const player = { username: 'John Doo' }
     const { container } = render(
-      html`<${HomePage} data=${{ session: { player } }} />`
+      html`<${HomePage}
+        data=${{
+          session: { player },
+          catalog: games,
+          currentGames: [
+            {
+              name: '32-cards',
+              locales: { fr: { title: 'Jeu de 32 cartes' } },
+              players: [],
+              created: Date.parse('2022-07-15 10:15:00')
+            }
+          ]
+        }}
+      />`
     )
     await waitFor(() =>
       expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     )
     expect(container).toMatchSnapshot()
+  })
+})
+
+describe('/home reoute loader', () => {
+  beforeEach(jest.clearAllMocks)
+
+  it('loads catalog only for anonymous user', async () => {
+    const parent = async () => ({ session: null })
+    const catalog = [{ id: 'game-1' }, { id: 'game-2' }]
+    listCatalog.mockResolvedValueOnce(catalog)
+    expect(await load({ parent })).toEqual({
+      catalog,
+      currentGames: null
+    })
+    expect(listCatalog).toHaveBeenCalledTimes(1)
+    expect(listGames).not.toHaveBeenCalled()
+  })
+
+  it('loads catalog and current games for authenticated user', async () => {
+    const parent = async () => ({ session: { player: { name: 'dude' } } })
+    const catalog = [{ id: 'game-1' }, { id: 'game-2' }]
+    const currentGames = [{ id: 'game-3' }]
+    listCatalog.mockResolvedValueOnce(catalog)
+    listGames.mockResolvedValueOnce(currentGames)
+    expect(await load({ parent })).toEqual({
+      catalog,
+      currentGames
+    })
+    expect(listCatalog).toHaveBeenCalledTimes(1)
+    expect(listGames).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/routes/home/__snapshots__/+page.test.js.snap
+++ b/apps/web/tests/routes/home/__snapshots__/+page.test.js.snap
@@ -197,7 +197,6 @@ exports[`/home route displays anonymous catalog 1`] = `
               </caption>
             </div>
           </article>
-          
         </section>
       </div>
     </main>
@@ -243,11 +242,41 @@ exports[`/home route displays connected catalog 1`] = `
         <section
           aria-roledescription="games"
         >
-          <span
-            class="no-games"
-          >
-            Rien pour l'instant ! Choisissez un jeu disponible.
-          </span>
+          
+          <article>
+            <span
+              class="title"
+            >
+              <h3>
+                Jeu de 32 cartes
+              </h3>
+               
+              <button
+                class="secondary"
+              >
+                <span
+                  class="material-icons"
+                >
+                  delete
+                </span>
+                
+                
+                
+              </button>
+            </span>
+             
+            <span
+              class="created"
+            >
+              15 juil., 10:15
+            </span>
+             
+            <span
+              class="players"
+            >
+              avec 
+            </span>
+          </article>
         </section>
          
         <h2>
@@ -495,7 +524,6 @@ exports[`/home route displays connected catalog 1`] = `
               </caption>
             </div>
           </article>
-          
         </section>
       </div>
     </main>


### PR DESCRIPTION
### :book: What's in there?

Sveltekit's marvelous [load](https://kit.svelte.dev/docs/load) mechanism allows to load a page's data on server side while serving the page (or generating it), and on client side during client navigation.

The PR refactors the home page to list the catalog (public or private) and the list of current games (for authenticated users only) on both sides, and pass it as a property to the page.

Are included here:

- feat(web))!: lists home current games and catalog on both sides
- feat(server)\!: splits GraphQL listGames into a query and a subscription

### :test_tube: How to test?

**This can not be tested on the preview environment, as it requires re-deploying the server.**
1. start the app locally `npm run start` (root folder).
2. (optional if already logged out) in the opened browser, click on the logout button
3. hard reload the home page
   > the public catalog almost immediately displays (with a flash of unstyled content)
4. click on the login button
5. provides valid credentials
   > when redirected to the home page, the private catalog and current games almost immediately display (with a flash of unstyled content)
6. hard reload the home page
   > the private catalog and current games almost immediately display (with a flash of unstyled content)
7. click on the logout button
   > the public catalog almost immediately displays (with a flash of unstyled content), and the current game list is gone.

### :up: Notes to reviewers

This needed a breaking change on the GraphQL API: we need a query to list current games. It was a subscription previously that was immediately sending values upon subscription.
The query part was extracted (`query listGames()`), and the subscription remains with a different name (`subscription receiveGameListUpdates()`).
