### PR TITLE
feat(web): ability to change username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ debug.txt
 .svelte-kit
 test-results
 .vercel
+.last-db
 upload-manually.sh

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,22 @@
 
 ## Brittle tests
 
+- tests/atelier/tools.test.js > Toolshot > components/RadialMenu.tools.svelte
+  > Error: expect(received).toMatchSnapshot()
+  >
+  > Snapshot name: `More items 1`
+- expectEvents tests/3d/managers/input.test.js:1591:19
+  >     1589|     expect(hovers).toHaveLength(counts.hovers ?? 0)
+  >     1590|     expect(wheels).toHaveLength(counts.wheels ?? 0)
+  >     1591|     expect(longs).toHaveLength(counts.longs ?? 0)
+  >         |                   ^
+  >     1592|     expect(keys).toHaveLength(counts.keys ?? 0)
+
 ## Refactor
 
+- explicit vitest import
+- automatically sort imports
+- fix all sveltekit warnings
 - graphQL: remove signal type and make signal optional
 - add tests for web/src/utils/peer-connection
 - use node 18 when msw/interceptor will [handle it](https://github.com/mswjs/interceptors/pull/283)

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,5 @@
 # TODO
 
-Roadmap
-
-- server + web: set usernamd + avatar
-- server + web: friend list
-
 ## Brittle tests
 
 ## Refactor
@@ -27,15 +22,19 @@ Roadmap
 
 ## UI
 
+- bug: no rules on game creation?
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected, mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - hide non-connected participants
+- loading spinner on game/new
+- updates avatar
 - is this right? given an active selection, when it anchrs with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players'hand
+- select multiple meshes in hand
 - shortcuts cheatsheet
 - peer notifications: joining, joined, left, error (stop waiting when navigating away)
 - hand support for quantifiable behavior

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -107,11 +107,11 @@ export default {
         if (await services.isUsernameUsed(sanitizedUsername, player.id)) {
           throw new Error('Username already used')
         }
-        const updated = await services.upsertPlayer({
-          id: player.id,
-          username: sanitizedUsername,
-          avatar
-        })
+        const update = { id: player.id, username: sanitizedUsername }
+        if (avatar) {
+          update.avatar = avatar
+        }
+        const updated = await services.upsertPlayer(update)
         services.notifyRelatedPlayers(player.id)
         return updated
       }

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -95,8 +95,21 @@ export default {
      * @param {object} context - graphQL context.
      * @returns {Promise<Player>} the updated player.
      */
-    updateCurrentPlayer: isAuthenticated(async (obj, args, { player }) =>
-      services.upsertPlayer({ id: player.id, ...args })
+    updateCurrentPlayer: isAuthenticated(
+      async (obj, { username, avatar }, { player }) => {
+        const sanitizedUsername =
+          username
+            .match(/\p{sc=Latin}|\p{Number}|\p{Emoji}|-|_/giu)
+            ?.join('') ?? ''
+        if (sanitizedUsername.length < 3) {
+          throw new Error('Username too short')
+        }
+        return services.upsertPlayer({
+          id: player.id,
+          username: sanitizedUsername,
+          avatar
+        })
+      }
     )
   }
 }

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -104,11 +104,16 @@ export default {
         if (sanitizedUsername.length < 3) {
           throw new Error('Username too short')
         }
-        return services.upsertPlayer({
+        if (await services.isUsernameUsed(sanitizedUsername, player.id)) {
+          throw new Error('Username already used')
+        }
+        const updated = await services.upsertPlayer({
           id: player.id,
           username: sanitizedUsername,
           avatar
         })
+        services.notifyRelatedPlayers(player.id)
+        return updated
       }
     )
   }

--- a/apps/server/src/graphql/players.graphql
+++ b/apps/server/src/graphql/players.graphql
@@ -29,4 +29,5 @@ type Mutation {
   addPlayer(id: ID!, username: String!, password: String!): Player
   logIn(id: ID!, password: String!): PlayerWithTurnCredentials
   acceptTerms: Player
+  updateCurrentPlayer(username: String, avatar: String): Player
 }

--- a/apps/server/src/plugins/auth.js
+++ b/apps/server/src/plugins/auth.js
@@ -23,7 +23,7 @@ import { makeToken } from './utils.js'
  * @param {OAuth2ProviderOptions} options - plugin's options.
  */
 export default async function registerAuth(app, options) {
-  const { githubAuth, googleAuth, addPlayer } = services
+  const { githubAuth, googleAuth, upsertPlayer } = services
   const allowedOriginsRegExp = new RegExp(options.allowedOrigins)
 
   for (const { service, provider } of [
@@ -58,7 +58,7 @@ export default async function registerAuth(app, options) {
         `/${provider}/callback`,
         async ({ query: { code, state } }, reply) => {
           const { location, user } = await service.authenticateUser(code, state)
-          const player = await addPlayer({ ...user, provider })
+          const player = await upsertPlayer({ ...user, provider })
           const url = new URL(location)
           url.searchParams.append('token', makeToken(player, options.jwt))
           return reply.redirect(url.toString())

--- a/apps/server/src/repositories/players.js
+++ b/apps/server/src/repositories/players.js
@@ -109,23 +109,24 @@ class PlayerRepository extends AbstractRepository {
   }
 
   /**
-   * Finds players starting with a given text in their username.
+   * Finds players starting with a (or being the same exact) text in their username.
    * @async
    * @param {object} args - search arguments, including:
    * @param {string} args.search - searched text
    * @param {number} [args.from = 0] - 0-based index of the first result
    * @param {number} [args.size = 10] - maximum number of models returned after first results.
+   * @param {number} [args.exact = false] - for exact search.
    * @returns {import('./abstract-repository').Page} a given page of matching players.
    */
-  async searchByUsername({ search, from = 0, size = 10 } = {}) {
+  async searchByUsername({ search, from = 0, size = 10, exact = false } = {}) {
     let results = []
     let total = 0
     if (this.client) {
       const seed = normalizeString(search)
       const matching = await this.client.zrangebylex(
         this.usernameAutocompleteKey,
-        `[${seed}`,
-        `[${seed}{`
+        `[${seed}${exact ? ':' : ''}`,
+        `[${seed}${exact ? ':{' : '{'}`
       )
       total = matching.length
       results = await this.getById(

--- a/apps/server/src/services/auth/github.js
+++ b/apps/server/src/services/auth/github.js
@@ -82,7 +82,8 @@ function mapToUserDetails({
   id: providerId,
   login: username,
   avatar_url: avatar,
-  email
+  email,
+  name
 }) {
-  return { username, avatar, email, providerId }
+  return { username, avatar, email, providerId, fullName: name || username }
 }

--- a/apps/server/src/services/auth/google.js
+++ b/apps/server/src/services/auth/google.js
@@ -70,7 +70,8 @@ function mapToUserDetails({
   sub: providerId,
   given_name: username,
   picture: avatar,
-  email
+  email,
+  name
 }) {
-  return { username, avatar, email, providerId }
+  return { username, avatar, email, providerId, fullName: name || username }
 }

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -320,14 +320,20 @@ export async function listGames(playerId) {
 }
 
 /**
- * When a player starts or stops playing, notify other players by updating their game list
- * @param {string} gameId - the game this player starts or stops playing to.
+ * Updates game lists including a given player id. Usefull when updating a player's username.
+ * @param {string} playerId - the player id which is triggering the update.
  * @return {Promise<void>}
  */
-export async function notifyGamePlayers(gameId) {
-  const game = await repositories.games.getById(gameId)
-  if (game) {
-    gameListsUpdate$.next(game.playerIds)
+export async function notifyRelatedPlayers(playerId) {
+  const playerIds = new Set()
+  for (const game of await listGames(playerId)) {
+    for (const playerId of game.playerIds) {
+      playerIds.add(playerId)
+    }
+  }
+  playerIds.delete(playerId)
+  if (playerIds.size) {
+    gameListsUpdate$.next([...playerIds])
   }
 }
 

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -31,9 +31,9 @@ export async function upsertPlayer(userDetails) {
       delete userDetails.username
       userDetails.id = existing.id
     } else {
-      const { username, provider } = userDetails
+      const { username } = userDetails
       if (await isUsernameUsed(username)) {
-        userDetails.username = `${username} @${provider}`
+        userDetails.username = `${username}-${Math.floor(Math.random() * 1000)}`
       }
     }
   } else {

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -30,6 +30,11 @@ export async function upsertPlayer(userDetails) {
       delete userDetails.avatar
       delete userDetails.username
       userDetails.id = existing.id
+    } else {
+      const { username, provider } = userDetails
+      if (await isUsernameUsed(username)) {
+        userDetails.username = `${username} @${provider}`
+      }
     }
   } else {
     delete userDetails.provider

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -81,6 +81,22 @@ export async function searchPlayers(search, playerId, excludeCurrent = true) {
 }
 
 /**
+ * Indicates whether a given username is already used.
+ * This is case insensitive, accent insensitive, and does not considere non-letters (emojis).
+ * It can include a player id from the results.
+ * @param {string} username - tested username.
+ * @param {string} excludedId - id of excluded player.
+ * @returns {Promise<boolean>} whether this username is already in use, or not.
+ */
+export async function isUsernameUsed(username, excludedId) {
+  const { results } = await repositories.players.searchByUsername({
+    search: username,
+    exact: true
+  })
+  return results.filter(({ id }) => id !== excludedId).length > 0
+}
+
+/**
  * Records a player accepting terms of service.
  * @param {Player} player - the corresponding player.
  * @returns {Promise<Player>} the player, updates.

--- a/apps/server/tests/plugins/auth.test.js
+++ b/apps/server/tests/plugins/auth.test.js
@@ -17,7 +17,7 @@ vi.mock('../../src/services/auth/google.js', () => ({
   }
 }))
 vi.mock('../../src/services/players.js', () => ({
-  addPlayer: vi.fn()
+  upsertPlayer: vi.fn()
 }))
 
 describe('auth plugin', () => {
@@ -137,7 +137,7 @@ describe('auth plugin', () => {
           location,
           user
         })
-        services.addPlayer.mockResolvedValueOnce(player)
+        services.upsertPlayer.mockResolvedValueOnce(player)
         const response = await server.inject(
           `/auth/${name}/callback?code=${code}&state=${state}`
         )
@@ -154,11 +154,11 @@ describe('auth plugin', () => {
           state
         )
         expect(services[serviceName].authenticateUser).toHaveBeenCalledTimes(1)
-        expect(services.addPlayer).toHaveBeenCalledWith({
+        expect(services.upsertPlayer).toHaveBeenCalledWith({
           ...user,
           provider: name
         })
-        expect(services.addPlayer).toHaveBeenCalledTimes(1)
+        expect(services.upsertPlayer).toHaveBeenCalledTimes(1)
       })
 
       it(`returns an error when ${name} authentication fails`, async () => {
@@ -181,7 +181,7 @@ describe('auth plugin', () => {
           state
         )
         expect(services[serviceName].authenticateUser).toHaveBeenCalledTimes(1)
-        expect(services.addPlayer).not.toHaveBeenCalled()
+        expect(services.upsertPlayer).not.toHaveBeenCalled()
       })
     })
   })

--- a/apps/server/tests/repositories/players.test.js
+++ b/apps/server/tests/repositories/players.test.js
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker'
-import { describe, expect, it } from 'vitest'
 import { players } from '../../src/repositories/players.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
@@ -57,7 +56,7 @@ describe('given a connected repository and several players', () => {
       },
       { id: faker.datatype.uuid(), username: 'Agent Moebius' },
       { id: faker.datatype.uuid(), username: 'Agent' },
-      { id: faker.datatype.uuid(), username: 'Agent X' }
+      { id: faker.datatype.uuid(), username: 'AgentX' }
     ]
     await players.save(models)
   })
@@ -179,7 +178,7 @@ describe('given a connected repository and several players', () => {
           total: 3,
           from: 0,
           size: 10,
-          results: [models[7], models[9], models[8]]
+          results: [models[7], models[8], models[9]]
         })
       })
 
@@ -192,7 +191,7 @@ describe('given a connected repository and several players', () => {
         })
       })
 
-      it('returns players containing seed regardless od diacritics', async () => {
+      it('returns players containing seed regardless of diacritics', async () => {
         expect(await players.searchByUsername({ search: 'Adv' })).toEqual({
           total: 1,
           from: 0,
@@ -204,6 +203,17 @@ describe('given a connected repository and several players', () => {
           from: 0,
           size: 10,
           results: [models[5]]
+        })
+      })
+
+      it('returns exact results', async () => {
+        expect(
+          await players.searchByUsername({ search: 'agent', exact: true })
+        ).toEqual({
+          total: 1,
+          from: 0,
+          size: 10,
+          results: [models[8]]
         })
       })
 
@@ -223,7 +233,7 @@ describe('given a connected repository and several players', () => {
           total: 6,
           from: 2,
           size: 3,
-          results: [models[5], models[7], models[9]]
+          results: [models[5], models[7], models[8]]
         })
 
         expect(
@@ -232,7 +242,7 @@ describe('given a connected repository and several players', () => {
           total: 6,
           from: 4,
           size: 2,
-          results: [models[9], models[8]]
+          results: [models[8], models[9]]
         })
       })
 

--- a/apps/server/tests/services/auth/github.test.js
+++ b/apps/server/tests/services/auth/github.test.js
@@ -75,7 +75,8 @@ describe('Github authentication service', () => {
           login: faker.name.fullName(),
           avatar_url: faker.internet.avatar(),
           email: faker.internet.email(),
-          id: faker.datatype.number()
+          id: faker.datatype.number(),
+          name: faker.name.fullName()
         }
         const token = faker.datatype.uuid()
         githubMock
@@ -96,7 +97,8 @@ describe('Github authentication service', () => {
             username: user.login,
             avatar: user.avatar_url,
             email: user.email,
-            providerId: user.id
+            providerId: user.id,
+            fullName: user.name
           }
         })
         expect(accessTokenInvoked).toHaveBeenCalledWith({

--- a/apps/server/tests/services/auth/google.test.js
+++ b/apps/server/tests/services/auth/google.test.js
@@ -79,7 +79,8 @@ describe('Google authentication service', () => {
           given_name: faker.name.fullName(),
           picture: faker.internet.avatar(),
           email: faker.internet.email(),
-          sub: faker.datatype.uuid()
+          sub: faker.datatype.uuid(),
+          name: faker.name.fullName()
         }
         const token = signJWT(user)
         googleApiMock
@@ -96,7 +97,8 @@ describe('Google authentication service', () => {
             username: user.given_name,
             avatar: user.picture,
             email: user.email,
-            providerId: user.sub
+            providerId: user.sub,
+            fullName: user.name
           }
         })
         expect(accessTokenInvoked).toHaveBeenCalledWith({

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -3,6 +3,7 @@ import repositories from '../../src/repositories/index.js'
 import {
   acceptTerms,
   getPlayerById,
+  isUsernameUsed,
   searchPlayers,
   setPlaying,
   upsertPlayer
@@ -58,7 +59,7 @@ describe('given initialized repository', () => {
       })
     })
 
-    it.only('ignores id, avatar and username when updating with provider & providerId', async () => {
+    it('ignores id, avatar and username when updating with provider & providerId', async () => {
       const original = await repositories.players.save({
         username: faker.name.firstName(),
         email: faker.internet.email(),
@@ -224,6 +225,25 @@ describe('given initialized repository', () => {
         expect(await searchPlayers(null, players[0].id)).toEqual([])
         expect(await searchPlayers(' a ', players[0].id)).toEqual([])
         expect(await searchPlayers('a', players[0].id)).toEqual([])
+      })
+    })
+
+    describe('isUsernameUsed()', () => {
+      it('returns true for used value', async () => {
+        expect(await isUsernameUsed('adaptoid')).toBe(true)
+        expect(await isUsernameUsed('adversary')).toBe(true)
+      })
+
+      it('returns true for un-used value', async () => {
+        expect(await isUsernameUsed('adaptoi')).toBe(false)
+        expect(await isUsernameUsed('adversari')).toBe(false)
+      })
+
+      it('can exclude a given id', async () => {
+        expect(await isUsernameUsed('adaptoid', players[2].id)).toBe(false)
+        expect(await isUsernameUsed('adversary', faker.datatype.uuid())).toBe(
+          true
+        )
       })
     })
   })

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -59,6 +59,24 @@ describe('given initialized repository', () => {
       })
     })
 
+    it('checks username unicity when creating new account from provider', async () => {
+      const username = faker.name.fullName()
+      await repositories.players.save({ username })
+      const creation = {
+        providerId: faker.datatype.uuid(),
+        provider: 'oauth',
+        avatar: faker.internet.avatar(),
+        email: faker.internet.email(),
+        username
+      }
+      const created = await upsertPlayer(creation)
+      expect(created).toEqual({
+        ...creation,
+        username: `${username} @${creation.provider}`,
+        id: expect.any(String)
+      })
+    })
+
     it('ignores id, avatar and username when updating with provider & providerId', async () => {
       const original = await repositories.players.save({
         username: faker.name.firstName(),

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker'
+import { expect } from 'vitest'
 import repositories from '../../src/repositories/index.js'
 import {
   acceptTerms,
@@ -72,7 +73,7 @@ describe('given initialized repository', () => {
       const created = await upsertPlayer(creation)
       expect(created).toEqual({
         ...creation,
-        username: `${username} @${creation.provider}`,
+        username: expect.stringMatching(new RegExp(`^${username}-\\d+`)),
         id: expect.any(String)
       })
     })

--- a/apps/server/tests/test-utils.js
+++ b/apps/server/tests/test-utils.js
@@ -1,5 +1,6 @@
 import { createSigner } from 'fast-jwt'
 import Redis from 'ioredis'
+import { readFileSync, writeFileSync } from 'node:fs'
 import WebSocket from 'ws'
 
 /**
@@ -110,12 +111,22 @@ export function signToken(playerId, key) {
   return createSigner({ key })({ id: playerId })
 }
 
+const lastDBFile = '.last-db'
+
 /**
- * Returns an URL to a random database, between 15 and 1, on a Redis instance.
+ * Returns an URL a new Redis database, between 1 and 15.
  * @returns {string} url to the redis database.
  */
 export function getRedisTestUrl() {
-  return `redis://localhost:6379/${Math.floor(Math.random() * (15 - 1) + 1)}`
+  let lastDatabase = 0
+  try {
+    lastDatabase = parseInt(readFileSync(lastDBFile, 'utf-8'))
+  } catch {
+    lastDatabase = 0
+  }
+  lastDatabase = lastDatabase % 15 === 0 ? 1 : lastDatabase + 1
+  writeFileSync(lastDBFile, lastDatabase.toString())
+  return `redis://localhost:6379/${lastDatabase}`
 }
 
 /**

--- a/apps/server/tests/test-utils.js
+++ b/apps/server/tests/test-utils.js
@@ -124,5 +124,8 @@ export function getRedisTestUrl() {
  * @returns {Promise<void>} resolves when done.
  */
 export async function clearDatabase(databaseUrl) {
+  if (!databaseUrl) {
+    throw new Error('you forgot to specificy a database url')
+  }
   await new Redis(databaseUrl).flushdb()
 }

--- a/apps/web/src/components/GameLink.svelte
+++ b/apps/web/src/components/GameLink.svelte
@@ -9,8 +9,8 @@
 
   const dispatch = createEventDispatcher()
   const owned = game.players[0]?.id === playerId
-  const isSingle = game.players.length === 1
-  const peerNames = game.players
+  $: isSingle = game.players.length === 1
+  $: peerNames = game.players
     .filter(player => player && player.id !== playerId)
     .map(({ username }) => username)
 

--- a/apps/web/src/components/Input.svelte
+++ b/apps/web/src/components/Input.svelte
@@ -4,6 +4,7 @@
   export let placeholder = null
   export let value = ''
   export let ref = null
+  export let disabled = false
 
   const dispatch = createEventDispatcher()
 
@@ -15,11 +16,15 @@
 </script>
 
 <fieldset>
-  {#if placeholder}<legend class:has-value={!!value}>{placeholder}</legend>{/if}
+  {#if placeholder}<legend
+      class:has-value={!!value}
+      class:disabled={disabled === true}>{placeholder}</legend
+    >{/if}
   <input
     {...$$restProps}
     bind:value
     bind:this={ref}
+    {disabled}
     on:focus
     on:blur
     on:input
@@ -44,6 +49,10 @@
     &.has-value {
       @apply transform-gpu -translate-y-4 scale-75;
     }
+
+    &.disabled {
+      @apply text-$disabled;
+    }
   }
 
   input {
@@ -51,6 +60,9 @@
 
     &:focus {
       @apply outline-none border-$primary-light;
+    }
+    &:disabled {
+      @apply text-$disabled;
     }
   }
 </style>

--- a/apps/web/src/components/PlayerThumbnail.svelte
+++ b/apps/web/src/components/PlayerThumbnail.svelte
@@ -6,8 +6,9 @@
   export let screenPosition = null
   export let color = null
 
+  $: isShort = dimension < 60
   $: hasImage = player?.avatar
-  let caption = dimension < 60 ? abbreviate(player?.username) : player?.username
+  $: caption = isShort ? abbreviate(player?.username) : player?.username
 
   function formatVariables() {
     return [
@@ -15,7 +16,7 @@
       `--color: ${color}`,
       `--top: ${screenPosition?.y}px`,
       `--left: ${screenPosition?.x}px`,
-      `--border-width: ${dimension < 50 ? 0 : dimension < 100 ? 3 : 5}px`
+      `--border-width: ${isShort ? 0 : dimension < 100 ? 3 : 5}px`
     ].join('; ')
   }
 </script>
@@ -34,7 +35,7 @@
     on:load={() => (hasImage = true)}
   />
   {#if !hasImage}
-    <figcaption>{caption}</figcaption>
+    <figcaption class:abbreviated={isShort}>{caption}</figcaption>
   {/if}
 </figure>
 
@@ -64,6 +65,10 @@
 
   figcaption {
     @apply flex items-center justify-center p-1 text-$primary-lightest text-center;
+
+    &.abbreviated {
+      @apply whitespace-nowrap;
+    }
   }
 
   img {

--- a/apps/web/src/components/Progress.svelte
+++ b/apps/web/src/components/Progress.svelte
@@ -1,14 +1,29 @@
-<svg class="animate-spin" role="progressbar" viewBox="22 22 44 44">
-  <circle cx="44" cy="44" r="20.2" fill="none" stroke-width="3.6" />
+<script>
+  export let radius = 35
+</script>
+
+<svg
+  class="animate-spin"
+  role="progressbar"
+  viewBox="0 0 {radius * 4} {radius * 4}"
+  width={radius * 2}
+>
+  <circle
+    cx={radius * 2}
+    cy={radius * 2}
+    r={radius}
+    fill="none"
+    stroke-width={radius / 5.6}
+    stroke-dasharray="{radius * 4}px, {radius * 10}px"
+  />
 </svg>
 
 <style lang="postcss">
   svg {
-    @apply inline-block w-10 h-10 m-4;
+    @apply inline-block;
   }
 
   circle {
     @apply stroke-$primary stroke-offset-0;
-    stroke-dasharray: 80px, 200px;
   }
 </style>

--- a/apps/web/src/graphql/index.js
+++ b/apps/web/src/graphql/index.js
@@ -1,39 +1,4 @@
-import { listCatalog } from './catalog.graphql'
-import {
-  createGame,
-  deleteGame,
-  getGamePlayers,
-  invite,
-  listGames,
-  loadGame,
-  receiveGameListUpdates,
-  receiveGameUpdates,
-  saveGame
-} from './games.graphql'
-import {
-  acceptTerms,
-  getCurrentPlayer,
-  logIn,
-  searchPlayers
-} from './players.graphql'
-import { sendSignal, awaitSignal } from './signals.graphql'
-
-// jest transformers don't allow export all from graphql files
-export {
-  acceptTerms,
-  awaitSignal,
-  createGame,
-  deleteGame,
-  getCurrentPlayer,
-  getGamePlayers,
-  invite,
-  listCatalog,
-  listGames,
-  loadGame,
-  logIn,
-  receiveGameListUpdates,
-  receiveGameUpdates,
-  saveGame,
-  searchPlayers,
-  sendSignal
-}
+export * from './catalog.graphql'
+export * from './games.graphql'
+export * from './players.graphql'
+export * from './signals.graphql'

--- a/apps/web/src/graphql/players.graphql
+++ b/apps/web/src/graphql/players.graphql
@@ -42,3 +42,9 @@ mutation acceptTerms {
     termsAccepted
   }
 }
+
+mutation updateCurrentPlayer($username: String) {
+  updateCurrentPlayer(username: $username) {
+    ...player
+  }
+}

--- a/apps/web/src/locales/fr.yaml
+++ b/apps/web/src/locales/fr.yaml
@@ -22,7 +22,8 @@ actions:
 errors:
   login-failure: Pseudo ou mot de passe incorrect. Merci de réessayer.
   too-many-games: Vous avez déjà {count} parties en cours, vous ne pouvez pas en créer davantage.
-  restricted-game: Ce jeu n'est pas accessible
+  restricted-game: Ce jeu n'est pas accessible.
+  username-used: Ce pseudo est déjà utilisé, veillez en choisir un autre.
 # https://github.com/format-message/format-message/tree/master/packages/format-message#formatmessagesetupoptions
 formats:
   date:
@@ -55,7 +56,7 @@ labels:
   terms-accepted: J'ai lu et accepté les Conditions Générales d'Utilisation
   terms-intro: Ici, nous ne sommes pas des sauvages ! Pour profiter de Tabulous, merci d'approuver les conditions d'utilisation.
   terms-of-service: Mentions Légales & Conditions Générales d'Utilisation
-  username: "Nom d'affichage : "
+  username: 'Pseudo : '
 page-titles:
   accept-terms: Tabulous • Conditions Générales d'Utilisation
   account: Tabulous • Paramètres

--- a/apps/web/src/locales/fr.yaml
+++ b/apps/web/src/locales/fr.yaml
@@ -24,6 +24,7 @@ errors:
   too-many-games: Vous avez déjà {count} parties en cours, vous ne pouvez pas en créer davantage.
   restricted-game: Ce jeu n'est pas accessible.
   username-used: Ce pseudo est déjà utilisé, veillez en choisir un autre.
+  username-too-short: Votre pseudo doit avoir au moins 3 charactères.
 # https://github.com/format-message/format-message/tree/master/packages/format-message#formatmessagesetupoptions
 formats:
   date:

--- a/apps/web/src/routes/(auth)/account/+page.svelte
+++ b/apps/web/src/routes/(auth)/account/+page.svelte
@@ -19,14 +19,14 @@
   const saveSubscription = username$
     .pipe(
       tap(() => (usernameError = null)),
-      debounceTime(200),
+      debounceTime(500),
       switchMap(username => {
         isSaving = true
-        user.username = username
         return from(
           updateCurrentPlayer(username)
             // updates page data with new user details
             .then(invalidateAll)
+            .then(() => (user.username = username))
             .catch(error => (usernameError = error))
         ).pipe(finalize(() => (isSaving = false)))
       })

--- a/apps/web/src/routes/(auth)/game/new/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/new/+page.svelte
@@ -7,6 +7,7 @@
   import { Button } from '../../../../components'
   import { Header } from '../../../../connected-components'
   import { createGame } from '../../../../stores'
+  import { translateError } from '../../../../utils'
 
   /** @type {import('./$types').PageData} */
   export let data = {}
@@ -19,24 +20,12 @@
       try {
         goto(await createGame(gameName), { replaceState: true })
       } catch (err) {
-        error = translateError(err.message)
+        error = translateError(get(_), err)
       }
     } else {
       goto('/home')
     }
   })
-
-  function translateError(message) {
-    const translate = get(_)
-    if (/^Access to game/.test(message)) {
-      return translate('errors.restricted-game')
-    }
-    const match = message.match(/^You own (\d+) games/)
-    if (match) {
-      return translate('errors.too-many-games', { count: match[1] })
-    }
-    return null
-  }
 </script>
 
 <svelte:head>

--- a/apps/web/src/stores/players.js
+++ b/apps/web/src/stores/players.js
@@ -7,10 +7,9 @@ const logger = makeLogger('players')
 
 /**
  * Recovers previous session by calling server.
- * @async
  * @param {function} fetch - the fetch implementation used to initialize GraphQL client.
  * @param {string} bearer - the Bearer authorization value used to recover session.
- * @returns {object|null} the recovered session in case of success, or null.
+ * @returns {Promise<object|null>} the recovered session in case of success, or null.
  */
 export async function recoverSession(fetch, bearer) {
   let session = null
@@ -32,9 +31,9 @@ export async function recoverSession(fetch, bearer) {
 
 /**
  * Logs a player in with id/password method.
- * @async
  * @param {string} id - the authenticating player id.
  * @param {string} password - clear password.
+ * @returns {Promise<void>}
  * @throws {Error} when authentication was rejected
  */
 export async function logIn(id, password) {
@@ -50,7 +49,7 @@ export async function logIn(id, password) {
 
 /**
  * Navigates to the logout url which clear cookie and redirect to home page.
- * @async
+ * @returns {Promise<void>}
  */
 export async function logOut() {
   logger.info(`logging out`)
@@ -59,9 +58,8 @@ export async function logOut() {
 
 /**
  * Searches for player whom username contains the searched text.
- * @async
  * @param {string} search - searched text.
- * @returns {object[]} a list (possibly empty) of matching candidates.
+ * @returns {Promise<object[]>} a list (possibly empty) of matching candidates.
  */
 export async function searchPlayers(search) {
   logger.info({ search }, `searches for ${search}`)
@@ -70,9 +68,17 @@ export async function searchPlayers(search) {
 
 /**
  * Accept terms for the current player.
- * @async
- * @returns {object} the current player, updated.
+ * @returns {Promise<object>} the current player, updated.
  */
 export async function acceptTerms() {
   return runMutation(graphQL.acceptTerms)
+}
+
+/**
+ * Updates user details for the current player.
+ * @param {string} username - the desired username, if any.
+ * @returns {Promise<object>} the current player, updated.
+ */
+export async function updateCurrentPlayer(username) {
+  return runMutation(graphQL.updateCurrentPlayer, { username })
 }

--- a/apps/web/src/utils/string.js
+++ b/apps/web/src/utils/string.js
@@ -26,6 +26,8 @@ export function translateError(svelteIntl, error) {
     return svelteIntl('errors.restricted-game')
   } else if (/^Username already used/.test(message)) {
     return svelteIntl('errors.username-used')
+  } else if (/^Username too short/.test(message)) {
+    return svelteIntl('errors.username-too-short')
   }
   const match = message.match(/^You own (\d+) games/)
   if (match) {

--- a/apps/web/src/utils/string.js
+++ b/apps/web/src/utils/string.js
@@ -3,7 +3,33 @@
  * @param {string} value - abbreviated value.
  * @returns {string} value's initials.
  */
-export function abbreviate(value = '') {
-  const words = value.toUpperCase().split(/\s|-|_/)
-  return words.map(([letter]) => letter).join('')
+export function abbreviate(value) {
+  const words = (value || '').toUpperCase().split(/\s|-|_/)
+  return words
+    .map(([letter]) => letter)
+    .slice(0, 2)
+    .join('')
+}
+
+/**
+ * Translate errors from server into human-readable localized equivalent
+ * @param {(key: string, options: object) => string} formatMessage - svelte-intl's format message function.
+ * @param {Error} error - error to translate.
+ * @return {string|null} the translate error message, if any
+ */
+export function translateError(svelteIntl, error) {
+  const message = error?.message || error
+  if (!message) {
+    return null
+  }
+  if (/^Access to game/.test(message)) {
+    return svelteIntl('errors.restricted-game')
+  } else if (/^Username already used/.test(message)) {
+    return svelteIntl('errors.username-used')
+  }
+  const match = message.match(/^You own (\d+) games/)
+  if (match) {
+    return svelteIntl('errors.too-many-games', { count: match[1] })
+  }
+  return message
 }

--- a/apps/web/tests/components/Input.tools.svelte
+++ b/apps/web/tests/components/Input.tools.svelte
@@ -14,4 +14,8 @@
     props={{ placeholder: 'Please enter value', value: 'initial value' }}
   />
   <Tool name="No value" props={{ placeholder: 'Please enter value' }} />
+  <Tool
+    name="Disabled"
+    props={{ placeholder: 'Please enter value', disabled: true }}
+  />
 </ToolBox>

--- a/apps/web/tests/components/Progress.tools.svelte
+++ b/apps/web/tests/components/Progress.tools.svelte
@@ -3,4 +3,9 @@
   import { Progress } from '../../src/components'
 </script>
 
-<Tool component={Progress} name="Components/Progress" layout="centered" />
+<Tool
+  component={Progress}
+  name="Components/Progress"
+  layout="centered"
+  props={{ radius: 30 }}
+/>

--- a/apps/web/tests/components/__snapshots__/Input.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Input.tools.shot
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Disabled 1`] = `
+<fieldset
+  class="s-Fe6WNbR-55zp"
+>
+  <legend
+    class="s-Fe6WNbR-55zp disabled"
+  >
+    Please enter value
+  </legend>
+   
+  <input
+    class="s-Fe6WNbR-55zp"
+    disabled=""
+  />
+</fieldset>
+`;
+
 exports[`No value 1`] = `
 <fieldset
   class="s-Fe6WNbR-55zp"

--- a/apps/web/tests/components/__snapshots__/PlayerThumbnail.tools.shot
+++ b/apps/web/tests/components/__snapshots__/PlayerThumbnail.tools.shot
@@ -55,7 +55,7 @@ exports[`Positionned avatar 1`] = `
 exports[`Small text 1`] = `
 <figure
   class="s-engCJu8q-fNe"
-  style="--dimension: 50px; --color: null; --top: undefinedpx; --left: undefinedpx; --border-width: 3px"
+  style="--dimension: 50px; --color: null; --top: undefinedpx; --left: undefinedpx; --border-width: 0px"
 >
   <img
     alt="avatar for Joe le clodo"
@@ -65,9 +65,9 @@ exports[`Small text 1`] = `
   />
    
   <figcaption
-    class="s-engCJu8q-fNe"
+    class="s-engCJu8q-fNe abbreviated"
   >
-    JLC
+    JL
   </figcaption>
 </figure>
 `;

--- a/apps/web/tests/components/__snapshots__/Progress.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Progress.tools.shot
@@ -4,15 +4,17 @@ exports[`Components/Progress 1`] = `
 <svg
   class="animate-spin s-GSPH2LpcdUHQ"
   role="progressbar"
-  viewBox="22 22 44 44"
+  viewBox="0 0 120 120"
+  width="60"
 >
   <circle
     class="s-GSPH2LpcdUHQ"
-    cx="44"
-    cy="44"
+    cx="60"
+    cy="60"
     fill="none"
-    r="20.2"
-    stroke-width="3.6"
+    r="30"
+    stroke-dasharray="120px, 300px"
+    stroke-width="5.357142857142858"
   />
 </svg>
 `;

--- a/apps/web/tests/routes/(auth)/account/+page.test.js
+++ b/apps/web/tests/routes/(auth)/account/+page.test.js
@@ -30,7 +30,7 @@ describe('/account route', () => {
     expectEditable()
     expect(updateCurrentPlayer).not.toHaveBeenCalled()
     expect(invalidateAll).not.toHaveBeenCalled()
-    await sleep(250)
+    await sleep(550)
     expectEditable()
     expect(usernameInput).toHaveValue(username)
     expect(updateCurrentPlayer).toHaveBeenCalledWith(username)
@@ -49,7 +49,7 @@ describe('/account route', () => {
     await userEvent.type(usernameInput, `{Control>}A{/Control}${username}`)
 
     expectEditable()
-    await sleep(250)
+    await sleep(550)
     expectProgress()
     expect(invalidateAll).not.toHaveBeenCalled()
     await sleep(100)
@@ -66,7 +66,7 @@ describe('/account route', () => {
     render(html`<${AccountPage} data=${{ session: { player } }} />`)
     const usernameInput = screen.getByRole('textbox')
     await userEvent.type(usernameInput, `{Control>}A{/Control}${username}`)
-    await sleep(250)
+    await sleep(550)
     expectEditable()
     expect(screen.queryByText(error)).toBeInTheDocument()
     expect(invalidateAll).not.toHaveBeenCalled()
@@ -75,7 +75,7 @@ describe('/account route', () => {
       usernameInput,
       `{Control>}A{/Control}${player.username}`
     )
-    await sleep(250)
+    await sleep(550)
     expect(screen.queryByText(error)).not.toBeInTheDocument()
     expectEditable()
     expect(updateCurrentPlayer).toHaveBeenNthCalledWith(1, username)

--- a/apps/web/tests/routes/(auth)/account/+page.test.js
+++ b/apps/web/tests/routes/(auth)/account/+page.test.js
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/svelte'
+import userEvent from '@testing-library/user-event'
+import { faker } from '@faker-js/faker'
+import { invalidateAll } from '$app/navigation'
+import html from 'svelte-htm'
+import { updateCurrentPlayer } from '../../../../src/stores'
+import AccountPage from '../../../../src/routes/(auth)/account/+page.svelte'
+import { expect } from 'vitest'
+import { sleep, translate } from '../../../test-utils'
+
+vi.mock('../../../../src/stores')
+
+describe('/account route', () => {
+  const player = {
+    id: faker.datatype.uuid(),
+    username: 'Batman'
+  }
+
+  beforeEach(vi.resetAllMocks)
+
+  it('debounce input and saves username', async () => {
+    const username = 'Robin'
+    updateCurrentPlayer.mockResolvedValueOnce({ ...player, username })
+    render(html`<${AccountPage} data=${{ session: { player } }} />`)
+    const usernameInput = screen.getByRole('textbox')
+    expect(usernameInput).toHaveValue(player.username)
+    expect(updateCurrentPlayer).not.toHaveBeenCalled()
+
+    await userEvent.type(usernameInput, `{Control>}A{/Control}${username}`)
+    expectEditable()
+    expect(updateCurrentPlayer).not.toHaveBeenCalled()
+    expect(invalidateAll).not.toHaveBeenCalled()
+    await sleep(250)
+    expectEditable()
+    expect(usernameInput).toHaveValue(username)
+    expect(updateCurrentPlayer).toHaveBeenCalledWith(username)
+    expect(updateCurrentPlayer).toHaveBeenCalledTimes(1)
+    expect(invalidateAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('disable username input while saving', async () => {
+    const username = 'Robin'
+    updateCurrentPlayer.mockImplementation(async () => {
+      await sleep(100)
+      return { ...player, username }
+    })
+    render(html`<${AccountPage} data=${{ session: { player } }} />`)
+    const usernameInput = screen.getByRole('textbox')
+    await userEvent.type(usernameInput, `{Control>}A{/Control}${username}`)
+
+    expectEditable()
+    await sleep(250)
+    expectProgress()
+    expect(invalidateAll).not.toHaveBeenCalled()
+    await sleep(100)
+    expectEditable()
+    expect(invalidateAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('displays saving errors', async () => {
+    const username = 'Robin'
+    const error = translate('errors.username-used')
+    updateCurrentPlayer
+      .mockRejectedValueOnce(new Error('Username already used'))
+      .mockResolvedValueOnce(player)
+    render(html`<${AccountPage} data=${{ session: { player } }} />`)
+    const usernameInput = screen.getByRole('textbox')
+    await userEvent.type(usernameInput, `{Control>}A{/Control}${username}`)
+    await sleep(250)
+    expectEditable()
+    expect(screen.queryByText(error)).toBeInTheDocument()
+    expect(invalidateAll).not.toHaveBeenCalled()
+
+    await userEvent.type(
+      usernameInput,
+      `{Control>}A{/Control}${player.username}`
+    )
+    await sleep(250)
+    expect(screen.queryByText(error)).not.toBeInTheDocument()
+    expectEditable()
+    expect(updateCurrentPlayer).toHaveBeenNthCalledWith(1, username)
+    expect(updateCurrentPlayer).toHaveBeenNthCalledWith(2, player.username)
+    expect(updateCurrentPlayer).toHaveBeenCalledTimes(2)
+  })
+})
+
+function expectProgress() {
+  expect(screen.getByRole('textbox')).toBeDisabled()
+  expect(screen.queryByRole('progressbar')).toBeInTheDocument()
+}
+
+function expectEditable() {
+  expect(screen.getByRole('textbox')).toBeEnabled()
+  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+}

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
@@ -119,19 +119,28 @@ exports[`Manual account 1`] = `
         class="s-GQCXmK5OKySU"
         for="username"
       >
-        Nom d'affichage : 
+        Pseudo : 
       </label>
        
-      <fieldset
-        class="s-Fe6WNbR-55zp"
+      <span
+        class="with-progress s-GQCXmK5OKySU"
       >
-         
-        <input
+        <fieldset
           class="s-Fe6WNbR-55zp"
-          name="username"
+        >
+           
+          <input
+            class="s-Fe6WNbR-55zp"
+            name="username"
+          />
+        </fieldset>
+        <!--&lt;Input&gt;-->
+         
+        <span
+          class="s-GQCXmK5OKySU"
         />
-      </fieldset>
-      <!--&lt;Input&gt;-->
+         
+      </span>
        
       <span
         class="s-GQCXmK5OKySU"
@@ -277,19 +286,28 @@ exports[`OAuth account 1`] = `
         class="s-GQCXmK5OKySU"
         for="username"
       >
-        Nom d'affichage : 
+        Pseudo : 
       </label>
        
-      <fieldset
-        class="s-Fe6WNbR-55zp"
+      <span
+        class="with-progress s-GQCXmK5OKySU"
       >
-         
-        <input
+        <fieldset
           class="s-Fe6WNbR-55zp"
-          name="username"
+        >
+           
+          <input
+            class="s-Fe6WNbR-55zp"
+            name="username"
+          />
+        </fieldset>
+        <!--&lt;Input&gt;-->
+         
+        <span
+          class="s-GQCXmK5OKySU"
         />
-      </fieldset>
-      <!--&lt;Input&gt;-->
+         
+      </span>
        
       <span
         class="s-GQCXmK5OKySU"

--- a/apps/web/tests/routes/(auth)/game/new/+page.test.js
+++ b/apps/web/tests/routes/(auth)/game/new/+page.test.js
@@ -10,7 +10,7 @@ import { sleep } from '../../../../test-utils'
 
 vi.mock('../../../../../src/stores')
 
-describe('/login route', () => {
+describe('/game/new route', () => {
   const game = {
     id: faker.datatype.uuid(),
     name: faker.commerce.productMaterial()

--- a/apps/web/tests/routes/(auth)/game/new/__snapshots__/+page.test.js.snap
+++ b/apps/web/tests/routes/(auth)/game/new/__snapshots__/+page.test.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`/login route > displays error game is restricted 1`] = `
+exports[`/game/new route > displays error game is restricted 1`] = `
 <body>
   <div>
      
@@ -79,7 +79,7 @@ exports[`/login route > displays error game is restricted 1`] = `
         <p
           class="s-1rlJbZ_1rgK_"
         >
-          Ce jeu n'est pas accessible
+          Ce jeu n'est pas accessible.
         </p>
          
         <a
@@ -112,7 +112,7 @@ exports[`/login route > displays error game is restricted 1`] = `
 </body>
 `;
 
-exports[`/login route > displays error when too many games where created 1`] = `
+exports[`/game/new route > displays error when too many games where created 1`] = `
 <body>
   <div>
      

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -439,7 +439,7 @@ exports[`Authenticated 1`] = `
             />
              
             <figcaption
-              class="s-engCJu8q-fNe"
+              class="s-engCJu8q-fNe abbreviated"
             >
               JD
             </figcaption>

--- a/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
@@ -2346,7 +2346,7 @@ exports[`Connected 1`] = `
             />
              
             <figcaption
-              class="s-engCJu8q-fNe"
+              class="s-engCJu8q-fNe abbreviated"
             >
               JD
             </figcaption>

--- a/apps/web/tests/setup.js
+++ b/apps/web/tests/setup.js
@@ -12,7 +12,8 @@ vi.mock('$app/environment', () => ({ browser: true }))
 
 vi.mock('$app/navigation', () => {
   return {
-    goto: vi.fn()
+    goto: vi.fn(),
+    invalidateAll: vi.fn()
   }
 })
 

--- a/apps/web/tests/stores/players.test.js
+++ b/apps/web/tests/stores/players.test.js
@@ -6,7 +6,8 @@ import {
   logIn,
   logOut,
   recoverSession,
-  searchPlayers
+  searchPlayers,
+  updateCurrentPlayer
 } from '../../src/stores/players'
 import {
   initGraphQlClient,
@@ -114,6 +115,18 @@ describe('acceptTerms()', () => {
     runMutation.mockResolvedValueOnce(player)
     expect(await acceptTerms()).toEqual(player)
     expect(runMutation).toHaveBeenCalledWith(graphQL.acceptTerms)
+    expect(runMutation).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('updateCurrentPlayer()', () => {
+  it('returns player on success', async () => {
+    const username = faker.name.fullName()
+    runMutation.mockResolvedValueOnce(player)
+    expect(await updateCurrentPlayer(username)).toEqual(player)
+    expect(runMutation).toHaveBeenCalledWith(graphQL.updateCurrentPlayer, {
+      username
+    })
     expect(runMutation).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/utils/string.test.js
+++ b/apps/web/tests/utils/string.test.js
@@ -1,0 +1,85 @@
+import { get } from 'svelte/store'
+import { _ } from 'svelte-intl'
+import { abbreviate, translateError } from '../../src/utils'
+import { translate } from '../test-utils'
+
+describe('string utilities', () => {
+  describe('abbreviate()', () => {
+    it.each([
+      { title: 'handles no input', output: '' },
+      { title: 'handles null', input: null, output: '' },
+      { title: 'handles false', input: false, output: '' },
+      { title: 'handles empty input', input: '', output: '' },
+      {
+        title: 'returns words first letter, capitalized',
+        input: 'big daddy',
+        output: 'BD'
+      },
+      {
+        title: 'consider - as word separator',
+        input: 'Jean-baptiste',
+        output: 'JB'
+      },
+      {
+        title: 'consider _ as word separator',
+        input: 'lone_wolf',
+        output: 'LW'
+      },
+      {
+        title: 'handles digits',
+        input: 'little 41',
+        output: 'L4'
+      },
+      {
+        title: 'only returns frist 2 letters',
+        input: 'node package manager',
+        output: 'NP'
+      }
+    ])('$title', ({ input, output }) => {
+      expect(abbreviate(input)).toBe(output)
+    })
+  })
+
+  describe('translateError()', () => {
+    const formatMessage = get(_)
+
+    it('translates "restricted access" error', () => {
+      expect(
+        translateError(
+          formatMessage,
+          new Error('Access to game klondike is restricted')
+        )
+      ).toEqual(translate('errors.restricted-game'))
+    })
+
+    it('translates "too many owned games" error', () => {
+      expect(
+        translateError(
+          formatMessage,
+          new Error('You own 10 games, you can not create more')
+        )
+      ).toEqual(translate('errors.too-many-games', { count: 10 }))
+    })
+
+    it('translates "Username already used" error', () => {
+      expect(
+        translateError(formatMessage, new Error('Username already used'))
+      ).toEqual(translate('errors.username-used'))
+    })
+
+    it('consider string as error message', () => {
+      expect(
+        translateError(formatMessage, 'Access to game klondike is restricted')
+      ).toEqual(translate('errors.restricted-game'))
+    })
+
+    it('does not translate unknown error', () => {
+      const message = 'this error is not known'
+      expect(translateError(formatMessage, new Error(message))).toEqual(message)
+    })
+
+    it('returns null on missing input', () => {
+      expect(translateError(formatMessage)).toBeNull()
+    })
+  })
+})

--- a/apps/web/tests/utils/string.test.js
+++ b/apps/web/tests/utils/string.test.js
@@ -43,13 +43,14 @@ describe('string utilities', () => {
   describe('translateError()', () => {
     const formatMessage = get(_)
 
-    it('translates "restricted access" error', () => {
-      expect(
-        translateError(
-          formatMessage,
-          new Error('Access to game klondike is restricted')
-        )
-      ).toEqual(translate('errors.restricted-game'))
+    it.each([
+      { error: 'Access to game is restricted', key: 'errors.restricted-game' },
+      { error: 'Username already used', key: 'errors.username-used' },
+      { error: 'Username too short', key: 'errors.username-too-short' }
+    ])('translates "$error" error', ({ error, key }) => {
+      expect(translateError(formatMessage, new Error(error))).toEqual(
+        translate(key)
+      )
     })
 
     it('translates "too many owned games" error', () => {
@@ -59,12 +60,6 @@ describe('string utilities', () => {
           new Error('You own 10 games, you can not create more')
         )
       ).toEqual(translate('errors.too-many-games', { count: 10 }))
-    })
-
-    it('translates "Username already used" error', () => {
-      expect(
-        translateError(formatMessage, new Error('Username already used'))
-      ).toEqual(translate('errors.username-used'))
     })
 
     it('consider string as error message', () => {


### PR DESCRIPTION
### :book: What's in there?

Now that players can create their account, they need a way to tweak their username.
Username:
- must be unique
- must have at least 3 characters
- can have any letters (including accents), but no symbols, except `-` and `_`

Usernames created upon OAuth2 registration are guaranteed to be unique.
Changing one's username would trigger update to any connected peer that share at least one game with them.

Are included here:

- feat(server): adds mutation to update current player username and avatar, including sanitization and validations (unicity, allowed characters)
- feat(server): ensures username unicity when creating from oauth2 provider, and stores their original full name
- feat(web): saves player username upon editing, after 500ms inactivity, and displays potential errors
- chore(server): ensure consistent, different database used during tests
- chore(web): allows resizable progress component, disabled inputs

### :test_tube: How to test?

- Logs in with player A that has some games with another player(s).
- In a different browser, logs with some of these related players.
- Got to player A's account page, and change their username
   > other players' home page is immediately refreshed to display the latest username
- Clear player A's username
   > an error is displayed and the user name not changed (in header, or home page)
- Set player A's username to any other player's username
   > an error is displayed and the user name not changed (in header, or home page)

Finally, logs for the first time with a Github or Google account that has the same username than an existing user
   > the created account has a random numerical suffix

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
