### PR TITLE
fix(cli): can not pass username option before command name

### DIFF
--- a/apps/cli/src/index.mjs
+++ b/apps/cli/src/index.mjs
@@ -40,11 +40,8 @@ function printProductionMessage({ production }) {
 }
 
 function findCommand(args) {
-  return (
-    Object.entries(commands).find(([name]) =>
-      camelCase(args.command).includes(name)
-    ) ?? []
-  )
+  const command = args.command.map(arg => camelCase(arg))
+  return Object.entries(commands).find(([name]) => command.includes(name)) ?? []
 }
 
 async function invokeCommand(command, argv, name) {

--- a/apps/cli/tests/index.test.js
+++ b/apps/cli/tests/index.test.js
@@ -5,15 +5,19 @@ import { mockConsole } from './test-util.js'
 
 const mockCatalog = jest.fn()
 const mockAddPlayer = jest.fn()
+const mockGrant = jest.fn()
 
 jest.unstable_mockModule('../src/commands/catalog.js', () => ({
   default: mockCatalog,
   catalog: jest.fn()
 }))
-
 jest.unstable_mockModule('../src/commands/add-player.js', () => ({
   default: mockAddPlayer,
   addPlayer: jest.fn()
+}))
+jest.unstable_mockModule('../src/commands/grant.js', () => ({
+  default: mockGrant,
+  grant: jest.fn()
 }))
 
 describe('Tabulous CLI', () => {
@@ -71,5 +75,15 @@ describe('Tabulous CLI', () => {
     mockAddPlayer.mockResolvedValue(result)
     await cli(['add-player'])
     expect(output.stdout).toContain(inspect(result))
+  })
+
+  it('handles specific and general options', async () => {
+    const result = { foo: 'bar' }
+    const username = 'user'
+    const game = 'game'
+    mockGrant.mockResolvedValue(result)
+    await cli(['-p', '-u', username, 'grant', game])
+    expect(output.stdout).toContain(inspect(result))
+    expect(mockGrant).toHaveBeenCalledWith(['-p', '-u', username, game])
   })
 })


### PR DESCRIPTION
### :book: What's in there?

Option ordering in CLI is too fragile:
- works: `tabulous -p grant 6-takes -u someone`
- does not work: ` tabulous -p -u someone grant 6-takes`

### :test_tube: How to test?

Run any command which require specific arguments, like username

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
