### PR TITLE
feat(web): introduces player own colors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,9 +92,9 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 
 ## UI
 
-- bug: no rules on game creation?
+- bug: can't type 'h' in invite dialogue (considered as shortcut)
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
-- bug: attached, unselected, mesh are not ignored during dragging
+- bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - show peers' selection
 - make peers' selection uncontrollable
@@ -102,7 +102,7 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - hide non-connected participants
 - loading spinner on game/new
 - updates avatar
-- is this right? given an active selection, when it anchrs with other items, then items are part of the selection
+- is this right? given an active selection, when it anchors with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url

--- a/TODO.md
+++ b/TODO.md
@@ -96,7 +96,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected, mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
-- bug: player indicator on anchor is offset on the right
 - show peers' selection
 - make peers' selection uncontrollable
 - detailable/stackable behavior: preview a stack of meshes

--- a/apps/games/klondike/logic/build.js
+++ b/apps/games/klondike/logic/build.js
@@ -44,7 +44,7 @@ function makeColumnSlots() {
         bagId,
         anchorId,
         count: 1,
-        flippable: row !== column ? { isFlipped: true } : undefined
+        flippable: { isFlipped: row !== column }
       })
     }
   }

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -10,6 +10,7 @@ type Game {
   messages: [Message]
   cameras: [CameraPosition]
   hands: [Hand]
+  preferences: [PlayerPreference]
   rulesBookPageCount: Int
   availableSeats: Int
   zoomSpec: ZoomSpec
@@ -160,6 +161,11 @@ type CameraPosition {
 type Hand {
   playerId: ID!
   meshes: [Mesh]!
+}
+
+type PlayerPreference {
+  playerId: ID!
+  color: String
 }
 
 type ZoomSpec {

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -97,6 +97,7 @@ export default {
      */
     updateCurrentPlayer: isAuthenticated(
       async (obj, { username, avatar }, { player }) => {
+        // https://en.wikipedia.org/wiki/Latin_script_in_Unicode
         const sanitizedUsername =
           username
             .match(/\p{sc=Latin}|\p{Number}|\p{Emoji}|-|_/giu)

--- a/apps/server/src/utils/collections.js
+++ b/apps/server/src/utils/collections.js
@@ -21,3 +21,16 @@ export function shuffle(source = [], iterations = 5) {
 
   return result
 }
+
+/**
+ * Pick a random value amongst candidates, ignoring some of the candidates.
+ * @param { any[]} candidates - possible candidates.
+ * @param {any[]} [ignored=[]] - ignored candidates.
+ * @returns {any} one of the candidates
+ */
+export function pickRandom(candidates = [], ignored = []) {
+  const actualCandidates = candidates.filter(
+    candidate => !ignored.includes(candidate)
+  )
+  return actualCandidates[Math.floor(Math.random() * actualCandidates.length)]
+}

--- a/apps/server/tests/services/games.test.js
+++ b/apps/server/tests/services/games.test.js
@@ -107,7 +107,8 @@ describe('given a subscription to game lists and an initialized repository', () 
         meshes: expect.any(Array),
         cameras: [],
         messages: [],
-        hands: []
+        hands: [],
+        preferences: [{ playerId: player.id, color: expect.any(String) }]
       })
       await setTimeout(50)
       expect(updates).toEqual([{ playerId: player.id, games: [game] }])
@@ -126,6 +127,7 @@ describe('given a subscription to game lists and an initialized repository', () 
         cameras: [],
         messages: [],
         hands: [{ playerId: player.id, meshes: [] }],
+        preferences: [{ playerId: player.id, color: expect.any(String) }],
         zoomSpec: { min: 5, max: 50 }
       })
       await setTimeout(50)
@@ -295,12 +297,16 @@ describe('given a subscription to game lists and an initialized repository', () 
         expect(updates).toHaveLength(0)
       })
 
-      it(`adds guest id to game's player id list and trigger list updates`, async () => {
+      it(`adds guest id to game's player id and preference lists, and trigger list updates`, async () => {
         const updated = await invite(game.id, peer.id, player.id)
         expect(updated).toEqual({
           ...game,
           availableSeats: 0,
-          playerIds: [player.id, peer.id]
+          playerIds: [player.id, peer.id],
+          preferences: [
+            { playerId: player.id, color: expect.any(String) },
+            { playerId: peer.id, color: expect.any(String) }
+          ]
         })
         // only once
         expect(await invite(game.id, peer.id, player.id)).toEqual(null)
@@ -351,11 +357,17 @@ describe('given a subscription to game lists and an initialized repository', () 
           ])
         ).map(({ id }) => id)
         let availableSeats = game.availableSeats
+        let playerIds
         for (let rank = 0; rank < guestIds.length; rank++) {
+          playerIds = [player.id, ...guestIds.slice(0, rank + 1)]
           expect(await invite(game.id, guestIds[rank], player.id)).toEqual({
             ...game,
             availableSeats: availableSeats - 1,
-            playerIds: [player.id, ...guestIds.slice(0, rank + 1)]
+            playerIds,
+            preferences: playerIds.map(playerId => ({
+              playerId,
+              color: expect.any(String)
+            }))
           })
           availableSeats--
         }

--- a/apps/server/tests/utils/collections.test.js
+++ b/apps/server/tests/utils/collections.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { shuffle } from '../../src/utils/index.js'
+import { pickRandom, shuffle } from '../../src/utils/index.js'
 
 describe('shuffle()', () => {
   it('randomizes elements of an array, leaving source array unmodified', () => {
@@ -23,5 +23,23 @@ describe('shuffle()', () => {
     expect(shuffle()).toEqual([])
     expect(shuffle(null)).toEqual([])
     expect(shuffle([])).toEqual([])
+  })
+})
+
+describe('pickRandom()', () => {
+  it('picks a random element with no ignored ones', () => {
+    const colors = ['red', 'green', 'blue']
+    for (let i = 0; i < 30; i++) {
+      const color = pickRandom(colors)
+      expect(color).toBeTruthy()
+      expect(colors).toContain(color)
+    }
+  })
+
+  it('does not pick any of the ignored ones', () => {
+    const colors = ['red', 'green', 'blue']
+    for (let i = 0; i < 30; i++) {
+      expect(pickRandom(colors, ['red', 'blue'])).toBe('green')
+    }
   })
 })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "autoprefixer": "^10.4.13",
     "chalk": "^5.1.2",
     "chalk-template": "^0.4.0",
+    "colorjs.io": "0.4.1-patch.1",
     "cookie": "^0.5.0",
     "dotenv": "^16.0.3",
     "earcut": "^2.2.4",

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -87,7 +87,6 @@ export function createEngine({
   })
   moveManager.init({ scene })
   controlManager.init({ scene, handScene })
-  selectionManager.init({ scene, handScene })
   indicatorManager.init({ scene })
 
   engine.start = () =>
@@ -113,9 +112,10 @@ export function createEngine({
    * @async
    * @param {object} game - serialized game data TODO.
    * @param {string} playerId - current player id (to determine their hand).
+   * @param {string} color - hexadecimal string of the current player color.
    * @param {boolean} initial? - set to true to show Babylon's loading UI while loading assets.
    */
-  engine.load = async (gameData, playerId, initial) => {
+  engine.load = async (gameData, playerId, color, initial) => {
     const game = removeNulls(gameData)
     cameraManager.adjustZoomLevels(game.zoomSpec)
     const handsEnabled = hasHandsEnabled(game)
@@ -123,7 +123,18 @@ export function createEngine({
       isLoading = true
       engine.onLoadingObservable.notifyObservers(isLoading)
       engine.displayLoadingUI()
-      targetManager.init({ scene, playerId })
+
+      selectionManager.init({
+        scene,
+        handScene,
+        color,
+        overlayAlpha: 0.2
+      })
+      targetManager.init({
+        scene,
+        playerId,
+        color
+      })
       materialManager.init(
         { gameAssetsUrl, scene, handScene: handsEnabled ? handScene : null },
         game

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -4,7 +4,7 @@ import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent.js'
 import { Engine } from '@babylonjs/core/Engines/engine.js'
 import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial.js'
 import { Texture } from '@babylonjs/core/Materials/Textures/texture.js'
-import { Color3, Color4 } from '@babylonjs/core/Maths/math.color.js'
+import { Color4 } from '@babylonjs/core/Maths/math.color.js'
 
 import { makeLogger } from '../../utils/logger'
 
@@ -63,8 +63,6 @@ class MaterialManager {
     mesh.material =
       materialByUrl.get(texture) ?? buildMaterials(this, texture, scene)
     mesh.receiveShadows = true
-    mesh.overlayColor = new Color3(0, 0.8, 0)
-    mesh.overlayAlpha = 0.2
   }
 
   /**

--- a/apps/web/src/components/GameHand.svelte
+++ b/apps/web/src/components/GameHand.svelte
@@ -8,6 +8,7 @@
   export let meshes = []
   export let node
   export let highlight = false
+  export let color = '#00ff00'
 
   let meshCount = meshes?.length ?? 0
   let minimized = meshCount === 0
@@ -23,7 +24,7 @@
   })
 </script>
 
-<aside class:highlight class:visible>
+<aside class:highlight class:visible style="--color: {color}">
   <MinimizableSection
     placement="bottom"
     tabs={[{ icon: 'front_hand', key: $_('shortcuts.hand') }]}
@@ -46,7 +47,7 @@
       border-top-width: 50px;
       border-image: radial-gradient(
           farthest-side ellipse at bottom center,
-          rgba(0, 255, 0, var(--tw-border-opacity)),
+          var(--color),
           rgba(0, 0, 0, 0)
         )
         100% 0 0 0;

--- a/apps/web/src/components/Indicators.svelte
+++ b/apps/web/src/components/Indicators.svelte
@@ -34,7 +34,7 @@
       content={computeLabel(player, rest)}
     />
   {:else}
-    <PlayerThumbnail {screenPosition} {player} />
+    <PlayerThumbnail {screenPosition} {player} color={player?.color} />
   {/if}
 {/each}
 {#each feedbacks as { screenPosition, id, player, ...rest } (id)}

--- a/apps/web/src/components/Label.svelte
+++ b/apps/web/src/components/Label.svelte
@@ -21,7 +21,7 @@
     clip-path: polygon(1rem 0%, 100% 0, 100% 100%, 1rem 100%, 0% 50%);
 
     &.centered {
-      @apply p-2 pt-1 pb-3 rounded-none -translate-y-16;
+      @apply p-2 pt-1 pb-3 rounded-none -translate-y-[100%] -translate-x-[50%];
       --offset: 85%;
       clip-path: polygon(
         0% 0%,

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -110,6 +110,10 @@ fragment fullGame on Game {
       ...mesh
     }
   }
+  preferences {
+    playerId
+    color
+  }
   rulesBookPageCount
   zoomSpec {
     min

--- a/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
@@ -33,6 +33,7 @@
     loadGame,
     longInputs,
     meshDetails,
+    playerColor,
     restoreCamera,
     saveCamera,
     sendToThread,
@@ -126,6 +127,7 @@
       visible={$handVisible}
       highlight={$highlightHand}
       meshes={$handMeshes}
+      color={$playerColor}
       bind:node={hand}
     />
     <MeshDetails mesh={$meshDetails} on:close={handleCloseDetails} />

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -420,7 +420,7 @@ export function attachInputs({
           fn === 'push' &&
           [...selectionManager.meshes].some(({ id }) => args[0] === id)
         ) {
-          selectionManager.selectById(meshId)
+          selectionManager.selectById([meshId])
         }
       }
     })
@@ -601,12 +601,12 @@ const menuActions = [
       badge: 'shortcuts.pop',
       onClick: async ({ detail } = {}) =>
         selectionManager.select(
-          ...(await triggerAction(
+          await triggerAction(
             mesh.metadata.stack[0],
             'pop',
             detail?.quantity,
             true
-          ))
+          )
         ),
       max: computesStackSize(mesh, params)
     })
@@ -620,9 +620,9 @@ const menuActions = [
       title: 'tooltips.decrement',
       badge: 'shortcuts.pop',
       onClick: async ({ detail } = {}) =>
-        selectionManager.select(
+        selectionManager.select([
           await triggerAction(mesh, 'decrement', detail?.quantity, true)
-        ),
+        ]),
       max: computesQuantity(mesh, params)
     })
   },

--- a/apps/web/src/utils/game.js
+++ b/apps/web/src/utils/game.js
@@ -1,0 +1,37 @@
+import Color from 'colorjs.io'
+
+/**
+ * Find game preferences of a given player.
+ * @param {object} game - game date, including preferences and players arrays.
+ * @param {string} playerId - desired player
+ * @returns {object} found preferences, or an empty object.
+ */
+export function findPlayerPreferences(game, playerId) {
+  // playerId is unused, and simply ommitted from returned preferences.
+  // eslint-disable-next-line no-unused-vars
+  const { playerId: _unused, ...preferences } =
+    game?.preferences?.find(preferences => preferences.playerId === playerId) ??
+    {}
+  return preferences
+}
+
+/**
+ * Returns player's color, or orange red.
+ * @param {object} game - game date, including preferences and players arrays.
+ * @param {string} playerId - desired player
+ * @returns {string} player's color.
+ */
+export function findPlayerColor(game, playerId) {
+  return findPlayerPreferences(game, playerId).color ?? '#ff4500'
+}
+
+/**
+ * Mutates a player color so it could be used for highlighting meshes and actions.
+ * @param {string} color - player's color as hexadecimal string.
+ * @returns {string} the highlighted hexadecimal color string.
+ */
+export function makeHighlightColor(color) {
+  return new Color(color)
+    .set('hsl.l', 50)
+    .toString({ format: 'hex', collapse: false })
+}

--- a/apps/web/src/utils/index.js
+++ b/apps/web/src/utils/index.js
@@ -1,6 +1,7 @@
 export * from './collections'
 export * from './dom'
 export * from './env'
+export * from './game'
 export * from './game-interaction'
 export * from './logger'
 export * from './math'

--- a/apps/web/tests/3d/behaviors/anchorable.test.js
+++ b/apps/web/tests/3d/behaviors/anchorable.test.js
@@ -736,7 +736,7 @@ describe('AnchorBehavior', () => {
       expectSnapped(mesh, meshes[0], 0)
       expectSnapped(mesh, meshes[1], 1)
 
-      selectionManager.select(mesh, meshes[0])
+      selectionManager.select([mesh, meshes[0]])
 
       moveManager.notifyMove(mesh)
 
@@ -791,14 +791,13 @@ describe('AnchorBehavior', () => {
       expectUnsnapped(mesh, snapped1, 0)
       expectUnsnapped(mesh, snapped2, 1)
 
-      selectionManager.select(...meshes)
+      selectionManager.select(meshes)
 
       await Promise.all([
         mesh.metadata.snap(snapped1.id, behavior.zones[0].mesh.id),
         mesh.metadata.snap(snapped2.id, behavior.zones[1].mesh.id)
       ])
 
-      console.log(behavior.state)
       expectSnapped(mesh, snapped1, 0)
       expectSnapped(mesh, snapped2, 1)
       expect(behavior.getSnappedIds()).toEqual([snapped1.id, snapped2.id])

--- a/apps/web/tests/3d/behaviors/quantifiable.test.js
+++ b/apps/web/tests/3d/behaviors/quantifiable.test.js
@@ -414,7 +414,7 @@ describe('QuantityBehavior', () => {
       const meshCount = scene.meshes.length
       behavior.fromState({ quantity })
       expectQuantity(mesh, quantity)
-      selectionManager.select(mesh)
+      selectionManager.select([mesh])
 
       moveManager.start(mesh, {})
 

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -54,6 +54,7 @@ describe('createEngine()', () => {
   describe('given an engine', () => {
     let displayLoadingUI
     let loadingObserver
+    const color = '#f0f'
     const receiveLoading = vi.fn()
 
     beforeEach(() => {
@@ -85,7 +86,7 @@ describe('createEngine()', () => {
         y: 0,
         z: -10
       }
-      await engine.load({ meshes: [mesh], hands: [] }, playerId, false)
+      await engine.load({ meshes: [mesh], hands: [] }, playerId, color, false)
       engine.scenes[1].onDataLoadedObservable.notifyObservers()
       expect(engine.scenes[1].getMeshById(mesh.id)).toBeDefined()
       expect(displayLoadingUI).not.toHaveBeenCalled()
@@ -134,7 +135,7 @@ describe('createEngine()', () => {
         z: -10
       }
       expect(engine.isLoading).toBe(false)
-      await engine.load({ meshes: [mesh], hands: [] }, playerId, true)
+      await engine.load({ meshes: [mesh], hands: [] }, playerId, color, true)
       expect(engine.isLoading).toBe(true)
       expect(receiveLoading).toHaveBeenCalledWith(true, expect.anything())
       expect(receiveLoading).toHaveBeenCalledTimes(1)
@@ -157,6 +158,7 @@ describe('createEngine()', () => {
           hands: [{ playerId, meshes: [{ id: 'box', shape: 'card' }] }]
         },
         playerId,
+        color,
         true
       )
       expect(engine.isLoading).toBe(true)
@@ -195,6 +197,7 @@ describe('createEngine()', () => {
             hands: []
           },
           playerId,
+          color,
           true
         )
         engine.start()

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -71,7 +71,7 @@ describe('HandManager', () => {
 
   beforeAll(() => {
     savedCameraPosition = camera.position.clone()
-    targetManager.init({ scene, playerId })
+    targetManager.init({ scene, playerId, color: '#00ff00' })
     indicatorManager.init({ scene })
     actionObserver = controlManager.onActionObservable.add(actionRecorded)
   })
@@ -533,7 +533,7 @@ describe('HandManager', () => {
 
       it('can re-order an entire selection of hand meshes', async () => {
         const [mesh1, mesh2, mesh3] = handCards
-        selectionManager.select(mesh2, mesh3)
+        selectionManager.select([mesh2, mesh3])
         const positions = getPositions(handCards)
         const z = positions[0][3]
         expect(draggableToHandReceived).not.toHaveBeenCalled()
@@ -725,7 +725,7 @@ describe('HandManager', () => {
       it('moves all selected meshes to hand by dragging', async () => {
         const [mesh1, mesh2, mesh3] = cards
         mesh3.metadata.push(mesh2.id)
-        selectionManager.select(mesh1, mesh2, mesh3)
+        selectionManager.select([mesh1, mesh2, mesh3])
         actionRecorded.mockReset()
         const stopDrag = vi.spyOn(inputManager, 'stopDrag')
 
@@ -1114,7 +1114,7 @@ describe('HandManager', () => {
 
         it(`moves multiple drawn meshes to player's drop zone`, async () => {
           const [mesh1, mesh2] = handCards
-          selectionManager.select(mesh1, mesh2)
+          selectionManager.select([mesh1, mesh2])
           mesh2.metadata.draw()
           await waitForLayout()
           expect(handScene.getMeshById(mesh1.id)?.id).toBeUndefined()
@@ -1232,7 +1232,7 @@ describe('HandManager', () => {
 
         it(`automatically moves multiple dragged meshes to player's drop zone`, async () => {
           const [mesh1, mesh2] = handCards
-          selectionManager.select(mesh1, mesh2)
+          selectionManager.select([mesh1, mesh2])
           inputManager.onDragObservable.notifyObservers({
             type: 'dragStart',
             mesh: mesh1,

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -59,7 +59,7 @@ describe('MoveManager', () => {
 
   beforeAll(() => {
     controlManager.init({ scene, handScene })
-    targetManager.init({ scene })
+    targetManager.init({ scene, color: '#0000ff' })
     indicatorManager.init({ scene })
     actionObserver = controlManager.onActionObservable.add(actionRecorded)
     moveObserver = manager.onMoveObservable.add(moveRecorded)
@@ -516,7 +516,7 @@ describe('MoveManager', () => {
         createMovable('box1', positions[0]),
         createMovable('box2', positions[1])
       ]
-      selectionManager.select(...meshes, moved)
+      selectionManager.select([...meshes, moved])
 
       manager.start(moved, { x: centerX, y: centerY })
       expect(manager.inProgress).toBe(true)
@@ -550,7 +550,7 @@ describe('MoveManager', () => {
         createMovable('box1', new Vector3(0, 5, 0)),
         createMovable('box2', new Vector3(-3, 0.5, -3))
       ]
-      selectionManager.select(...moved)
+      selectionManager.select(moved)
       targets = [
         createsTarget(1, new Vector3(3, 0, 0)),
         createsTarget(2, new Vector3(-1, 0, -4.1))
@@ -785,7 +785,7 @@ describe('MoveManager', () => {
 
       it('ignores unknow meshes', () => {
         selectionManager.clear()
-        selectionManager.select(...moved.slice(0, 2))
+        selectionManager.select(moved.slice(0, 2))
         manager.start(moved[1], { x: centerX, y: centerY })
         actionRecorded.mockReset()
 
@@ -878,7 +878,7 @@ describe('MoveManager', () => {
       ]
       moved[1].setParent(moved[0])
       moved[2].setParent(moved[1])
-      selectionManager.select(moved[0], moved[1])
+      selectionManager.select([moved[0], moved[1]])
     })
 
     describe('start()', () => {
@@ -1003,7 +1003,7 @@ describe('MoveManager', () => {
     })
 
     describe('given the entire stack is selected', () => {
-      beforeEach(() => selectionManager.select(...moved))
+      beforeEach(() => selectionManager.select(moved))
 
       it.each([
         { title: 'highest mesh', rank: 2 },

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -20,6 +20,8 @@ describe('TargetManager', () => {
     handScene = created.handScene
   })
 
+  beforeAll(() => selectionManager.init({ scene, color: '#FF00FF' }))
+
   beforeEach(() => {
     vi.resetAllMocks()
     drops = []
@@ -33,7 +35,9 @@ describe('TargetManager', () => {
   describe('init()', () => {
     it('sets scene', () => {
       const playerId = faker.datatype.uuid()
-      manager.init({ scene, playerId })
+      const color = faker.color.rgb()
+      const overlayAlpha = Math.random()
+      manager.init({ scene, playerId, color, overlayAlpha })
       expect(manager.scene).toEqual(scene)
       expect(manager.playerId).toEqual(playerId)
     })
@@ -41,8 +45,9 @@ describe('TargetManager', () => {
 
   describe('given an initialized manager', () => {
     const playerId = faker.datatype.uuid()
+    const color = '#00FF00'
 
-    beforeAll(() => manager.init({ scene, playerId }))
+    beforeAll(() => manager.init({ scene, playerId, color, overlayAlpha: 0.2 }))
 
     describe('registerTargetable()', () => {
       it('registers a mesh', () => {
@@ -109,7 +114,7 @@ describe('TargetManager', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(aboveZone1)
 
-        expectActiveZone(manager.findDropZone(mesh), zone1)
+        expectActiveZone(manager.findDropZone(mesh), zone1, color)
       })
 
       it('ignores an overlaping target when mesh is too far from center', () => {
@@ -136,7 +141,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select(zone1.targetable.mesh)
+        selectionManager.select([zone1.targetable.mesh])
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
@@ -175,14 +180,14 @@ describe('TargetManager', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(aboveZone3)
 
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone3)
+        expectActiveZone(manager.findDropZone(mesh, 'box'), zone3, color)
       })
 
       it('returns kind-less targets below mesh with kind', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(aboveZone1)
 
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone1)
+        expectActiveZone(manager.findDropZone(mesh, 'box'), zone1, color)
       })
 
       it('returns targets below mesh with matching kind', () => {
@@ -190,7 +195,7 @@ describe('TargetManager', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(aboveZone2)
 
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone2)
+        expectActiveZone(manager.findDropZone(mesh, 'box'), zone2, color)
       })
 
       it('returns highest target below mesh regardless of priorities', () => {
@@ -206,7 +211,7 @@ describe('TargetManager', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(new Vector3(0, 5, 0))
 
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4)
+        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4, color)
       })
 
       it('returns highest priority target below mesh', () => {
@@ -223,7 +228,7 @@ describe('TargetManager', () => {
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(new Vector3(0, 5, 0))
 
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4)
+        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4, color)
       })
 
       describe('clear()', () => {
@@ -313,7 +318,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select(zone1.targetable.mesh)
+        selectionManager.select([zone1.targetable.mesh])
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
@@ -331,7 +336,7 @@ describe('TargetManager', () => {
       })
 
       it('returns kind-less targets for provided kind', () => {
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone1)
+        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone1, color)
       })
 
       it('returns targets with matching kind', () => {
@@ -340,7 +345,7 @@ describe('TargetManager', () => {
           playerId,
           kinds: ['card', 'box']
         })
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3)
+        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3, color)
       })
 
       it('returns highest target', () => {
@@ -348,7 +353,7 @@ describe('TargetManager', () => {
           position: new Vector3(0, 1, 0),
           playerId
         })
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3)
+        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3, color)
       })
 
       describe('clear()', () => {
@@ -461,12 +466,13 @@ describe('TargetManager', () => {
     return behavior.addZone(target, { extent: 0.5, ...properties })
   }
 
-  function expectActiveZone(actual, expected) {
+  function expectActiveZone(actual, expected, color) {
     expect(actual.mesh.id).toEqual(expected.mesh.id)
     expectVisibility(actual, true)
+    expect(actual.mesh.material?.diffuseColor?.toHexString()).toEqual(color)
   }
 
   function expectVisibility(zone, isVisible) {
-    expect(zone.mesh.visibility).toEqual(isVisible ? 0.1 : 0)
+    expect(zone.mesh.visibility).toEqual(isVisible ? 1 : 0)
   }
 })

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -163,7 +163,7 @@ describe('Indicators store', () => {
           .getBehaviorByName(StackBehaviorName)
           .fromState({ stackIds: ['card5'] })
         expectIndicators()
-        selectionManager.select(card5, card3)
+        selectionManager.select([card5, card3])
         expectIndicators([
           {
             id: `${card5.id}.stack-size`,
@@ -211,7 +211,7 @@ describe('Indicators store', () => {
           .getBehaviorByName(StackBehaviorName)
           .fromState({ stackIds: ['card5'] })
         expectIndicators()
-        selectionManager.select(card5, card3, card2, card1, card4)
+        selectionManager.select([card5, card3, card2, card1, card4])
         expectIndicators([
           {
             id: `${card4.id}.stack-size`,

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -44,7 +44,7 @@ describe('Game interaction model', () => {
   configures3dTestEngine(created => {
     controlManager.init(created)
     moveManager.init(created)
-    selectionManager.init(created)
+    selectionManager.init({ ...created, color: '#ff0000' })
     engine = created.engine
   })
 
@@ -282,7 +282,7 @@ describe('Game interaction model', () => {
 
     it('can trigger all actions for a selected stack', async () => {
       const [, , mesh3, , mesh5, mesh6] = meshes
-      selectionManager.select(mesh3, mesh5, mesh6)
+      selectionManager.select([mesh3, mesh5, mesh6])
       const menuProps = computeMenuProps(mesh6)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -314,7 +314,7 @@ describe('Game interaction model', () => {
 
     it('can trigger all actions for a selected quantifiable', async () => {
       const [, , mesh3, , mesh5, mesh6, mesh7] = meshes
-      selectionManager.select(mesh5, mesh7, mesh6)
+      selectionManager.select([mesh5, mesh7, mesh6])
       const menuProps = computeMenuProps(mesh7)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -340,7 +340,7 @@ describe('Game interaction model', () => {
       mesh1.metadata.canPush.mockReturnValue(true)
       mesh2.metadata.stack = [mesh2]
       mesh2.metadata.canPush.mockReturnValue(true)
-      selectionManager.select(mesh1, mesh2)
+      selectionManager.select([mesh1, mesh2])
       const menuProps = computeMenuProps(mesh2)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -370,7 +370,7 @@ describe('Game interaction model', () => {
       mesh1.metadata.canPush.mockReturnValue(true)
       mesh2.metadata.stack = [mesh2]
       mesh2.metadata.canPush.mockReturnValue(true)
-      selectionManager.select(mesh1, mesh2)
+      selectionManager.select([mesh1, mesh2])
       const menuProps = computeMenuProps(mesh2, true)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -397,7 +397,7 @@ describe('Game interaction model', () => {
       mesh3.metadata.canPush.mockReturnValue(true)
       mesh5.metadata.canPush.mockReturnValue(true)
       mesh6.metadata.canPush.mockReturnValue(true)
-      selectionManager.select(mesh2, mesh3, mesh4, mesh5, mesh6)
+      selectionManager.select([mesh2, mesh3, mesh4, mesh5, mesh6])
       const menuProps = computeMenuProps(mesh2)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -440,7 +440,7 @@ describe('Game interaction model', () => {
       mesh7.metadata.canIncrement.mockReturnValue(true)
       mesh8.metadata.canIncrement.mockReturnValue(true)
       mesh9.metadata.canIncrement.mockReturnValue(true)
-      selectionManager.select(mesh7, mesh8, mesh9)
+      selectionManager.select([mesh7, mesh8, mesh9])
       const menuProps = computeMenuProps(mesh7)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -470,7 +470,7 @@ describe('Game interaction model', () => {
       const [mesh1, mesh2] = meshes
       mesh1.metadata.canPush.mockReturnValue(true)
       mesh2.metadata.canPush.mockReturnValue(false)
-      selectionManager.select(mesh1, mesh2)
+      selectionManager.select([mesh1, mesh2])
       const menuProps = computeMenuProps(mesh2)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -492,7 +492,7 @@ describe('Game interaction model', () => {
       const [, , , , , , mesh7, mesh8] = meshes
       mesh7.metadata.canIncrement.mockReturnValue(true)
       mesh8.metadata.canIncrement.mockReturnValue(false)
-      selectionManager.select(mesh7, mesh8)
+      selectionManager.select([mesh7, mesh8])
       const menuProps = computeMenuProps(mesh8)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -516,7 +516,7 @@ describe('Game interaction model', () => {
       mesh3.metadata.canPush.mockReturnValue(true)
       mesh5.metadata.canPush.mockReturnValue(true)
       mesh6.metadata.canPush.mockReturnValue(true)
-      selectionManager.select(mesh1, mesh3, mesh5, mesh6)
+      selectionManager.select([mesh1, mesh3, mesh5, mesh6])
       const menuProps = computeMenuProps(mesh5)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -568,7 +568,7 @@ describe('Game interaction model', () => {
 
     it('triggers action on mesh', () => {
       const [mesh1, mesh2, mesh3] = meshes
-      selectionManager.select(mesh1, mesh3)
+      selectionManager.select([mesh1, mesh3])
       triggerAction(mesh2, 'draw')
       expectMeshActions(mesh1)
       expectMeshActions(mesh2, 'draw')
@@ -577,7 +577,7 @@ describe('Game interaction model', () => {
 
     it('triggers action on selected mesh', () => {
       const [mesh1, mesh2, mesh3] = meshes
-      selectionManager.select(mesh1, mesh3)
+      selectionManager.select([mesh1, mesh3])
       triggerAction(mesh1, 'flip')
       expectMeshActions(mesh1, 'flip')
       expectMeshActions(mesh2)
@@ -604,7 +604,7 @@ describe('Game interaction model', () => {
 
     describe('given current selection', () => {
       beforeEach(() => {
-        selectionManager.select(meshes[0], meshes[2], meshes[4], meshes[5])
+        selectionManager.select([meshes[0], meshes[2], meshes[4], meshes[5]])
       })
 
       it('triggers action on the entire selection', () => {
@@ -971,7 +971,7 @@ describe('Game interaction model', () => {
 
     describe('given current selection', () => {
       beforeEach(() => {
-        selectionManager.select(meshes[0], meshes[2], meshes[4], meshes[5])
+        selectionManager.select([meshes[0], meshes[2], meshes[4], meshes[5]])
       })
 
       it('clears selection when double-tapping on the table', async () => {
@@ -1061,7 +1061,7 @@ describe('Game interaction model', () => {
       it('does not alter selection when pushing an unselected mesh', () => {
         const [mesh1, mesh2, mesh3] = meshes
         selectionManager.clear()
-        selectionManager.select(mesh1)
+        selectionManager.select([mesh1])
         controlManager.onActionObservable.notifyObservers({
           meshId: mesh3.id,
           fn: 'push',
@@ -1075,8 +1075,7 @@ describe('Game interaction model', () => {
       it('selects the entire stack when pushing a selected mesh', () => {
         const [mesh1, mesh2, mesh3, , mesh5, mesh6] = meshes
         selectionManager.clear()
-        selectionManager.select(mesh1)
-        selectionManager.select(mesh2)
+        selectionManager.select([mesh1, mesh2])
         mesh3.metadata.stack.push(mesh2)
         mesh2.metadata.stack = [...mesh3.metadata.stack]
         controlManager.onActionObservable.notifyObservers({
@@ -1159,7 +1158,7 @@ describe('Game interaction model', () => {
       it(`triggers increment on 'g' key`, () => {
         const [box1, , , , , , box7, box8] = meshes
         selectionManager.clear()
-        selectionManager.select(box7, box8, box1)
+        selectionManager.select([box7, box8, box1])
         box7.metadata.canIncrement.mockReturnValue(true)
         box8.metadata.canIncrement.mockReturnValue(true)
         inputManager.onKeyObservable.notifyObservers({
@@ -1193,7 +1192,7 @@ describe('Game interaction model', () => {
       it(`does not trigger decrement on 'u' key`, () => {
         const [box1, , , , , , box7, box8] = meshes
         selectionManager.clear()
-        selectionManager.select(box7, box8, box1)
+        selectionManager.select([box7, box8, box1])
         inputManager.onKeyObservable.notifyObservers({
           type: 'keyDown',
           meshes: [],

--- a/apps/web/tests/utils/game.test.js
+++ b/apps/web/tests/utils/game.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findPlayerColor,
+  findPlayerPreferences,
+  makeHighlightColor
+} from '../../src/utils/game'
+
+describe('Game utils', () => {
+  const game = {
+    preferences: [
+      { playerId: 'a', color: 'red' },
+      { playerId: 'b', color: 'blue' }
+    ]
+  }
+
+  describe('findPlayerPreferences()', () => {
+    it('returns an empty object on games with no preferences', async () => {
+      expect(findPlayerPreferences({}, 'whatever')).toEqual({})
+    })
+
+    it('returns an empty object for an unknown player', async () => {
+      expect(findPlayerPreferences(game, 'whatever')).toEqual({})
+    })
+
+    it('returns preferences of a given player, omitting the playerId', async () => {
+      expect(findPlayerPreferences(game, 'a')).toEqual({
+        ...game.preferences[0],
+        playerId: undefined
+      })
+      expect(findPlayerPreferences(game, 'b')).toEqual({
+        ...game.preferences[1],
+        playerId: undefined
+      })
+    })
+  })
+
+  describe('findPlayerColor()', () => {
+    const defaultColor = '#ff4500'
+
+    it('returns default color on games with no preferences', async () => {
+      expect(findPlayerColor({}, 'whatever')).toEqual(defaultColor)
+    })
+
+    it('returns default color for unknown player', async () => {
+      expect(findPlayerColor(game, 'whatever')).toEqual(defaultColor)
+    })
+
+    it('returns color of a given player', async () => {
+      expect(findPlayerColor(game, 'a')).toEqual('red')
+      expect(findPlayerColor(game, 'b')).toEqual('blue')
+    })
+  })
+
+  describe('makeHighlightColor()', () => {
+    it('does not change already light color', () => {
+      expect(makeHighlightColor('#ff0000')).toEqual('#ff0000')
+    })
+
+    it('returns an expanded hex color string', () => {
+      expect(makeHighlightColor('#f00')).toEqual('#ff0000')
+    })
+
+    it('increases color lightness', () => {
+      expect(makeHighlightColor('#123456')).toEqual('#2c80d3')
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,7 @@ importers:
       autoprefixer: ^10.4.13
       chalk: ^5.1.2
       chalk-template: ^0.4.0
+      colorjs.io: 0.4.1-patch.1
       cookie: ^0.5.0
       dotenv: ^16.0.3
       earcut: ^2.2.4
@@ -198,6 +199,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.18
       chalk: 5.1.2
       chalk-template: 0.4.0
+      colorjs.io: 0.4.1-patch.1
       cookie: 0.5.0
       dotenv: 16.0.3
       earcut: 2.2.4
@@ -728,7 +730,7 @@ packages:
     resolution: {integrity: sha512-69JnK7Cot+ktn7LD5TikP3b7psBPX55tYpQa8WSumt8r117PCa2zwHnImfBtRWYExreJlI48hr0WZaVrTBGj7w==}
     dependencies:
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       fast-uri: 2.1.0
 
   /@fastify/cors/8.1.1:
@@ -1471,10 +1473,8 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -1978,6 +1978,10 @@ packages:
 
   /colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+
+  /colorjs.io/0.4.1-patch.1:
+    resolution: {integrity: sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA==}
+    dev: true
 
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -2834,7 +2838,7 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.1.0
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       fast-deep-equal: 3.1.3
       fast-uri: 2.1.0
       rfdc: 1.3.0


### PR DESCRIPTION
### :book: What's in there?

In a multi-player game, distinct colors for players is a must-have. 
This PR introduce in-game, per-player preferences, including a color. This color is randomly assigned when joining game, and then used for target highlighting, selection box, selected meshes and hand overlay.

[player-color.webm](https://user-images.githubusercontent.com/186268/201375135-0835890a-7761-4a6a-9fc2-9e5a09d9db21.webm)


Eventually, it'll allow viewing other peers' selected meshes, but this will be in a different piece of work.

Are included here:

- fix(web): player indicator on anchor is not centered
- fix(klondike): visible cards on start can not be flipped
- feat(server): assigns a random color to joining players
- feat(server): includes player preferences into game data
- feat(web): target, selection box, selected meshes and hand overlay has per-player color

### :test_tube: How to test?

The best way to test is to have a game with other peers. Their pointers will have distinct colors.
Klondike is a good demonstration of the other features.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
