### PR TITLE
fix(cd): deployment upload takes too long

### DIFF
--- a/hosting/build.sh
+++ b/hosting/build.sh
@@ -14,13 +14,14 @@ cp hosting/tabulous.systemd dist/
 cp .nvmrc dist/
 
 # build server
-rm -rf node_modules
+rm -rf node_modules apps/*/node_modules
 pnpm --filter server --prod deploy dist/server
 cd dist/server
-tar --create -h --file ../server.tar.gz -z node_modules/ src/ package.json 
+tar --create --file ../server.tar.gz -z node_modules/ src/ package.json 
 cd ../..
+rm -rd dist/server
 
 # build games
 cd apps/games
-tar --create -h --file ../../dist/games.tar.gz -z *
+tar --create --file ../../dist/games.tar.gz -z *
 cd ../..


### PR DESCRIPTION
### :book: What's in there?

Server deployment [upload](https://github.com/feugy/tabulous/actions/runs/3138425683/jobs/5097739419) takes too long.
That was because it was uploading the archives AND their unzipped content.

- fix(cd): deployment upload takes too long

### :test_tube: How to test?

Only by deploying main.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
