### PR TITLE
fix(web): can not snap individual items of the dragged selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,6 +96,10 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected, mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
+- bug: player indicator on anchor is offset on the right
+- show peers' selection
+- make peers' selection uncontrollable
+- detailable/stackable behavior: preview a stack of meshes
 - hide non-connected participants
 - loading spinner on game/new
 - updates avatar

--- a/apps/web/src/3d/behaviors/anchorable.js
+++ b/apps/web/src/3d/behaviors/anchorable.js
@@ -87,13 +87,17 @@ export class AnchorBehavior extends TargetBehavior {
     )
 
     this.moveObserver = moveManager.onMoveObservable.add(({ mesh }) => {
-      let moved = selectionManager.meshes.has(mesh)
-        ? selectionManager.meshes.has(this.mesh)
-          ? []
-          : [...selectionManager.meshes]
-        : [mesh]
-      for (const { id } of moved) {
-        this.unsnap(id)
+      // unsnap the moved mesh, unless:
+      // 1. it is not snapped!
+      // 2. it is moved together with the current mesh
+      if (
+        this.zoneBySnappedId.has(mesh?.id) &&
+        !(
+          selectionManager.meshes.has(mesh) &&
+          selectionManager.meshes.has(this.mesh)
+        )
+      ) {
+        this.unsnap(mesh.id)
       }
     })
 

--- a/apps/web/src/3d/managers/target.js
+++ b/apps/web/src/3d/managers/target.js
@@ -80,7 +80,7 @@ class TargetManager {
    */
   findPlayerZone(dragged, kind) {
     logger.debug(
-      { dragged, kind, b: this.behaviors },
+      { dragged, kind },
       `find drop zones for ${this.playerId} (${kind})`
     )
     const candidates = findCandidates(
@@ -103,7 +103,7 @@ class TargetManager {
    */
   findDropZone(dragged, kind) {
     logger.debug(
-      { dragged, kind, b: this.behaviors },
+      { dragged, kind },
       `find drop zones for ${dragged?.id} (${kind})`
     )
     const candidates = findCandidates(this, dragged, zone => {


### PR DESCRIPTION
### :book: What's in there?

It appeared that we can't snap individual items of a dragged selection:

[snap-selection.webm](https://user-images.githubusercontent.com/186268/200788786-e856c655-e684-4e62-bb09-147a03245f88.webm)


This is because the active selection is processed sequentially:
1. snap the first mesh, which notifies `moveManager.onMoveObservable` for this mesh
2. snap the second mesh, which notifies `moveManager.onMoveObservable`  for the second mesh.
   > this unsnap the first mesh, because it is already snapped, and because it is part of the active selection

- fix(web): can not snap individual items of the dragged selection

### :test_tube: How to reproduce?

1. start a new Klondike game
3. free some anchors
4. select several cards, which position mimics the free anchor positions
5. move the selection above the anchors
   > all anchors should have the green highlight indicating they will snap dragged meshes
6. drop the selection on the anchors
   > individual meshes should be snapped to the anchors: they will position exactly above the anchors, and the "link" feedback icon indicates they are snapped

[snap-selection-fixed.webm](https://user-images.githubusercontent.com/186268/200789363-144aed07-2697-4d20-b550-039ae3074e82.webm)


<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
