### PR TITLE
fix(web): stabilizes multiplayer videos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,7 @@ Roadmap
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected, mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
+- hide non-connected participants
 - is this right? given an active selection, when it anchrs with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
@@ -44,6 +45,7 @@ Roadmap
 
 ## Server
 
+- bug: timezone used for Serverside rendering is wrong
 - database
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)
@@ -225,7 +227,7 @@ Removing server to only allow peer communication is really hard:
 I started with SSE to push game invites to players, and Websocket to keep the signaling server independant from the app logic, but it's too many sockets for the same user.
 GraphQL subscriptions over WS are perfect to implement both usecases.
 
-Enabling tree shaking in Babylon.js is [cumbersom](https://doc.babylonjs.com/divingDeeper/developWithBjs/treeShaking), but really effective:
+Enabling tree shaking in Babylon.js is [cumbersome](https://doc.babylonjs.com/divingDeeper/developWithBjs/treeShaking), but really effective:
 Final code went from 1417 modules to 674 (53% less) and the vendor.js file from 3782.23kb to 1389.03 (63% less).
 
 Running game with Babylon's debug panel kills `setTimeout()`. Something under the hood must monkey patch it.
@@ -293,6 +295,9 @@ Nice sources for 3D textures:
 Run playwright in debug mode, on a given file: `PWDEBUG=1 pnpm --filter web test:integration:run -- home.spec`
 
 WebRTC recent (2021) changes now allows [perfect negociation](https://w3c.github.io/webrtc-pc/#perfect-negotiation-example), which highly simplifies.
+Thus, connecting RTCDataChanel and RTCPeerConnection may happen in random order. One must wait for both event and then consider connection to be established.
+One must not acquire Media stream in parallel, because it actually holds different copies of the stream, which must be released independently.
+It is simpler to acquire once, and return the same result to all "parallel" requesters.
 
 `enumerateDevice` has a limitation: when user never allowed it yet, it's returning empty labels.
 There's no good way to solve it, and it's an [ongoing discussion](https://github.com/w3c/mediacapture-main/issues/874)

--- a/apps/web/tests/stores/stream.test.js
+++ b/apps/web/tests/stores/stream.test.js
@@ -191,6 +191,17 @@ describe('Media Stream store', () => {
       expect(localStreamChangeReceived).not.toHaveBeenCalled()
     })
 
+    it('returns the same stream to all "parallel" acquisition requests', async () => {
+      navigator.mediaDevices.getUserMedia.mockClear()
+      const streams = await Promise.all(
+        Array.from({ length: 3 }, acquireMediaStream)
+      )
+      expect(streams[0]).toBe(streams[1])
+      expect(streams[0]).toBe(streams[2])
+      expect(get(stream$)).toEqual(streams[0])
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+    })
+
     it('uses desired camera', async () => {
       vi.clearAllMocks()
       await acquireMediaStream(devices[1])


### PR DESCRIPTION
### :book: What's in there?

While the current multiplayer works fine for 2 players, it didn't for more.
Are included here:

- fix(web): 3rd player can not connect with non-host player
- fix(web): muted peers do not appear as muted when joining game
- fix(web): media stream are not released when leaving 2+ player game

![image](https://user-images.githubusercontent.com/186268/195983865-a7d8824b-dfab-4985-a3d4-a5f88f38528f.png)


### :test_tube: How to test?

You'll need at least 3 different set of camera+mic+speaker...
1. player A creates a game, invites players B & C
2. player C connects and join game
   > player C has to allow video first, then it connects with player A.
   > player A has to allow video, but player C is already loading game.
   > both their videos are enabled and player B is not present
3. player B connects and join game
   > player B has to allow video first, then it connects with players A & C
   > all videos are on, no other permissions are needed
4. player A reloads its page
   > player C becomes host
   > player A eventually connects with players C & B, all videos are on
5. player B leaves the game
   > players C & A have their videos on, player B is not present
   > player B's video stream was released
6. player C & A leave the game
   > all video streams are released

### :up: Notes to reviewers

Despite the "perfect negotiation" algorithm, connecting `RTCDataChanel` and `RTCPeerConnection` may happen in random order. One must wait for both event and then consider connection to be established.

One must not acquire Media stream in parallel, because it actually holds different copies of the stream, which must be released independently.
It is simpler to acquire once, and return the same result to all "parallel" requesters.

I moved the stream state management to the lower level: `peer-connection` (which needs unit testing), to split responsibilities more.