### PR TITLE
fix(server): NOAUTH error when running migrations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
+      - name: Run migrations
+        run: pnpm migrate
+
       - name: Run server test
         run: pnpm test:server
         env:
@@ -185,6 +188,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --ignore-scripts
+
+      - name: Run migrations
+        run: pnpm migrate
 
       - name: Install Playwright
         run: pnpm playwright install chromium

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@ Roadmap
 - web: terms & condition
 - web: cookie policy
 - server + web: first log-in with T&C
+- server + web: limit number of games
+- server + web: friend list
 
 ## Brittle tests
 

--- a/apps/server/migrations/001-redis.js
+++ b/apps/server/migrations/001-redis.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { access, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
     "ws": "^8.9.0"
   },
   "files": [
-    "src/"
+    "src/",
+    "migrations/"
   ]
 }

--- a/apps/server/src/repositories/abstract-repository.js
+++ b/apps/server/src/repositories/abstract-repository.js
@@ -95,6 +95,7 @@ export class AbstractRepository {
       await new Promise((resolve, reject) => {
         this.client = new Redis(url, {
           enableAutoPipelining: true,
+          enableReadyCheck: false,
           showFriendlyErrorStack: !isProduction
         })
         this.client.once('connect', () => {


### PR DESCRIPTION
### :book: What's in there?

Migrations don't run on production. This is because the migration script starts it's own Redis client, in addition to repositories, without applying authentication.

Are included here:

- fix(cd): migrations script are not deployed
- fix(server): NOAUTH error when running migrations
- refactor(server): do not load the full configuration when running migrations
- chore(ci): migrates DB prior to server tests

### :test_tube: How to test?

1. Run migration locally (where there are no authentication)
2. Run migration in production (where there is authentication)

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
