### PR TITLE
feat(server): enables oauth2 providers

### DIFF
--- a/apps/cli/src/commands/show-player.js
+++ b/apps/cli/src/commands/show-player.js
@@ -94,7 +94,6 @@ function formatPlayerDetails({
 }
 
 function formatGames({ id, games }) {
-  console.log(games)
   const { owned, invited } = games.reduce(
     (counts, { players: [owner] }) => {
       if (owner?.id === id) {

--- a/apps/server/src/plugins/auth.js
+++ b/apps/server/src/plugins/auth.js
@@ -33,9 +33,7 @@ export default async function registerAuth(app, options) {
     if (options[provider]) {
       service.init({
         ...options[provider],
-        redirect: `${options.domain}${
-          options.prefix ?? ''
-        }/${provider}/callback`
+        redirect: `${options.domain}/${provider}/callback`
       })
 
       app.get(

--- a/apps/server/src/services/configuration.js
+++ b/apps/server/src/services/configuration.js
@@ -215,7 +215,9 @@ export function loadConfiguration() {
       },
       domain:
         AUTH_DOMAIN ??
-        (isProduction ? 'https://auth.tabulous.fr' : 'http://localhost:3001'),
+        (isProduction
+          ? 'https://auth.tabulous.fr'
+          : 'http://localhost:3001/auth'),
       allowedOrigins
     }
   }

--- a/apps/server/tests/services/configuration.test.js
+++ b/apps/server/tests/services/configuration.test.js
@@ -170,7 +170,7 @@ describe('loadConfiguration()', () => {
         turn: { secret: turnSecret },
         auth: {
           jwt: { key: 'dummy-test-key' },
-          domain: 'http://localhost:3001',
+          domain: 'http://localhost:3001/auth',
           allowedOrigins
         }
       })
@@ -184,7 +184,7 @@ describe('loadConfiguration()', () => {
       }
 
       expect(loadConfiguration().auth).toEqual({
-        domain: 'http://localhost:3001',
+        domain: 'http://localhost:3001/auth',
         allowedOrigins: '^https?:\\/\\/localhost:\\d+',
         jwt: { key: 'dummy-test-key' },
         github: { id: githubId, secret: githubSecret }
@@ -199,7 +199,7 @@ describe('loadConfiguration()', () => {
       }
 
       expect(loadConfiguration().auth).toEqual({
-        domain: 'http://localhost:3001',
+        domain: 'http://localhost:3001/auth',
         allowedOrigins: '^https?:\\/\\/localhost:\\d+',
         jwt: { key: 'dummy-test-key' },
         google: { id: googleId, secret: googleSecret }

--- a/hosting/start.sh
+++ b/hosting/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 . ~/.nvm/nvm.sh
+nvm use
 trap 'kill 0' exit
 node .
 wait


### PR DESCRIPTION
### :book: What's in there?

Enabling Oauth2 providers in production unveiled a couple of issues:

- fix(server): auth.tabulous.fr production does not uses prefix (Google refusing our redirection callback)
- fix(hosting): node.js version used in production is wrong (fetch & FormData from undici being undefined because it requires node@16.8+ and it was running on node@15)
- fix(cli): undesired logs during show-player command

### :test_tube: How to test?

Logs with these provider in production: the fixes where already applied there.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
