### PR TITLE
refactor(server): replaces plain files with Redis database

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,8 +94,16 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: 6
+
       - name: Install dependencies
         run: pnpm install --ignore-scripts
+
+      - name: Run migrations
+        run: pnpm migrate
 
       - name: Run server test
         run: pnpm test:server
@@ -173,11 +181,19 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: 6
+
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
       - name: Install Playwright
         run: pnpm playwright install chromium
+
+      - name: Run migrations
+        run: pnpm migrate
 
       - name: Run UI integration tests
         run: pnpm test:integration

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,9 +102,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
-      - name: Run migrations
-        run: pnpm migrate
-
       - name: Run server test
         run: pnpm test:server
         env:
@@ -191,9 +188,6 @@ jobs:
 
       - name: Install Playwright
         run: pnpm playwright install chromium
-
-      - name: Run migrations
-        run: pnpm migrate
 
       - name: Run UI integration tests
         run: pnpm test:integration

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Meet your friends online to play your favorite games!
 
 ## How to use
 
-You need git, Node.js 16 and PNPM.
+You need [git], [Node.js 16][node], [PNPM] and [Redis]
 
 1. Checkout the code:
 
@@ -67,3 +67,7 @@ All the magic happens during continuous integration/deployment:
 
 [production]: https://tabulous.fr
 [license]: https://github.com/feugy/tabulous/blob/main/LICENSE
+[git]: https://git-scm.com/downloads
+[redis]: https://redis.io/docs/getting-started/installation/
+[node]: https://nodejs.org/en/download/
+[pnpm]: https://pnpm.io/installation

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,6 @@ Roadmap
 ## Server
 
 - bug: timezone used for Serverside rendering is wrong
-- database
 - invite players who have no account yet
 - allows a single connection per player (discards other JWTs)
 - logging (warning on invalid descriptors)

