### PR TITLE
fix(web): game engine bughunt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,27 @@
       }
   ```
 
+- tests/connected-components/InvitePlayerDialogue.test.js > InvitePlayerDialogue connected component > debounce searches
+
+```
+AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
+❯ tests/connected-components/InvitePlayerDialogue.test.js:56:27
+    54|     }
+    55|     expect(searchPlayers).toHaveBeenNthCalledWith(1, 'an')
+    56|     expect(searchPlayers).toHaveBeenNthCalledWith(2, 'anima')
+      |                           ^
+    57|     expect(searchPlayers).toHaveBeenCalledTimes(2)
+    58|   })
+
+  - Expected  - 1
+  + Received  + 1
+
+    Array [
+  -   "anima",
+  +   "anim",
+    ]
+```
+
 ## Refactor
 
 - graphQL: remove signal type and make signal optional
@@ -83,7 +104,6 @@
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players'hand
-- select multiple meshes in hand
 - shortcuts cheatsheet
 - peer notifications: joining, joined, left, error (stop waiting when navigating away)
 - hand support for quantifiable behavior

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -41,6 +41,7 @@ export async function upsertPlayer(userDetails) {
     delete userDetails.providerId
     delete userDetails.email
   }
+  userDetails.playing = false
   return repositories.players.save(userDetails)
 }
 

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -39,7 +39,8 @@ describe('given initialized repository', () => {
         id: expect.any(String),
         password,
         avatar,
-        username
+        username,
+        playing: false
       })
     })
 
@@ -50,7 +51,8 @@ describe('given initialized repository', () => {
       expect(await upsertPlayer({ username, id, avatar })).toEqual({
         id,
         avatar,
-        username
+        username,
+        playing: false
       })
     })
 
@@ -107,6 +109,7 @@ describe('given initialized repository', () => {
       }
       expect(await upsertPlayer(update)).toEqual({
         ...original,
+        playing: false,
         email: update.email
       })
     })

--- a/apps/web/.eslintrc.yml
+++ b/apps/web/.eslintrc.yml
@@ -1,0 +1,2 @@
+globals:
+  configureLoggers: true

--- a/apps/web/src/components/RadialMenu.svelte
+++ b/apps/web/src/components/RadialMenu.svelte
@@ -25,7 +25,7 @@
 
   $: left = typeof x === 'number' ? `${x}px` : x
   $: top = typeof y === 'number' ? `${y}px` : y
-  $: radius = 40 + 5 * items?.length
+  $: radius = 55 + 5 * items?.length
 
   function computeItemPosition({ i }) {
     const angle = (-2 * Math.PI * (items.length - i)) / items.length

--- a/apps/web/src/components/RadialMenu.svelte
+++ b/apps/web/src/components/RadialMenu.svelte
@@ -94,7 +94,7 @@
 
 <style lang="postcss">
   aside {
-    @apply absolute rounded-full border-2 flex items-center 
+    @apply absolute rounded-full border-2 flex items-center z-10
            justify-center border-$primary-light transform-gpu -translate-x-1/2 -translate-y-1/2;
     width: var(--size);
     height: var(--size);

--- a/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
@@ -68,9 +68,6 @@
         engine?.resize()
       }
     )
-    window.addEventListener('beforeunload', () => {
-      engine?.dispose()
-    })
   })
 
   onDestroy(() => {

--- a/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
@@ -68,6 +68,7 @@
         engine?.resize()
       }
     )
+    window.addEventListener('beforeunload', () => engine?.dispose())
   })
 
   onDestroy(() => {

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -166,6 +166,22 @@ describe('createEngine()', () => {
       expect(handManager.enabled).toBe(true)
     })
 
+    it('invokes observer before disposing', () => {
+      const ordering = []
+      const handleBeforeDispose = vi
+        .fn()
+        .mockImplementation(() => ordering.push('beforeDispose'))
+      const handleDispose = vi
+        .fn()
+        .mockImplementation(() => ordering.push('dispose'))
+      engine.onBeforeDisposeObservable.addOnce(handleBeforeDispose)
+      engine.onDisposeObservable.addOnce(handleDispose)
+      engine.dispose()
+      expect(handleBeforeDispose).toHaveBeenCalledTimes(1)
+      expect(handleDispose).toHaveBeenCalledTimes(1)
+      expect(ordering).toEqual(['beforeDispose', 'dispose'])
+    })
+
     describe('given some loaded meshes', () => {
       beforeEach(async () => {
         const duration = 200

--- a/apps/web/tests/components/__snapshots__/RadialMenu.tools.shot
+++ b/apps/web/tests/components/__snapshots__/RadialMenu.tools.shot
@@ -5,14 +5,14 @@ HTMLCollection [
   <aside
     class="s-rtlBPQxKceeD"
     role="menu"
-    style="left: 25%; top: 25%; --size:100px;"
+    style="left: 25%; top: 25%; --size:130px;"
   >
     <ul
       class="s-rtlBPQxKceeD"
     >
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_397341122_0 150ms linear 0ms 1 both;"
+        style="animation: __svelte_3505074470_0 150ms linear 0ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"
@@ -32,7 +32,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_2962324507_0 150ms linear 112.5ms 1 both;"
+        style="animation: __svelte_3890762829_0 150ms linear 112.5ms 1 both;"
       >
         <button
           class="secondary s-NMyTiX1zi6rz"
@@ -69,14 +69,14 @@ HTMLCollection [
   <aside
     class="s-rtlBPQxKceeD"
     role="menu"
-    style="left: 25%; top: 25%; --size:150px;"
+    style="left: 25%; top: 25%; --size:180px;"
   >
     <ul
       class="s-rtlBPQxKceeD"
     >
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_3871932778_0 150ms linear 0ms 1 both;"
+        style="animation: __svelte_3019659111_0 150ms linear 0ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"
@@ -96,7 +96,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_3040732129_0 150ms linear 112.5ms 1 both;"
+        style="animation: __svelte_1277330016_0 150ms linear 112.5ms 1 both;"
       >
         <button
           class="secondary s-NMyTiX1zi6rz"
@@ -116,7 +116,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_1023368731_0 150ms linear 225ms 1 both;"
+        style="animation: __svelte_2128706359_0 150ms linear 225ms 1 both;"
       >
         <button
           class="secondary s-NMyTiX1zi6rz"
@@ -136,7 +136,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_3264121526_0 150ms linear 337.5ms 1 both;"
+        style="animation: __svelte_4140758231_0 150ms linear 337.5ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"
@@ -156,7 +156,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_4053772584_0 150ms linear 450ms 1 both;"
+        style="animation: __svelte_63569755_0 150ms linear 450ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"
@@ -176,7 +176,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_756247263_0 150ms linear 562.5ms 1 both;"
+        style="animation: __svelte_4220652078_0 150ms linear 562.5ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"
@@ -196,7 +196,7 @@ HTMLCollection [
       
       <li
         class="s-rtlBPQxKceeD"
-        style="animation: __svelte_2867527063_0 150ms linear 675ms 1 both;"
+        style="animation: __svelte_2315107558_0 150ms linear 675ms 1 both;"
       >
         <button
           class="s-NMyTiX1zi6rz"

--- a/apps/web/tests/utils/logger.test.js
+++ b/apps/web/tests/utils/logger.test.js
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -62,5 +63,44 @@ describe('Logger', () => {
     expect(info).not.toHaveBeenCalledTimes(1)
     expect(warn).toHaveBeenCalledTimes(1)
     expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  describe('configureLoggers()', () => {
+    it('can change log level at runtime', () => {
+      const logger = makeLogger('flippable')
+      logger.debug(faker.lorem.words())
+      expect(log).not.toHaveBeenCalled()
+
+      expect(configureLoggers({ flippable: 'debug' })).toMatchObject({
+        flippable: 'debug'
+      })
+      const message = faker.lorem.words()
+      logger.debug(message)
+      expect(log).toHaveBeenCalledWith(message)
+      expect(log).toHaveBeenCalledTimes(1)
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('reports unknown logger', () => {
+      const logger = faker.commerce.productMaterial()
+
+      expect(configureLoggers({ [logger]: 'debug' })).not.toHaveProperty(
+        logger,
+        'debug'
+      )
+      expect(warn).toHaveBeenCalledWith(`ignoring unknown logger ${logger}`)
+    })
+
+    it('reports unknown level', () => {
+      const level = faker.commerce.productMaterial()
+
+      expect(configureLoggers({ anchorable: level })).not.toHaveProperty(
+        'anchorable',
+        level
+      )
+      expect(warn).toHaveBeenCalledWith(
+        `ignoring unknown level for anchorable: ${level}`
+      )
+    })
   })
 })


### PR DESCRIPTION
### :book: What's in there?

Let's pile here a couple fixes for the game engine.

Are included here:

- fix(server): can not create game after first connection 
- fix(web): meshes could disappear when leaving game page
- fix(web): mesh indicator can overlap with radial menu
- chore(web): exposes `configureLoggers()` function to change logger at runtime

### :test_tube: How to test?

1. disappearing meshes
   1. start a new 32-cards game.
   2. pick a card in hand (`p` shortcut)
   3. in less than 1s: play the card in hand (`p` shortcut), and close tab (`ctrl + w`) 
   4. re-open tab
      > the card has disappear

1. mesh indicator can overlap with radial menu
   1. start a new 32-cards game
   2. open mesh menu (right click)
   ![image](https://user-images.githubusercontent.com/186268/200191571-8d85c404-6de4-4983-afae-1045d3d00607.png)
 

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