--- a/apps/server/migrations/001-redis.js
+++ b/apps/server/migrations/001-redis.js
@@ -1,0 +1,21 @@
+import { access, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export async function apply(repositories) {
+  await migrateJSONData(repositories.players)
+  await migrateJSONData(repositories.games)
+}
+
+async function migrateJSONData(repository) {
+  const { name } = repository
+  const file = join(fileURLToPath(import.meta.url), `../../data/${name}.json`)
+  if (await access(file).catch(() => true)) {
+    return
+  }
+  console.log(`reading old data file ${file}`)
+  const models = new Map(JSON.parse(await readFile(file, 'utf-8')))
+  console.log(`${models.size} ${name} to save`)
+  await repository.save([...models.values()])
+  console.log(`${name} migrated!`)
+}

--- a/apps/server/migrations/index.js
+++ b/apps/server/migrations/index.js
@@ -1,0 +1,104 @@
+import { readdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { parseArgs } from 'node:util'
+import { fileURLToPath } from 'node:url'
+import { config } from 'dotenv'
+import Redis from 'ioredis'
+import { loadConfiguration } from '../src/services/configuration.js'
+import repositories from '../src/repositories/index.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationfileRexExp = /^\d+-.+\.js$/
+const versionKey = 'migration:versions'
+const options = {
+  version: {
+    type: 'string',
+    short: 'v'
+  }
+}
+
+async function main() {
+  const {
+    values: { version }
+  } = parseArgs({ options })
+  let desired = parseInt(version)
+  if (version && (isNaN(desired) || desired < 0)) {
+    throw new Error(`desired version '${version}' is not a positive number`)
+  }
+  const conf = loadConfiguration()
+  await initRepositories(conf)
+  const redis = await initRedisClient(conf.data)
+
+  const applied = await readAppliedVersions(redis)
+  const available = await readAvailableVersions(__dirname)
+  if (!version) {
+    desired = available.length
+  }
+  console.log(
+    `[migration] last applied version: ${applied.length}, desired: ${desired}`
+  )
+  const incremented = []
+  for (
+    let next = applied.length + 1;
+    next <= Math.min(desired, available.length);
+    next++
+  ) {
+    await applyMigration(available[next - 1])
+    incremented.push(next - 1)
+  }
+  console.log('[migration] all available migrations applied')
+  if (incremented.length) {
+    await updateAppliedVersions(redis, incremented)
+  }
+  process.exit(0)
+}
+
+config()
+await main()
+
+async function initRepositories(conf) {
+  await repositories.players.connect(conf.data)
+  await repositories.games.connect(conf.data)
+}
+
+async function initRedisClient(conf) {
+  return new Redis(conf.data)
+}
+
+async function readAppliedVersions(redis) {
+  const pairs = await redis.zrange(versionKey, 0, -1, 'WITHSCORES')
+  return pairs.reduce((versions, value, rank) => {
+    if (rank % 0) {
+      versions._tmp = value
+    } else {
+      versions[value] = versions._tmp
+      versions._tmp = undefined
+    }
+    return versions
+  }, [])
+}
+
+async function updateAppliedVersions(redis, incremented) {
+  await redis.zadd(
+    versionKey,
+    ...incremented.flatMap(version => [version, 'ok'])
+  )
+}
+
+async function readAvailableVersions(folder) {
+  const versions = []
+  for (const dirent of await readdir(folder, { withFileTypes: true })) {
+    if (dirent.isFile() && migrationfileRexExp.test(dirent.name)) {
+      versions.push(dirent.name)
+    }
+  }
+  const collator = new Intl.Collator([], { numeric: true })
+  return versions.sort(collator.compare.bind(collator))
+}
+
+async function applyMigration(file) {
+  console.log(`[migration] loading migration file: ${file}`)
+  const { apply } = await import(`./${file}`)
+  await apply(repositories)
+  console.log(`[migration] ${file} applied`)
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./src",
   "scripts": {
+    "migrate": "node migrations",
     "start": "nodemon . | pino-pretty -c -t",
     "test": "vitest run --coverage",
     "test:dev": "vitest dev"
@@ -20,7 +21,9 @@
     "fast-jwt": "^1.7.1",
     "fastify": "^4.8.1",
     "fastify-plugin": "^4.2.1",
+    "ioredis": "^5.2.3",
     "mercurius": "^11.0.1",
+    "mqemitter-redis": "^5.0.0",
     "pino-pretty": "^9.1.1",
     "rxjs": "^7.5.7",
     "undici": "^5.11.0"

--- a/apps/server/src/repositories/abstract-repository.js
+++ b/apps/server/src/repositories/abstract-repository.js
@@ -1,6 +1,9 @@
 import { randomUUID } from 'crypto'
-import { mkdir, readFile, writeFile } from 'fs/promises'
-import { dirname, join } from 'path'
+import Redis from 'ioredis'
+
+/**
+ * @typedef {import('ioredis').ChainableCommander} Transaction
+ */
 
 /**
  * @typedef {object} Page
@@ -11,39 +14,72 @@ import { dirname, join } from 'path'
  * @property {object[]} results - returned models.
  */
 
-async function persist(repository) {
-  return repository.file
-    ? writeFile(
-        repository.file,
-        JSON.stringify([...repository.modelsById.entries()])
-      )
-    : null
-}
+/**
+ * @typedef {object} DeleteTransactionContext
+ * @property {Transaction} transaction - deletion transaction.
+ * @property {(object | null)[]} models - array of deleted record object.
+ * @property {string[]} keys - array of deleted Redis keys.
+ */
 
-async function scheduleSave(repository) {
-  clearTimeout(repository.saveTimer)
-  repository.saveTimer = setTimeout(
-    () => persist(repository).catch(err => console.error(err)),
-    repository.saveDelay
-  )
-}
+/**
+ * @typedef {object} SaveTransactionContext
+ * @property {Transaction} transaction - save transaction.
+ * @property {object[]} models - array of saved models.
+ * @property {object[]} existings - array of pre-existing models.
+ * @property {(number | string)[]} indexed - for newly inserted models, their score and id.
+ */
+
+/**
+ * @typedef {object} SaveModelContext
+ * @property {Transaction} transaction - save transaction.
+ * @property {object} model - saved model.
+ * @property {string} key - Redis key for this model.
+ */
+
+/**
+ * @typedef {object} FieldDescriptor
+ * @property {string} name - the field name.
+ * @property {(value: string) => any} deserialize - function used to deserialize string values from Redis into JSON values.
+ */
 
 export class AbstractRepository {
   /**
+   * @type {FieldDescriptor[]}
+   * Describes fields that must be serialized/deserialized in Redis
+   */
+  static fields = []
+
+  /**
    * Builds a repository to manage a given set of models.
-   * Base class for all repository classes, providing CRUD operations.
+   * Base class for all repository classes, providing CRUD operations on top of Redis.
+   * Managed records must be JSON object with an `id` field.
+   * The underlying structure is:
+   * - ${name}:${id} holds the model, as a redis hash.
+   * - index:${name} is a Redis sorted set where values are record ids, and scores an incremented int
+   * - score:${name} is a Redis integer, holding the next available score
    * @param {object} args - arguments, including:
    * @param {string} args.name - model name.
-   * @param {number} [args.saveDelay=10000] - delay (in ms) before persisting data after it got updated.
    * @returns {AbstractRepository} a model repository.
    */
-  constructor({ name, saveDelay = 10e3 }) {
+  constructor({ name }) {
     if (!name) {
       throw new Error(`every repository needs a name`)
     }
     this.name = name
-    this.saveDelay = saveDelay
-    this.modelsById = new Map()
+    this.client = null
+    this.nextScore = 0
+    this.scoreKey = `score:${this.name}`
+    this.indexKey = `index:${this.name}`
+  }
+
+  /**
+   * Builds the key of a given model of this repository
+   * @private
+   * @param {string} id - the concerned model id.
+   * @returns {string} the corresponding key.
+   */
+  _buildKey(id) {
+    return `${this.name}:${id}`
   }
 
   /**
@@ -51,44 +87,47 @@ export class AbstractRepository {
    * Will store models into a JSON file named after the repository.
    * @async
    * @param {object} args - connection arguments:
-   * @param {string} args.path - folder path in which data will be stored.
+   * @param {string} args.url - url to the Redis Database, including potential authentication.
+   * @param {boolean} [args.isProduction = true] - when false, displays friendly stacktraces, which penalize performances.
    */
-  async connect({ path }) {
-    if (path) {
-      this.file = join(path, `${this.name}.json`)
-      await mkdir(dirname(this.file), { recursive: true })
-      try {
-        this.modelsById = new Map(
-          JSON.parse(await readFile(this.file, 'utf-8'))
-        )
-      } catch (err) {
-        if (err?.code === 'ENOENT') {
-          this.modelsById = new Map()
-          persist(this)
-        } else {
-          throw new Error(
-            `Failed to connect repository ${this.name}: ${err.message}`
+  async connect({ url, isProduction = true }) {
+    if (!this.client) {
+      await new Promise((resolve, reject) => {
+        this.client = new Redis(url, {
+          enableAutoPipelining: true,
+          showFriendlyErrorStack: !isProduction
+        })
+        this.client.once('connect', () => {
+          this.client.removeAllListeners('error')
+          resolve()
+        })
+        this.client.once('error', error => {
+          this.client.removeAllListeners('connect')
+          reject(
+            new Error(
+              `Failed to connect repository ${this.name}: ${error.message}`
+            )
           )
-        }
-      }
-    } else {
-      this.file = null
-      this.modelsById = new Map()
+        })
+      })
+      this.nextScore = parseInt((await this.client.get(this.scoreKey)) || '0')
     }
   }
 
   /**
    * Tears the repository down to release its connection.
-   * Saves data onto storage.
    */
   async release() {
-    clearTimeout(this.saveTimer)
-    await persist(this)
-    this.modelsById.clear()
+    try {
+      await this.client?.quit()
+    } finally {
+      // ignore disconnection errors
+      this.client = null
+    }
   }
 
   /**
-   * Lists models with pagination.
+   * Lists all models.
    * @async
    * @param {object} args - list arguments, including:
    * @param {number} [args.from = 0] - 0-based index of the first result
@@ -96,56 +135,120 @@ export class AbstractRepository {
    * @returns {Page} a given page of models.
    */
   async list({ from = 0, size = 10 } = {}) {
-    let i = 0
-    const results = []
-    for (const [, model] of this.modelsById) {
-      if (i >= from + size) {
-        break
-      }
-      if (i >= from) {
-        results.push(model)
-      }
-      i++
+    let results = []
+    let total = 0
+    if (this.client) {
+      const ids = await this.client.zrange(this.indexKey, from, from + size - 1)
+      results = (await this.getById(ids)).filter(Boolean)
+      total = await this.client.zcard(this.indexKey)
     }
-    return { total: this.modelsById.size, from, size, results }
+    return { total, from, size, results }
   }
 
   /**
    * Get a single or several model by their id.
    * @async
    * @param {string|string[]} id - desired id(s).
-   * @returns {object|null|[object|null]} matching model(s), or null(s).
+   * @returns {object|null|(object|null)[]} matching model(s), or null(s).
    */
-  async getById(id) {
+  async getById(id, ...internals) {
     const ids = Array.isArray(id) ? id : [id]
     const results = []
-    for (const id of ids) {
-      results.push(this.modelsById.get(id) ?? null)
+    if (this.client && ids.length) {
+      for (const id of ids) {
+        results.push(await this._fetchModel(this._buildKey(id), ...internals))
+      }
     }
     return Array.isArray(id) ? results : results[0]
+  }
+
+  /**
+   * Fetches and rebuild a JSON model from Redis.
+   * Allows subclasses to control how the data is stored on Redis.
+   * The default implementation hydrates a Redis hash into an JSON object: all its properties are strings.
+   * @param {string} key - the Redis key.
+   * @returns {Promise<object>} the corresponding model.
+   */
+  async _fetchModel(key) {
+    const data = await this.client.hgetall(key)
+    if (!data.id) {
+      return null
+    }
+    for (const { name, deserialize } of this.constructor.fields) {
+      if (name in data) {
+        data[name] = deserialize(data[name])
+      }
+    }
+    return data
   }
 
   /**
    * Saves given model to storage.
    * It creates new model when needed, and updates existing ones (based on provided id).
    * Partial update is supported: incoming data is merged with previous (top level properties only).
+   * Time complexity if O(2N + 1) + M * O(log(T)), with N saved records, M newly saved records, T total of records.
    * @async
    * @param {object|object[]} data - single or array of saved (partial) models.
    * @returns {object|object[]} single or array of saved models.
    */
   async save(data) {
     const records = Array.isArray(data) ? data : [data]
-    const results = []
-    for (const record of records) {
-      if (!record.id) {
-        record.id = randomUUID()
+    const models = []
+    if (this.client && records.length) {
+      const ids = []
+      for (const record of records) {
+        if (!record.id) {
+          record.id = randomUUID()
+        }
+        ids.push(record.id)
       }
-      const saved = { ...(this.modelsById.get(record.id) ?? {}), ...record }
-      results.push(saved)
-      this.modelsById.set(record.id, saved)
+      await this.client.watch(ids.map(this._buildKey.bind(this)))
+      const existings = await this.getById(ids)
+      const indexed = []
+      const transaction = this.client.multi()
+      for (const [index, record] of records.entries()) {
+        if (!existings[index]) {
+          indexed.push(this.nextScore++, record.id)
+          existings[index] = {}
+        }
+        const model = Object.assign({}, existings[index], record)
+        models.push(model)
+        this._saveModel({ key: this._buildKey(model.id), model, transaction })
+      }
+      await this._enrichSaveTransaction({
+        transaction,
+        models,
+        existings,
+        indexed
+      }).exec()
     }
-    scheduleSave(this)
-    return Array.isArray(data) ? results : results[0]
+    return Array.isArray(data) ? models : models[0]
+  }
+
+  /**
+   * Enrich the save transaction for saving a single model.
+   * Allows subclasses to control how the data is stored on Redis.
+   * This default implementation stringifies the whole model.
+   * @param {SaveModelContext} context - the save operation context.
+   */
+  _saveModel({ key, model, transaction }) {
+    transaction.hset(key, model)
+  }
+
+  /**
+   * Records new models into the index.
+   * Allows subclasses to tweak the Redis transaction used to save records.
+   * @private
+   * @param {SaveTransactionContext} context - contextual information.
+   * @returns {Transaction} the applied transaction.
+   */
+  _enrichSaveTransaction({ transaction, indexed }) {
+    if (indexed.length) {
+      transaction
+        .set(this.scoreKey, this.nextScore)
+        .zadd(this.indexKey, ...indexed)
+    }
+    return transaction
   }
 
   /**
@@ -157,12 +260,56 @@ export class AbstractRepository {
    */
   async deleteById(ids) {
     const recordIds = Array.isArray(ids) ? ids : [ids]
-    const results = []
-    for (const id of recordIds) {
-      results.push(this.modelsById.get(id) ?? null)
-      this.modelsById.delete(id)
+    let models = []
+    if (this.client && recordIds.length) {
+      const keys = recordIds.map(this._buildKey.bind(this)).filter(Boolean)
+      if (keys.length) {
+        models = await this.getById(recordIds)
+        const transaction = this.client.multi().del(...keys)
+        await this._enrichDeleteTransaction({
+          keys,
+          models,
+          transaction
+        }).exec()
+      }
     }
-    scheduleSave(this)
-    return Array.isArray(ids) ? results : results[0]
+    return Array.isArray(ids) ? models : models[0]
   }
+
+  /**
+   * Removes models from the index.
+   * Allows subclasses to tweak the Redis transaction used to delete records.
+   * @private
+   * @param {DeleteTransactionContext} context - contextual information.
+   * @returns {Transaction} the applied transaction.
+   */
+  _enrichDeleteTransaction({ transaction, models }) {
+    const ids = models.map(model => model?.id).filter(Boolean)
+    return ids.length ? transaction.zrem(this.indexKey, ...ids) : transaction
+  }
+}
+
+/**
+ * Deserializer for boolean values
+ * @param {string} value - serialzied boolean.
+ * @returns {boolean} the corresponding boolean.
+ */
+export function deserializeBoolean(value) {
+  return value === 'true'
+}
+
+/**
+ * Deserializer for number values
+ * @param {string} value - serialzied number.
+ * @returns {number} the corresponding number.
+ */
+export const deserializeNumber = parseFloat
+
+/**
+ * Deserializer for array values
+ * @param {string} value - serialzied array.
+ * @returns {array} the corresponding array.
+ */
+export function deserializeArray(value) {
+  return (value ?? '').split(',').filter(Boolean)
 }

--- a/apps/server/src/repositories/abstract-repository.js
+++ b/apps/server/src/repositories/abstract-repository.js
@@ -127,7 +127,7 @@ export class AbstractRepository {
   }
 
   /**
-   * Lists all models.
+   * Lists all models with pagination.
    * @async
    * @param {object} args - list arguments, including:
    * @param {number} [args.from = 0] - 0-based index of the first result
@@ -151,12 +151,12 @@ export class AbstractRepository {
    * @param {string|string[]} id - desired id(s).
    * @returns {object|null|(object|null)[]} matching model(s), or null(s).
    */
-  async getById(id, ...internals) {
+  async getById(id) {
     const ids = Array.isArray(id) ? id : [id]
     const results = []
     if (this.client && ids.length) {
       for (const id of ids) {
-        results.push(await this._fetchModel(this._buildKey(id), ...internals))
+        results.push(await this._fetchModel(this._buildKey(id)))
       }
     }
     return Array.isArray(id) ? results : results[0]

--- a/apps/server/src/repositories/catalog-items.js
+++ b/apps/server/src/repositories/catalog-items.js
@@ -25,7 +25,7 @@ class CatalogItemRepository extends AbstractRepository {
   async connect({ path }) {
     let entries
     this.models = []
-    this.modelsById = new Map()
+    this.modelsByName = new Map()
     try {
       entries = await readdir(path, { withFileTypes: true })
     } catch (err) {
@@ -44,7 +44,7 @@ class CatalogItemRepository extends AbstractRepository {
             ...(await import(descriptor))
           }
           this.models.push(item)
-          this.modelsById.set(name, item)
+          this.modelsByName.set(name, item)
         } catch (err) {
           // ignore folders with no index.js or invalid symbolic links
           // vite-node loader (used for tests) has a different error message than node.js
@@ -76,11 +76,26 @@ class CatalogItemRepository extends AbstractRepository {
    */
   async list() {
     return {
-      total: this.modelsById.size,
+      total: this.models.length,
       from: 0,
       size: Number.POSITIVE_INFINITY,
       results: this.models
     }
+  }
+
+  /**
+   * Get a single or several model by their id.
+   * @async
+   * @param {string|string[]} id - desired id(s).
+   * @returns {object|null|(object|null)[]} matching model(s), or null(s).
+   */
+  async getById(id) {
+    const ids = Array.isArray(id) ? id : [id]
+    const results = []
+    for (const id of ids) {
+      results.push(this.modelsByName.get(id) ?? null)
+    }
+    return Array.isArray(id) ? results : results[0]
   }
 
   /**

--- a/apps/server/src/repositories/games.js
+++ b/apps/server/src/repositories/games.js
@@ -92,7 +92,6 @@ class GameRepository extends AbstractRepository {
 
   /**
    * Lists all games of a given player.
-   * **Note**: this only returns lightweigth models.
    * @async
    * @param {object} playerId - id of the player for which games are returned.
    * @returns {object[]} this player's games.

--- a/apps/server/src/repositories/games.js
+++ b/apps/server/src/repositories/games.js
@@ -1,8 +1,19 @@
-import { AbstractRepository } from './abstract-repository.js'
+import {
+  AbstractRepository,
+  deserializeArray,
+  deserializeNumber
+} from './abstract-repository.js'
 
 class GameRepository extends AbstractRepository {
+  static fields = [
+    { name: 'created', deserialize: deserializeNumber },
+    { name: 'playerIds', deserialize: deserializeArray }
+  ]
+
   /**
    * Builds a repository to manage games.
+   * The underlying structure is the same as AbstractRepository, plus:
+   * - index:${name}:playerId:${playerId} are Redis Set holding game ids for a given player.
    * @returns {GameRepository} a repository for game models.
    */
   constructor() {
@@ -10,25 +21,88 @@ class GameRepository extends AbstractRepository {
   }
 
   /**
-   * Lists games of a given player with pagination.
-   * @async
-   * @param {object} args - list arguments, including:
-   * @param {number} [args.from = 0] - 0-based index of the first result
-   * @param {number} [args.size = 10] - maximum number of models returned after first results.
-   * @returns {import('./abstract-repository').Page} a given page of games.
+   * Fetches game from a Redis Hash.
+   * @param {string} key - the Redis key.
+   * @returns {Promise<object>} the corresponding model.
    */
-  async listByPlayerId(playerId, { from = 0, size = 10 } = {}) {
-    let i = 0
-    const results = []
-    for (const [, model] of this.modelsById) {
-      if (model.playerIds.includes(playerId)) {
-        if (i >= from && i < from + size) {
-          results.push(model)
-        }
-        i++
+  async _fetchModel(key) {
+    const data = await super._fetchModel(key)
+    if (data && 'otherFields' in data) {
+      Object.assign(data, JSON.parse(data.otherFields))
+      data.otherFields = undefined
+    }
+    return data
+  }
+
+  /**
+   * Saves player as Redis Hash.
+   * @private
+   * @param {AbstractRepository.SaveModelContext} context - contextual information.
+   */
+  _saveModel({ transaction, model, key }) {
+    const { id, created, playerIds, ...otherFields } = model
+    transaction.hset(key, {
+      id,
+      created,
+      playerIds,
+      otherFields: JSON.stringify(otherFields)
+    })
+  }
+
+  /**
+   * Builds the key of the set holding all game ids of a given player.
+   * @param {string} playerId - the concerned player id.
+   * @returns {string} the corresponding key.
+   */
+  _buildPlayerKey(playerId) {
+    return `index:${this.name}:players:${playerId}`
+  }
+
+  /**
+   * When saving games, adds the new ones into their respecive player sets of games.
+   * @private
+   * @param {AbstractRepository.SaveTransactionContext} context - contextual information.
+   * @returns {Transaction} the applied transaction.
+   */
+  _enrichSaveTransaction(context) {
+    const transaction = super._enrichSaveTransaction(context)
+    for (const game of context.models) {
+      for (const playerId of game?.playerIds ?? []) {
+        transaction.sadd(this._buildPlayerKey(playerId), game.id)
       }
     }
-    return { total: i, from, size, results }
+    return transaction
+  }
+
+  /**
+   * When deleting games, removes them from player sets of games.
+   * @private
+   * @param {AbstractRepository.DeleteTransactionContext} context - contextual information.
+   * @returns {Transaction} the applied transaction.
+   */
+  _enrichDeleteTransaction(context) {
+    const transaction = super._enrichDeleteTransaction(context)
+    for (const game of context.models) {
+      for (const playerId of game?.playerIds ?? []) {
+        transaction.srem(this._buildPlayerKey(playerId), game.id)
+      }
+    }
+    return transaction
+  }
+
+  /**
+   * Lists all games of a given player.
+   * **Note**: this only returns lightweigth models.
+   * @async
+   * @param {object} playerId - id of the player for which games are returned.
+   * @returns {object[]} this player's games.
+   */
+  async listByPlayerId(playerId) {
+    if (!this.client) {
+      return []
+    }
+    const ids = await this.client.smembers(this._buildPlayerKey(playerId))
+    return this.getById(ids.sort())
   }
 }
 

--- a/apps/server/src/repositories/players.js
+++ b/apps/server/src/repositories/players.js
@@ -1,47 +1,114 @@
-import { AbstractRepository } from './abstract-repository.js'
+import {
+  AbstractRepository,
+  deserializeArray,
+  deserializeBoolean
+} from './abstract-repository.js'
 
 class PlayerRepository extends AbstractRepository {
+  static fields = [
+    { name: 'playing', deserialize: deserializeBoolean },
+    { name: 'isAdmin', deserialize: deserializeBoolean },
+    { name: 'catalog', deserialize: deserializeArray }
+  ]
+
   /**
    * Builds a repository to manage players.
+   * The underlying structure is the same as AbstractRepository, plus:
+   * - index:${name}:providers:${provider}:${providerId} are Redis strings holding player id for a given provider id.
    * @returns {PlayerRepository} a repository for player models.
    */
   constructor() {
     super({ name: 'players' })
+    this.usernameAutocompleteKey = 'autocomplete:players:username'
   }
 
   /**
-   * Finds a player by their username.
-   * @async
-   * @param {string} username - desired username.
-   * @returns {object|null} the corresponding player or null.
+   * Builds the key of the string holding player id for a given provider id.
+   * @param {object} player - the player details, including:
+   * @param {string} player.provider - name of the provider.
+   * @param {string} player.providerId - provider id for this player
+   * @returns {string} the corresponding key.
    */
-  async getByUsername(username) {
-    for (const [, player] of this.modelsById) {
-      if (player.username === username) {
-        return player
-      }
+  _buildProviderIdKey({ provider, providerId }) {
+    return `index:${this.name}:providers:${provider}:${providerId}`
+  }
+
+  /**
+   * When saving players, add their provider id references, and updates their username for autocompletion.
+   * @private
+   * @param {AbstractRepository.SaveTransactionContext} context - contextual information.
+   * @returns {AbstractRepository.Transaction} the applied transaction.
+   */
+  _enrichSaveTransaction(context) {
+    const transaction = super._enrichDeleteTransaction(context)
+    const { models, existings } = context
+    const references = models
+      .map(player =>
+        player ? [this._buildProviderIdKey(player), player.id] : null
+      )
+      .filter(Boolean)
+    if (references.length) {
+      transaction.mset(...references)
     }
-    return null
+    const oldUsernames = existings
+      .map(player => buildUsernameAutocomplete(player))
+      .filter(Boolean)
+    if (oldUsernames.length) {
+      transaction.zrem(this.usernameAutocompleteKey, ...oldUsernames)
+    }
+    const newUsernames = models
+      .map(player => buildUsernameAutocomplete(player))
+      .filter(Boolean)
+    if (newUsernames.length) {
+      transaction.zadd(
+        this.usernameAutocompleteKey,
+        ...newUsernames.flatMap(username => [0, username])
+      )
+    }
+    return transaction
+  }
+
+  /**
+   * When deleting players, removes their provider id references and username for autocompletion.
+   * @private
+   * @param {AbstractRepository.DeleteTransactionContext} context - contextual information.
+   * @returns {AbstractRepository.Transaction} the applied transaction.
+   */
+  _enrichDeleteTransaction(context) {
+    const transaction = super._enrichDeleteTransaction(context)
+    const references = context.models
+      .map(player => (player ? this._buildProviderIdKey(player) : null))
+      .filter(Boolean)
+    if (references.length) {
+      transaction.del(...references)
+    }
+    const usernames = context.models
+      .map(player => buildUsernameAutocomplete(player))
+      .filter(Boolean)
+    if (usernames.length) {
+      transaction.zrem(this.usernameAutocompleteKey, ...usernames)
+    }
+    return transaction
   }
 
   /**
    * Finds a player by their provider and providerId details.
    * @async
-   * @param {string} provider - desired provider.
-   * @param {any} providerId - desired providerId.
+   * @param {object} player - the desired provider details, including:
+   * @param {string} player.provider - name of the provider.
+   * @param {string} player.providerId - provider id for this player
    * @returns {object|null} the corresponding player or null.
    */
-  async getByProviderDetails({ provider, providerId }) {
-    for (const [, player] of this.modelsById) {
-      if (player.provider === provider && player.providerId === providerId) {
-        return player
-      }
+  async getByProviderDetails(details) {
+    if (!this.client) {
+      return null
     }
-    return null
+    const id = await this.client.get(this._buildProviderIdKey(details))
+    return id ? this.getById(id) : null
   }
 
   /**
-   * Finds players containing a given seed in their username.
+   * Finds players starting with a given text in their username.
    * @async
    * @param {object} args - search arguments, including:
    * @param {string} args.search - searched text
@@ -50,18 +117,19 @@ class PlayerRepository extends AbstractRepository {
    * @returns {import('./abstract-repository').Page} a given page of matching players.
    */
   async searchByUsername({ search, from = 0, size = 10 } = {}) {
-    const results = []
+    let results = []
     let total = 0
-    let i = 0
-    const lowerSeed = search.toLowerCase().trim()
-    for (const [, player] of this.modelsById) {
-      if (player.username.toLowerCase().includes(lowerSeed)) {
-        total++
-        if (from <= i && i < from + size) {
-          results.push(player)
-        }
-        i++
-      }
+    if (this.client) {
+      const seed = normalizeString(search)
+      const matching = await this.client.zrangebylex(
+        this.usernameAutocompleteKey,
+        `[${seed}`,
+        `[${seed}{`
+      )
+      total = matching.length
+      results = await this.getById(
+        matching.slice(from, from + size).map(result => result.split(':')[1])
+      )
     }
     return { total, from, size, results }
   }
@@ -72,3 +140,20 @@ class PlayerRepository extends AbstractRepository {
  * @type {PlayerRepository}
  */
 export const players = new PlayerRepository()
+
+function normalizeString(str) {
+  return (
+    str
+      .trim()
+      // https://stackoverflow.com/a/37511463/1182976
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLowerCase()
+  )
+}
+
+function buildUsernameAutocomplete(player) {
+  return player?.username
+    ? `${normalizeString(player.username)}:${player.id}`
+    : null
+}

--- a/apps/server/src/server.js
+++ b/apps/server/src/server.js
@@ -23,9 +23,9 @@ export async function startServer(config) {
   })
 
   app.decorate('conf', config)
-  await repositories.players.connect({ path: config.data.path })
-  await repositories.games.connect({ path: config.data.path })
-  await repositories.catalogItems.connect({ path: config.games.path })
+  await repositories.players.connect(config.data)
+  await repositories.games.connect(config.data)
+  await repositories.catalogItems.connect(config.games)
 
   app.register(import('./plugins/cors.js'), config.plugins.cors)
   app.register(import('./plugins/graphql.js'), config.plugins.graphql)

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -312,8 +312,7 @@ export async function invite(gameId, guestId, hostId) {
  * @returns {Game[]} a list of games (could be empty).
  */
 export async function listGames(playerId) {
-  return (await repositories.games.listByPlayerId(playerId, { size: 50 }))
-    .results
+  return repositories.games.listByPlayerId(playerId)
 }
 
 /**

--- a/apps/server/src/utils/index.js
+++ b/apps/server/src/utils/index.js
@@ -1,4 +1,3 @@
 export * from './collections.js'
 export * from './crypto.js'
 export * from './games.js'
-export * from './time.js'

--- a/apps/server/src/utils/time.js
+++ b/apps/server/src/utils/time.js
@@ -1,8 +1,0 @@
-/**
- * Awaits for some time.
- * @aync
- * @param {number} [duration=0] - number of milliseconds to wait for
- */
-export async function sleep(n = 0) {
-  await new Promise(resolve => setTimeout(resolve, n))
-}

--- a/apps/server/tests/repositories/catalog-items.test.js
+++ b/apps/server/tests/repositories/catalog-items.test.js
@@ -80,6 +80,34 @@ describe('Catalog Items repository', () => {
         })
       })
 
+      describe('getById()', () => {
+        it('returns a model by id', async () => {
+          const model = faker.helpers.arrayElement(items)
+          expect(await catalogItems.getById(model.name)).toEqual(model)
+        })
+
+        it('returns null on unknown id', async () => {
+          expect(await catalogItems.getById(faker.datatype.uuid())).toBeNull()
+        })
+
+        it('returns several models by ids', async () => {
+          expect(
+            await catalogItems.getById(items.map(({ name }) => name).reverse())
+          ).toEqual([...items].reverse())
+        })
+
+        it('returns null on unknown ids', async () => {
+          expect(
+            await catalogItems.getById([
+              faker.datatype.uuid(),
+              items[2].name,
+              faker.datatype.uuid(),
+              items[1].name
+            ])
+          ).toEqual([null, items[2], null, items[1]])
+        })
+      })
+
       describe('save()', () => {
         it('throws error as it is not supported', async () => {
           await expect(catalogItems.save()).rejects.toThrow(

--- a/apps/server/tests/repositories/games.test.js
+++ b/apps/server/tests/repositories/games.test.js
@@ -1,65 +1,168 @@
 import { faker } from '@faker-js/faker'
+import { describe, expect, it } from 'vitest'
 import { games } from '../../src/repositories/games.js'
+import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
 describe('given a connected repository and several games', () => {
+  const redisUrl = getRedisTestUrl()
   const playerId1 = '1'
   const playerId2 = '2'
+  const playerId3 = '3'
 
-  const models = [
-    { id: faker.datatype.uuid(), playerIds: [playerId1] },
-    { id: faker.datatype.uuid(), playerIds: [playerId2] },
-    { id: faker.datatype.uuid(), playerIds: [playerId2, playerId1] },
-    { id: faker.datatype.uuid(), playerIds: [playerId1, playerId2] },
-    { id: faker.datatype.uuid(), playerIds: [playerId2] },
-    { id: faker.datatype.uuid(), playerIds: [playerId2] }
-  ]
+  let models = []
 
   beforeEach(async () => {
-    await games.connect({})
+    await games.connect({ url: redisUrl })
+    models = [
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId1],
+        created: Date.now()
+      },
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId2],
+        created: Date.now()
+      },
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId2, playerId1],
+        created: Date.now()
+      },
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId1, playerId2],
+        created: Date.now()
+      },
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId2],
+        created: Date.now()
+      },
+      {
+        id: faker.datatype.uuid(),
+        playerIds: [playerId2],
+        created: Date.now(),
+        // other fields,
+        kind: 'draughts',
+        foo: faker.datatype.number(),
+        bar: faker.datatype.boolean(),
+        baz: faker.datatype.array()
+      }
+    ]
     await games.save(models)
   })
 
-  afterEach(() => games.release())
+  afterEach(async () => {
+    await games.release()
+    await clearDatabase(redisUrl)
+  })
 
   describe('Game repository', () => {
-    describe('listByPlayerId()', () => {
-      it('lists games of a given player', async () => {
-        expect(await games.listByPlayerId(playerId1)).toEqual({
-          total: 3,
-          from: 0,
-          size: 10,
-          results: [models[0], models[2], models[3]]
+    describe('getById()', () => {
+      it('returns null for unknown game', async () => {
+        expect(await games.getById(faker.datatype.uuid())).toBeNull()
+      })
+
+      it('hydrates numbers', async () => {
+        expect(await games.getById(models[0].id)).toMatchObject({
+          created: models[0].created
         })
       })
 
-      it('returns a page of games', async () => {
-        expect(
-          await games.listByPlayerId(playerId2, { from: 2, size: 1 })
-        ).toEqual({ total: 5, from: 2, size: 1, results: [models[3]] })
-        expect(
-          await games.listByPlayerId(playerId2, { from: 0, size: 2 })
-        ).toEqual({
-          total: 5,
-          from: 0,
-          size: 2,
-          results: [models[1], models[2]]
+      it('hydrates arrays', async () => {
+        expect(await games.getById(models[1].id)).toMatchObject({
+          playerIds: [playerId2]
         })
+      })
+
+      it('hydrates multiple properties', async () => {
+        expect(await games.getById(models[2].id)).toMatchObject({
+          created: models[2].created,
+          playerIds: [playerId2, playerId1]
+        })
+      })
+
+      it('hydrates other fields', async () => {
+        expect(await games.getById(models[5].id)).toMatchObject({
+          kind: 'draughts',
+          foo: expect.any(Number),
+          bar: expect.any(Boolean),
+          baz: expect.any(Array)
+        })
+      })
+    })
+
+    describe('listByPlayerId()', () => {
+      it('returns nothing when disconnected', async () => {
+        await games.release()
+        expect(await games.listByPlayerId(playerId1)).toEqual([])
+      })
+
+      it('lists games of a given player', async () => {
+        expect(await games.listByPlayerId(playerId1)).toEqual(
+          sortResults([models[0], models[2], models[3]])
+        )
+        expect(await games.listByPlayerId(playerId2)).toEqual(
+          sortResults([models[1], models[2], models[3], models[4], models[5]])
+        )
       })
 
       it('returns nothing for a gameless player', async () => {
-        expect(await games.listByPlayerId(faker.datatype.uuid())).toEqual({
-          total: 0,
-          from: 0,
-          size: 10,
-          results: []
-        })
+        expect(await games.listByPlayerId(faker.datatype.uuid())).toEqual([])
       })
 
-      it('can return an empty a page', async () => {
-        expect(
-          await games.listByPlayerId(playerId2, { from: 10, size: 1 })
-        ).toEqual({ total: 5, from: 10, size: 1, results: [] })
+      it('reflects added players', async () => {
+        models[0].playerIds = [playerId1, playerId3, playerId2]
+        await games.save(models[0])
+        expect(await games.listByPlayerId(playerId1)).toEqual(
+          sortResults([models[0], models[2], models[3]])
+        )
+        expect(await games.listByPlayerId(playerId2)).toEqual(
+          sortResults([
+            models[0],
+            models[1],
+            models[2],
+            models[3],
+            models[4],
+            models[5]
+          ])
+        )
+        expect(await games.listByPlayerId(playerId3)).toEqual(
+          sortResults([models[0]])
+        )
+      })
+
+      it('reflects game additions and deletions', async () => {
+        expect(await games.listByPlayerId(playerId1)).toEqual(
+          sortResults([models[0], models[2], models[3]])
+        )
+        const [model1] = await games.save([
+          {
+            id: faker.datatype.uuid(),
+            playerIds: [playerId1, playerId3],
+            created: Date.now(),
+            kind: 'draughts'
+          },
+          {
+            id: faker.datatype.uuid(),
+            playerIds: [playerId3],
+            created: Date.now(),
+            kind: 'klondike'
+          }
+        ])
+        expect(await games.listByPlayerId(playerId1)).toEqual(
+          sortResults([models[0], models[2], models[3], model1])
+        )
+        await games.deleteById([models[0].id, model1.id])
+        expect(await games.listByPlayerId(playerId1)).toEqual(
+          sortResults([models[2], models[3]])
+        )
       })
     })
   })
 })
+
+function sortResults(results) {
+  return results.sort((a, b) => (a.id < b.id ? -1 : 1))
+}

--- a/apps/server/tests/repositories/players.test.js
+++ b/apps/server/tests/repositories/players.test.js
@@ -1,66 +1,118 @@
 import { faker } from '@faker-js/faker'
+import { describe, expect, it } from 'vitest'
 import { players } from '../../src/repositories/players.js'
+import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
 describe('given a connected repository and several players', () => {
+  const redisUrl = getRedisTestUrl()
   const provider1 = 'oauth'
   const provider2 = 'oauth2'
-  const providerId1 = faker.datatype.number()
-  const providerId2 = faker.datatype.number()
-  const providerId3 = faker.datatype.number()
+  const providerId1 = faker.datatype.string()
+  const providerId2 = faker.datatype.string()
+  const providerId3 = faker.datatype.string()
 
-  const models = [
-    {
-      id: faker.datatype.uuid(),
-      username: 'Jane',
-      provider: provider1,
-      providerId: providerId1
-    },
-    { id: faker.datatype.uuid(), username: 'Paul' },
-    {
-      id: faker.datatype.uuid(),
-      username: 'Andrew',
-      provider: provider1,
-      providerId: providerId2
-    },
-    { id: faker.datatype.uuid(), username: 'Diana' },
-    {
-      id: faker.datatype.uuid(),
-      username: 'Bruce',
-      provider: provider2,
-      providerId: providerId1
-    },
-    { id: faker.datatype.uuid(), username: 'Clark' },
-    {
-      id: faker.datatype.uuid(),
-      username: 'Peter',
-      provider: provider2,
-      providerId: providerId3
-    },
-    { id: faker.datatype.uuid(), username: 'Patience' },
-    { id: faker.datatype.uuid(), username: 'Carol' },
-    { id: faker.datatype.uuid(), username: 'Anthony' }
-  ]
+  let models = []
 
   beforeEach(async () => {
-    await players.connect({})
+    await players.connect({ url: redisUrl })
+    models = [
+      {
+        id: faker.datatype.uuid(),
+        username: 'Jane',
+        provider: provider1,
+        providerId: providerId1
+      },
+      {
+        id: faker.datatype.uuid(),
+        username: 'Paul',
+        catalog: [],
+        isAdmin: true,
+        playing: false
+      },
+      {
+        id: faker.datatype.uuid(),
+        username: 'Adam Destine',
+        provider: provider1,
+        providerId: providerId2,
+        catalog: ['klondike', 'draughts']
+      },
+      {
+        id: faker.datatype.uuid(),
+        username: 'Adam Mann',
+        catalog: ['draughts', 'klondike']
+      },
+      {
+        id: faker.datatype.uuid(),
+        username: 'Bruce',
+        provider: provider2,
+        providerId: providerId1
+      },
+      { id: faker.datatype.uuid(), username: 'àdversary' },
+      {
+        id: faker.datatype.uuid(),
+        username: 'Peter',
+        provider: provider2,
+        providerId: providerId3
+      },
+      { id: faker.datatype.uuid(), username: 'Agent Moebius' },
+      { id: faker.datatype.uuid(), username: 'Agent' },
+      { id: faker.datatype.uuid(), username: 'Agent X' }
+    ]
     await players.save(models)
   })
 
-  afterEach(() => players.release())
+  afterEach(async () => {
+    await players.release()
+    await clearDatabase(redisUrl)
+  })
 
   describe('Player repository', () => {
-    describe('getByUsername()', () => {
-      it('returns a player by username', async () => {
-        const model = faker.helpers.arrayElement(models)
-        expect(await players.getByUsername(model.username)).toEqual(model)
+    describe('getById()', () => {
+      it('returns null for unknown player', async () => {
+        expect(await players.getById(faker.datatype.uuid())).toBeNull()
       })
 
-      it('returns null on unknown unsername', async () => {
-        expect(await players.getByUsername(faker.lorem.word())).toBeNull()
+      it('hydrates booleans', async () => {
+        expect(await players.getById(models[0].id)).not.toHaveProperty(
+          'idAdmin'
+        )
+        expect(await players.getById(models[0].id)).not.toHaveProperty(
+          'playing'
+        )
+        expect(await players.getById(models[1].id)).toMatchObject({
+          isAdmin: true,
+          playing: false
+        })
+      })
+
+      it('hydrates arrays', async () => {
+        expect(await players.getById(models[0].id)).not.toHaveProperty(
+          'catalog'
+        )
+        expect(await players.getById(models[1].id)).toMatchObject({
+          catalog: []
+        })
+        expect(await players.getById(models[2].id)).toMatchObject({
+          catalog: ['klondike', 'draughts']
+        })
+      })
+
+      it('hydrates multiple properties', async () => {
+        expect(await players.getById(models[3].id)).toEqual(models[3])
       })
     })
 
     describe('getByProviderDetails()', () => {
+      it('returns nothing when disconnected', async () => {
+        await players.release()
+        expect(
+          await players.getByProviderDetails({
+            provider: provider2,
+            providerId: providerId1
+          })
+        ).toBeNull()
+      })
+
       it('returns a player by provider and providerId', async () => {
         expect(
           await players.getByProviderDetails({
@@ -87,75 +139,67 @@ describe('given a connected repository and several players', () => {
           })
         ).toBeNull()
       })
+
+      it('reflects player additions and deletions', async () => {
+        expect(await players.getByProviderDetails(models[0])).toEqual(models[0])
+        const added = await players.save({
+          id: faker.datatype.uuid(),
+          username: 'Jack',
+          provider: provider1,
+          providerId: faker.datatype.string(),
+          catalog: [],
+          isAdmin: false,
+          playing: false
+        })
+        expect(await players.getByProviderDetails(added)).toEqual(added)
+        await players.deleteById(added.id)
+        expect(await players.getByProviderDetails(added)).toBeNull()
+      })
     })
 
     describe('searchByUsername()', () => {
-      it('returns players containing given seed', async () => {
-        expect(await players.searchByUsername({ search: 'a' })).toEqual({
-          total: 8,
+      it('returns players starting with a given seed', async () => {
+        expect(await players.searchByUsername({ search: 'ad' })).toEqual({
+          total: 3,
           from: 0,
           size: 10,
-          results: [
-            models[0],
-            models[1],
-            models[2],
-            models[3],
-            models[5],
-            models[7],
-            models[8],
-            models[9]
-          ]
+          results: [models[2], models[3], models[5]]
         })
-        expect(await players.searchByUsername({ search: 'an' })).toEqual({
-          total: 4,
-          from: 0,
-          size: 10,
-          results: [models[0], models[2], models[3], models[9]]
-        })
-        expect(await players.searchByUsername({ search: 'dre' })).toEqual({
-          total: 1,
-          from: 0,
-          size: 10,
-          results: [models[2]]
-        })
-      })
-
-      it('returns players starting with given seed', async () => {
-        expect(await players.searchByUsername({ search: 'pa' })).toEqual({
+        expect(await players.searchByUsername({ search: 'ada' })).toEqual({
           total: 2,
           from: 0,
           size: 10,
-          results: [models[1], models[7]]
+          results: [models[2], models[3]]
         })
-      })
-
-      it('returns players ending with given seed', async () => {
-        expect(await players.searchByUsername({ search: 'ew' })).toEqual({
-          total: 1,
+        expect(await players.searchByUsername({ search: 'age' })).toEqual({
+          total: 3,
           from: 0,
           size: 10,
-          results: [models[2]]
+          results: [models[7], models[9], models[8]]
         })
       })
 
       it('returns players containing seed regardless of their case', async () => {
-        expect(await players.searchByUsername({ search: 'eW' })).toEqual({
-          total: 1,
-          from: 0,
-          size: 10,
-          results: [models[2]]
-        })
-        expect(await players.searchByUsername({ search: 'pA' })).toEqual({
+        expect(await players.searchByUsername({ search: 'AdA' })).toEqual({
           total: 2,
           from: 0,
           size: 10,
-          results: [models[1], models[7]]
+          results: [models[2], models[3]]
         })
-        expect(await players.searchByUsername({ search: 'AN' })).toEqual({
-          total: 4,
+      })
+
+      it('returns players containing seed regardless od diacritics', async () => {
+        expect(await players.searchByUsername({ search: 'Adv' })).toEqual({
+          total: 1,
           from: 0,
           size: 10,
-          results: [models[0], models[2], models[3], models[9]]
+          results: [models[5]]
+        })
+        expect(await players.searchByUsername({ search: 'àDv' })).toEqual({
+          total: 1,
+          from: 0,
+          size: 10,
+          results: [models[5]]
         })
       })
 
@@ -172,26 +216,64 @@ describe('given a connected repository and several players', () => {
         expect(
           await players.searchByUsername({ search: 'a', from: 2, size: 3 })
         ).toEqual({
-          total: 8,
+          total: 6,
           from: 2,
           size: 3,
-          results: [models[2], models[3], models[5]]
+          results: [models[5], models[7], models[9]]
         })
 
         expect(
-          await players.searchByUsername({ search: 'a', from: 6, size: 3 })
+          await players.searchByUsername({ search: 'a', from: 4, size: 2 })
         ).toEqual({
-          total: 8,
-          from: 6,
-          size: 3,
-          results: [models[8], models[9]]
+          total: 6,
+          from: 4,
+          size: 2,
+          results: [models[9], models[8]]
         })
       })
 
       it('can return an empty page', async () => {
         expect(
           await players.searchByUsername({ search: 'a', from: 100, size: 20 })
-        ).toEqual({ total: 8, from: 100, size: 20, results: [] })
+        ).toEqual({ total: 6, from: 100, size: 20, results: [] })
+      })
+
+      it('reflects player additions and deletions', async () => {
+        expect(await players.searchByUsername({ search: 'adv' })).toEqual({
+          total: 1,
+          from: 0,
+          size: 10,
+          results: [models[5]]
+        })
+        const saved = await players.save({
+          ...models[5],
+          username: 'Black Panther'
+        })
+        expect(await players.searchByUsername({ search: 'adv' })).toEqual({
+          total: 0,
+          from: 0,
+          size: 10,
+          results: []
+        })
+        expect(await players.searchByUsername({ search: 'bla' })).toEqual({
+          total: 1,
+          from: 0,
+          size: 10,
+          results: [saved]
+        })
+        await players.deleteById(saved.id)
+        expect(await players.searchByUsername({ search: 'adv' })).toEqual({
+          total: 0,
+          from: 0,
+          size: 10,
+          results: []
+        })
+        expect(await players.searchByUsername({ search: 'bla' })).toEqual({
+          total: 0,
+          from: 0,
+          size: 10,
+          results: []
+        })
       })
     })
   })

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -6,11 +6,17 @@ import {
   searchPlayers,
   setPlaying
 } from '../../src/services/players.js'
+import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
 describe('given initialized repository', () => {
-  beforeAll(() => repositories.players.connect({}))
+  const redisUrl = getRedisTestUrl()
 
-  afterAll(() => repositories.players.release())
+  beforeAll(() => repositories.players.connect({ url: redisUrl }))
+
+  afterAll(async () => {
+    await clearDatabase(redisUrl)
+    await repositories.players.release()
+  })
 
   describe('addPlayer()', () => {
     it('assigns a new id', async () => {
@@ -105,10 +111,10 @@ describe('given initialized repository', () => {
 
   describe('given some players', () => {
     const players = [
-      { username: 'Wolverine' },
-      { username: 'SuperMan' },
-      { username: 'Docteur Strange' },
-      { username: 'Spiderman' },
+      { username: 'Adam Destine' },
+      { username: 'Batman' },
+      { username: 'Adaptoid' },
+      { username: 'Adversary' },
       { username: 'Hulk' }
     ]
 
@@ -169,16 +175,20 @@ describe('given initialized repository', () => {
 
     describe('searchPlayers()', () => {
       it('returns matching players', async () => {
-        expect(await searchPlayers('man', players[0].id)).toEqual([
-          players[1],
-          players[3]
+        expect(await searchPlayers('ada', players[3].id)).toEqual([
+          players[0],
+          players[2]
         ])
       })
 
       it('excludes current player from results, on demand', async () => {
-        expect(await searchPlayers('man', players[3].id)).toEqual([players[1]])
-        expect(await searchPlayers('man', players[3].id, false)).toEqual([
-          players[1],
+        expect(await searchPlayers('ad', players[3].id)).toEqual([
+          players[0],
+          players[2]
+        ])
+        expect(await searchPlayers('ad', players[3].id, false)).toEqual([
+          players[0],
+          players[2],
           players[3]
         ])
       })

--- a/apps/server/tests/test-utils.js
+++ b/apps/server/tests/test-utils.js
@@ -1,4 +1,5 @@
 import { createSigner } from 'fast-jwt'
+import Redis from 'ioredis'
 import WebSocket from 'ws'
 
 /**
@@ -107,4 +108,21 @@ export function cloneAsJSON(object) {
  */
 export function signToken(playerId, key) {
   return createSigner({ key })({ id: playerId })
+}
+
+/**
+ * Returns an URL to a random database, between 15 and 1, on a Redis instance.
+ * @returns {string} url to the redis database.
+ */
+export function getRedisTestUrl() {
+  return `redis://localhost:6379/${Math.floor(Math.random() * (15 - 1) + 1)}`
+}
+
+/**
+ * Synchronously removes all keys from a given Redis database.
+ * @param {string} url to the redis database.
+ * @returns {Promise<void>} resolves when done.
+ */
+export async function clearDatabase(databaseUrl) {
+  await new Redis(databaseUrl).flushdb()
 }

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -123,7 +123,7 @@ fragment fullGame on Game {
   }
 }
 
-fragment currentGame on Game {
+fragment lightGame on Game {
   id
   created
   kind
@@ -157,13 +157,13 @@ mutation invite($gameId: ID!, $playerId: ID!) {
 
 query listGames {
   listGames {
-    ...currentGame
+    ...lightGame
   }
 }
 
 subscription receiveGameListUpdates {
   receiveGameListUpdates {
-    ...currentGame
+    ...lightGame
   }
 }
 

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -115,6 +115,23 @@ First commands will need to connect with IPv4 (hence the `-4` flag) in the meant
     - uncomment `#pkey=[PATH]` and change path value for `/home/tabulous/certbot/live/tabulous.fr/privkey.pem`
   - restart service: `sudo systemctl restart coturn`
 
+- install Redis:
+
+  - open an SSH connection to the VPS: `ssh ubuntu@vps-XYZ.vps.ovh.net`
+  - install Redis: `sudo apt install -y redis`
+  - configure redis:
+    1. `sudo vi /etc/redis/redis.conf`
+    1. change line `supervised no` to `superivsed auto`
+    1. uncomment line `aclfile /etc/redis/users.acl`
+    1. save and quit
+    1. generate 2 random secrets values (save them somewhere): `tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n 2`
+    1. add these:
+       - `user default off`
+       - `user USERNAME on allkeys +@keyspace +@list +@set +@sortedset +@hash +@string +@transaction >PASSWORD_1`
+       - `user USERNAME_2 on +@pubsub >PASSWORD_2`
+    1. save and quit
+  - restart redis to apply changes: `sudo systemctl restart redis`
+
 ## Continuous deployment
 
 [Inspiration](https://coderflex.com/blog/2-easy-steps-to-automate-a-deployment-in-a-vps-with-github-actions)
@@ -156,6 +173,8 @@ Because such configuration should not be commited on Github, it is stored in an 
   - add `NODE_ENV=production`
   - add `JWT_KEY=[SECRET]` with the secret you just generated
   - add `TURN_SECRET=[SECRET]` with the same secret value as coTURN's `static-auth-secret`
+  - add `REDIS_URL=redis://[USER]:[SECRET]@localhost:6379` with the first user and secret from `/etc/redis/users.acl`
+  - add `PUBSUB_URL=redis://[USER]:[SECRET]@localhost:6379` with the second user and password from `/etc/redis/users.acl`
 
 ## Maintenance
 

--- a/hosting/build.sh
+++ b/hosting/build.sh
@@ -17,7 +17,7 @@ cp .nvmrc dist/
 rm -rf node_modules apps/*/node_modules
 pnpm --filter server --prod deploy dist/server
 cd dist/server
-tar --create --file ../server.tar.gz -z node_modules/ src/ package.json 
+tar --create --file ../server.tar.gz -z node_modules/ src/ migrations/ package.json 
 cd ../..
 rm -rd dist/server
 

--- a/hosting/deploy.sh
+++ b/hosting/deploy.sh
@@ -30,6 +30,10 @@ set +x
 nvm install
 set -x
 
+# run migrations
+cd ~/server
+node migrations
+
 # restart all
 sudo nginx -s reload
 sudo systemctl daemon-reload 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:web": "pnpm --filter web test:dev",
     "format": "prettier --write .",
     "lint": "eslint .",
+    "migrate": "pnpm --filter server migrate",
     "prepare": "husky install",
     "start": "pnpm run -r --if-present start",
     "test": "pnpm -r --if-present t",
@@ -35,7 +36,8 @@
     "prettier": "^2.7.1",
     "prettier-plugin-svelte": "^2.8.0",
     "svelte": "^3.51.0",
-    "vite": "^3.1.7"
+    "vite": "^3.1.7",
+    "vitest": "^0.23.4"
   },
   "lint-staged": {
     "*.{js,svelte}": "eslint --cache --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ importers:
       prettier-plugin-svelte: ^2.8.0
       svelte: ^3.51.0
       vite: ^3.1.7
+      vitest: ^0.23.4
     devDependencies:
       '@vitest/coverage-c8': 0.23.4
       eslint: 8.25.0
@@ -27,6 +28,7 @@ importers:
       prettier-plugin-svelte: 2.8.0_ibge6ami6vq2q2j5g4rcvk62hq
       svelte: 3.51.0
       vite: 3.1.7
+      vitest: 0.23.4
 
   apps/cli:
     specifiers:
@@ -84,7 +86,9 @@ importers:
       fast-jwt: ^1.7.1
       fastify: ^4.8.1
       fastify-plugin: ^4.2.1
+      ioredis: ^5.2.3
       mercurius: ^11.0.1
+      mqemitter-redis: ^5.0.0
       nodemon: ^2.0.20
       pino-pretty: ^9.1.1
       rxjs: ^7.5.7
@@ -102,7 +106,9 @@ importers:
       fast-jwt: 1.7.1
       fastify: 4.8.1
       fastify-plugin: 4.2.1
+      ioredis: 5.2.3
       mercurius: 11.0.1
+      mqemitter-redis: 5.0.0
       pino-pretty: 9.1.1
       rxjs: 7.5.7
       undici: 5.11.0
@@ -727,7 +733,7 @@ packages:
     resolution: {integrity: sha512-IRnids8lblQ8e1i8h4JLyfJmebXE+ohcj8x8X/+Ew6ZB4H0Ui05z5YL6q5FOcl0zItVpu4adRzeyVNNUwmduIg==}
     dependencies:
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       fast-uri: 2.1.0
 
   /@fastify/cors/8.1.0:
@@ -825,6 +831,10 @@ packages:
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
+
+  /@ioredis/commands/1.2.0:
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: false
 
   /@isaacs/ttlcache/1.2.0:
     resolution: {integrity: sha512-BgSn1R16Aba33Qq9sA47tndBvLzJZeboJe9t+0bMlyb0Q01cvtVbLzE2gowMKRFzjaR7qb8VaPw0I8EC5dn8iA==}
@@ -1460,8 +1470,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -1938,6 +1950,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /cluster-key-slot/1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /color-convert/1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -2175,6 +2192,11 @@ packages:
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     dev: true
+
+  /denque/2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /depd/2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2740,6 +2762,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  /event-lite/0.1.2:
+    resolution: {integrity: sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==}
+    dev: false
+
   /event-target-shim/5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -2824,7 +2850,7 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.1.0
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       fast-deep-equal: 3.1.3
       fast-uri: 2.1.0
       rfdc: 1.3.0
@@ -3358,6 +3384,13 @@ packages:
     hasBin: true
     dev: true
 
+  /hyperid/3.0.1:
+    resolution: {integrity: sha512-I+tl7TS5nsoVhkxqX1rS3Qmqlq44eoPUcgPthW8v3IW8CvWL7lwtd6HQbkDUMrBKJTG0vgEaRsjT35imW/D+9Q==}
+    dependencies:
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
+    dev: false
+
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3438,6 +3471,10 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /int64-buffer/0.1.10:
+    resolution: {integrity: sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==}
+    dev: false
+
   /internal-slot/1.0.3:
     resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
     engines: {node: '>= 0.4'}
@@ -3446,6 +3483,29 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
+
+  /ioredis-auto-pipeline/1.0.2:
+    resolution: {integrity: sha512-Axp07oVqbUAArCuIjlfXfME0/te/R7x43zfeGEpY1UTJjWdTUIw/h+K/LfIkRGCv8aCB4bCypHft8AQZ+1Z7zw==}
+    dependencies:
+      to-fast-properties: 3.0.1
+    dev: false
+
+  /ioredis/5.2.3:
+    resolution: {integrity: sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.1
+      debug: 4.3.4
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3615,6 +3675,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
     dev: true
+
+  /isarray/1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3986,6 +4050,14 @@ packages:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
     dev: false
 
+  /lodash.defaults/4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
+  /lodash.isarguments/3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    dev: false
+
   /lodash.kebabcase/4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
     dev: false
@@ -4038,6 +4110,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /lru-cache/7.14.0:
+    resolution: {integrity: sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /lz-string/1.4.4:
     resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
@@ -4205,6 +4282,28 @@ packages:
       obliterator: 2.0.4
     dev: false
 
+  /mqemitter-redis/5.0.0:
+    resolution: {integrity: sha512-4ld+yZHfQ+YTbP5IfF8nsZDjSyfMe8DTefdm40E80BwvGbKvMSOABMWXUjmmXHawGm+whKUGBIYlMytsQoOIUw==}
+    dependencies:
+      hyperid: 3.0.1
+      inherits: 2.0.4
+      ioredis: 5.2.3
+      ioredis-auto-pipeline: 1.0.2
+      lru-cache: 7.14.0
+      mqemitter: 4.5.0
+      msgpack-lite: 0.1.26
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mqemitter/4.5.0:
+    resolution: {integrity: sha512-Mp/zytFeIv6piJQkEKnncHcP4R/ErJc5C7dfonkhkNUT2LA/nTayrfNxbipp3M5iCJUTQSUtzfQAQA3XVcKz6w==}
+    engines: {node: '>=10'}
+    dependencies:
+      fastparallel: 2.4.1
+      qlobber: 5.0.3
+    dev: false
+
   /mqemitter/5.0.0:
     resolution: {integrity: sha512-rqNRQhGgl0W/NV+Zrx0rpAUTZcSlAtivCVUmXBUPcFYt+AeDEpoJgy5eKlFWJP6xnatONL59WIFdV0W6niOMhw==}
     engines: {node: '>=10'}
@@ -4236,6 +4335,16 @@ packages:
     resolution: {integrity: sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==}
     engines: {node: '>=12.13'}
     dev: true
+
+  /msgpack-lite/0.1.26:
+    resolution: {integrity: sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==}
+    hasBin: true
+    dependencies:
+      event-lite: 0.1.2
+      ieee754: 1.2.1
+      int64-buffer: 0.1.10
+      isarray: 1.0.0
+    dev: false
 
   /msw/0.47.3:
     resolution: {integrity: sha512-X3w/1fi29mEqoCajgFV59hrmns+mdD/FPegYMRwW7CK0vi//yX9NVy07/XspdBm6W1TNtb8Giv79SmS2BAb0Wg==}
@@ -4790,6 +4899,11 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
+  /qlobber/5.0.3:
+    resolution: {integrity: sha512-wW4GTZPePyh0RgOsM18oDyOUlXfurVRgoNyJfS+y7VWPyd0GYhQp5T2tycZFZjonH+hngxIfklGJhTP/ghidgQ==}
+    engines: {node: '>= 8'}
+    dev: false
+
   /qlobber/7.0.1:
     resolution: {integrity: sha512-FsFg9lMuMEFNKmTO9nV7tlyPhx8BmskPPjH2akWycuYVTtWaVwhW5yCHLJQ6Q+3mvw5cFX2vMfW2l9z2SiYAbg==}
     engines: {node: '>= 14'}
@@ -4859,6 +4973,18 @@ packages:
       indent-string: 4.0.0
       strip-indent: 3.0.0
     dev: true
+
+  /redis-errors/1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser/3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
@@ -5188,6 +5314,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /standard-as-callback/2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /statuses/2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -5471,6 +5601,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /to-fast-properties/3.0.1:
+    resolution: {integrity: sha512-/wtNi1tW1F3nf0OL6AqVxGw9Tr1ET70InMhJuVxPwFdGqparF0nQ4UWGLf2DsoI2bFDtthlBnALncZpUzOnsUw==}
+    engines: {node: '>=8'}
+    dev: false
+
   /to-regex-range/5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5617,6 +5752,15 @@ packages:
       safe-buffer: 5.2.1
       which-typed-array: 1.1.8
     dev: true
+
+  /uuid-parse/1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+    dev: false
+
+  /uuid/8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: false
 
   /v8-to-istanbul/9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}


### PR DESCRIPTION
### :book: What's in there?

Tabulous server is storing data into plain json files. While it was acceptable for the beginning, it is now time to use a proper database.
Given tabulous has very basic needs in terms of querying data, and because we already need a Publisher/Subscriber backbone for GraphQL subscription, Redis is the right Database to use.

Are included here:

- refactor(server)!: introduces new REDIS_URL and PUBSUB_URL environment variables
- refactor(server)!: player searches only support starting text
- refactor(server): reworks Games and Players repositories to fetch and store data into Redis
- refactor(server): uses Redis PubSub for graphQL subscriptions
- test(server): refactors existing tests to use a real Redis instance (and clean it up)
- chore(server): introduces a simple CLI tool to apply database migrations
- chore(server): writes a first migration to move data from files to Redis
- chore(hosting): run migrations while deploying
- chore(ci): introduces a Redis instance on task running server test

### :test_tube: How to test?

This obviously requires a local Redis instance. Have a look at the hosting documentation to install and configure one.
Then, run the server tests
Run the migration (`pnpm migrate`) and start the application. All features should still work.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
