### PR TITLE
feat(web): displays peers selections

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,7 +92,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 
 ## UI
 
-- bug: can't type 'h' in invite dialogue (considered as shortcut)
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered

--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
-- show peers' selection
 - make peers' selection uncontrollable
 - detailable/stackable behavior: preview a stack of meshes
 - hide non-connected participants

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,14 +4,15 @@
   "description": "Tabulous utility Command Line Interface",
   "type": "module",
   "bin": {
-    "tabulous": "./src/index.mjs"
+    "tabulous": "./src/index.js"
   },
-  "main": "./src/index.mjs",
+  "main": "./src/index.js",
   "scripts": {
     "test": "vitest run --coverage",
     "test:dev": "vitest dev"
   },
   "dependencies": {
+    "@tabulous/cli": "^0.0.1",
     "@urql/core": "^3.0.5",
     "add": "^2.0.6",
     "ajv": "^8.11.0",

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env -S node --no-warnings
 // @ts-check
-// this file is using mjs for istanbul to stop complaining about import.meta
 
-import esMain from 'es-main'
+import chalkTemplate from 'chalk-template'
 import { config } from 'dotenv'
+import esMain from 'es-main'
 import camelCase from 'lodash.camelcase'
 import { resolve } from 'path'
 import { cwd } from 'process'
+
 import * as commands from './commands/index.js'
 import { commonArgSpec, parseArgv, shiftCommand } from './util/args.js'
-import chalkTemplate from 'chalk-template'
 import { printWithFormaters } from './util/formaters.js'
 
 /**
@@ -58,7 +58,7 @@ function printErrorAndHelp(err, command = commands) {
   console.log(command.help())
 }
 
-/* istanbul ignore next */
+/* c8 ignore next 3 */
 if (esMain(import.meta)) {
   main(process.argv.slice(2))
 }

--- a/apps/cli/tests/index.test.js
+++ b/apps/cli/tests/index.test.js
@@ -26,7 +26,7 @@ describe('Tabulous CLI', () => {
   let cli
 
   beforeAll(async () => {
-    cli = (await import('../src/index.mjs')).default
+    cli = (await import('../src/index.js')).default
   })
 
   it('prints help on unknown command', async () => {

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -133,17 +133,16 @@ import { canAccess } from './catalog.js'
 
 const maxOwnedGames = 6
 
-// https://colorkit.co/color-palette-generator/4297a0-ff4500-239646-9c3096-578c64-bf963d-e42256-83746e-2f435a/
+// https://colorkit.co/color-palette-generator/9c3096-ff4500-239646-2349a9-686467-bf963d-a82424-1a85a2/
 const colors = [
-  '#4297a0',
-  '#ff4500',
-  '#239646',
-  '#9c3096',
-  '#578c64',
-  '#bf963d',
-  '#e42256',
-  '#83746e',
-  '#2f435a'
+  '#9c3096', // violet
+  '#ff4500', // orange-foncé
+  '#239646', // vert
+  '#2349a9', // bleu
+  '#686467', // gris
+  '#bf963d', // marron
+  '#a82424', // rouge
+  '#1a85a2' // cyan
 ]
 
 const gameListsUpdate$ = new Subject()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,6 @@
     "autoprefixer": "^10.4.13",
     "chalk": "^5.1.2",
     "chalk-template": "^0.4.0",
-    "colorjs.io": "0.4.1-patch.1",
     "cookie": "^0.5.0",
     "dotenv": "^16.0.3",
     "earcut": "^2.2.4",

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -148,7 +148,7 @@ export function createEngine({
         handManager.init({ scene, handScene, overlay: hand })
       }
     }
-    selectionManager.updateColors(playerId, colorByPlayerId, 0.2)
+    selectionManager.updateColors(playerId, colorByPlayerId)
 
     await customShapeManager.init({ ...game, gameAssetsUrl })
     loadMeshes(scene, game.meshes)

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -25,7 +25,9 @@ class SelectionManager {
    * @property {Observable<Set<import('@babylonjs/core').Mesh>>} onSelectionObservable - emits when selection is modified.
    */
   constructor() {
-    this.meshes = new Set()
+    // we need to keep this set immutable, because it is referenced when adding to it
+    const meshes = new Set()
+    Object.defineProperty(this, 'meshes', { get: () => meshes })
     this.onSelectionObservable = new Observable()
     // private
     this.scene = null
@@ -34,6 +36,7 @@ class SelectionManager {
     this.skipNotify = false
     this.color = Color4.FromHexString('#00ff00')
     this.overlayColor = Color4.FromHexString('#00ff00ff')
+    this.selectionByPeerId = new Map()
   }
 
   /**
@@ -41,15 +44,28 @@ class SelectionManager {
    * @param {object} params - parameters, including:
    * @param {Scene} params.scene - scene attached to.
    * @param {Scene} params.handScene - scene for meshes in hand.
-   * @param {string} params.color - hexadecimal color string used for selection box, and selected mesh overlay.
-   * @param {number} params.overlayAlpha - [0-1] transparency used for selected mesh overlay
    */
-  init({ scene, handScene, color, overlayAlpha }) {
+  init({ scene, handScene }) {
     this.scene = scene
     this.handScene = handScene
-    this.color = Color4.FromHexString(color)
-    this.overlayColor = Color4.FromHexString(color)
-    this.overlayColor.a = overlayAlpha
+  }
+
+  /**
+   * Updates colors to reflect players in game.
+   * @param {string} playerId - current player id, to find selection box color.
+   * @param {Map<string, string>} colorByPlayerId - map of hexadecimal color strings used for selection box, and selected mesh overlay, by player id.
+   * @param {number} overlayAlpha - [0-1] transparency used for selected mesh overlay
+   */
+  updateColors(playerId, colorByPlayerId, overlayAlpha) {
+    this.overlayColorByPlayerId = new Map(
+      [...colorByPlayerId.entries()].map(([playerId, color]) => {
+        const overlayColor = Color4.FromHexString(color)
+        overlayColor.a = overlayAlpha
+        return [playerId, overlayColor]
+      })
+    )
+    this.overlayColor = this.overlayColorByPlayerId.get(playerId)
+    this.color = Color4.FromHexString(colorByPlayerId.get(playerId))
   }
 
   /**
@@ -117,9 +133,16 @@ class SelectionManager {
         this.skipNotify = true
         this.clear()
       }
+      const allSelections = [this.meshes, ...this.selectionByPeerId.values()]
       for (const mesh of scene.meshes) {
         if (mesh.isPickable && isContaining(box, mesh)) {
-          addToSelection(this, mesh, this.overlayColor)
+          addToSelection(
+            allSelections,
+            this.meshes,
+            this.onSelectionObservable,
+            mesh,
+            this.overlayColor
+          )
         }
       }
       reorderSelection(this)
@@ -136,19 +159,31 @@ class SelectionManager {
   selectWithinBox() {}
 
   /**
-   * Adds meshes into selection (if not already in)
+   * Adds meshes into selection (if not already in).
+   * Ignores mesh already selected by other players.
    * @param {Mesh[]} - array of meshes added to the active selection
    * @param {Color4} [overlayColor] - color used for mesh overlay, default to manager's color.
    */
   select(meshes, overlayColor) {
+    const allSelections = [this.meshes, ...this.selectionByPeerId.values()]
+    const oldSize = this.meshes.size
     for (const mesh of meshes) {
-      addToSelection(this, mesh, overlayColor ?? this.overlayColor)
+      addToSelection(
+        allSelections,
+        this.meshes,
+        this.onSelectionObservable,
+        mesh,
+        overlayColor ?? this.overlayColor
+      )
     }
-    reorderSelection(this)
+    if (this.meshes.size !== oldSize) {
+      reorderSelection(this)
+    }
   }
 
   /**
    * Adds meshes into selection (if not already in), by their ids.
+   * Ignores mesh already selected by other players.
    * @param {string[]} ids - selected mesh ids
    * @param {Color4} [overlayColor] - color used for mesh overlay, default to manager's color.
    */
@@ -191,6 +226,37 @@ class SelectionManager {
   getSelection(mesh) {
     return this.meshes.has(mesh) ? [...this.meshes] : [mesh]
   }
+
+  /**
+   * Applies selection from peer players: highlight selected meshes with the player's own color.
+   * Ignores meshes that are part of current player's selection.
+   * @async
+   * @param {string[]} meshIds - ids of selected meshes.
+   * @param {string} playerId - id of the peer selecting these meshes.s.
+   */
+  apply(meshIds, playerId) {
+    if (!playerId) {
+      return
+    }
+    const selection = this.selectionByPeerId.get(playerId) ?? new Set()
+    for (const mesh of selection) {
+      mesh.renderOverlay = false
+    }
+    selection.clear()
+    const allSelections = [this.meshes, ...this.selectionByPeerId.values()]
+    for (const id of meshIds) {
+      addToSelection(
+        allSelections,
+        selection,
+        null,
+        this.scene.getMeshById(id),
+        this.overlayColorByPlayerId.get(playerId)
+      )
+    }
+    if (selection.size) {
+      this.selectionByPeerId.set(playerId, selection)
+    }
+  }
 }
 
 /**
@@ -199,17 +265,17 @@ class SelectionManager {
  */
 export const selectionManager = new SelectionManager()
 
-function addToSelection(manager, mesh, color) {
-  if (mesh && !manager.meshes.has(mesh)) {
+function addToSelection(allSelections, selection, observable, mesh, color) {
+  if (mesh && !allSelections.find(selection => selection.has(mesh))) {
     for (const added of mesh.metadata?.stack ?? [mesh]) {
-      manager.meshes.add(added)
+      selection.add(added)
       added.overlayColor = color
       added.overlayAlpha = color.a
       added.renderOverlay = true
       added.onDisposeObservable.addOnce(() => {
-        manager.meshes.delete(added)
+        selection.delete(added)
         mesh.renderOverlay = false
-        manager.onSelectionObservable.notifyObservers(manager.meshes)
+        observable?.notifyObservers(selection)
       })
     }
   }
@@ -217,7 +283,11 @@ function addToSelection(manager, mesh, color) {
 
 function reorderSelection(manager) {
   // keep selection ordered from lowest to highest: it'll guarantuee gravity application
-  manager.meshes = new Set(sortByElevation(manager.meshes))
+  const ordered = sortByElevation(manager.meshes)
+  manager.meshes.clear()
+  for (const mesh of ordered) {
+    manager.meshes.add(mesh)
+  }
   manager.onSelectionObservable.notifyObservers(manager.meshes)
 }
 

--- a/apps/web/src/components/Dialogue.svelte
+++ b/apps/web/src/components/Dialogue.svelte
@@ -49,6 +49,7 @@
       class="backdrop"
       transition:fade
       on:click={close}
+      on:keydown|stopPropagation
       on:keyup={handleKeyup}
     >
       {#if closable}
@@ -56,7 +57,11 @@
           <Button icon="close" on:click={close} />
         </span>
       {/if}
-      <article role="dialog" on:click|stopPropagation on:keyup|stopPropagation>
+      <article
+        role="dialog"
+        on:click|stopPropagation
+        on:keyup|stopPropagation={handleKeyup}
+      >
         <Pane>
           <header class="heading">{title}</header>
           <div class="content">

--- a/apps/web/src/components/Dropdown.svelte
+++ b/apps/web/src/components/Dropdown.svelte
@@ -21,13 +21,6 @@
     text = value ? value.label || value : text
   }
 
-  function handleSelect({ detail }) {
-    if (value !== detail) {
-      value = detail
-      dispatch('select', value)
-    }
-  }
-
   function handleClick() {
     if (openOnClick) {
       handleArrowClick()
@@ -76,12 +69,12 @@
     {anchor}
     {open}
     {options}
-    {value}
     takesFocus
+    bind:value
     bind:ref={menu}
     on:close
+    on:select
     on:close={() => (open = false)}
-    on:select={handleSelect}
   />
 </span>
 

--- a/apps/web/src/components/Feedback.svelte
+++ b/apps/web/src/components/Feedback.svelte
@@ -1,17 +1,21 @@
 <script>
   export let icon = ''
   export let content = ''
+  export let color = '#ffffff'
   export let screenPosition = { x: 0, y: 0 }
 </script>
 
-<div style="top: {screenPosition.y}px; left: {screenPosition.x}px">
+<div
+  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}"
+>
   <span class="material-icons">{icon}</span>{content}
 </div>
 
 <style lang="postcss">
   div {
-    @apply absolute transform-gpu pointer-events-none opacity-0 z-20 text-xl text-$base-lightest font-extrabold;
+    @apply absolute transform-gpu pointer-events-none opacity-0 z-20 text-xl font-extrabold;
     animation: ping 1s cubic-bezier(0, 0, 0.2, 1.5);
+    color: var(--color);
     -webkit-text-stroke: 1px var(--primary);
   }
 

--- a/apps/web/src/components/Indicators.svelte
+++ b/apps/web/src/components/Indicators.svelte
@@ -32,6 +32,7 @@
       {screenPosition}
       centered={!!player}
       content={computeLabel(player, rest)}
+      color={player?.color}
     />
   {:else}
     <PlayerThumbnail {screenPosition} {player} color={player?.color} />
@@ -42,5 +43,6 @@
     {screenPosition}
     icon={computeFeedback(rest)}
     content={player?.username ?? ''}
+    color={player?.color}
   />
 {/each}

--- a/apps/web/src/components/Label.svelte
+++ b/apps/web/src/components/Label.svelte
@@ -1,12 +1,13 @@
 <script>
   export let content
   export let screenPosition = { x: 0, y: 0 }
+  export let color = '#7a7a7a'
   export let centered = false
 </script>
 
 <div
   class:centered
-  style="top: {screenPosition.y}px; left: {screenPosition.x}px"
+  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}"
 >
   {content}
 </div>
@@ -15,10 +16,10 @@
   div {
     @apply absolute transform-gpu -translate-y-1/2 -translate-x-1
             pointer-events-none 
-            font-bold text-lg text-$primary-lightest
-            bg-$primary opacity-85
+            text-lg text-$primary-lightest opacity-85
             py-1 pr-2 pl-5 rounded z-10;
     clip-path: polygon(1rem 0%, 100% 0, 100% 100%, 1rem 100%, 0% 50%);
+    background-color: var(--color);
 
     &.centered {
       @apply p-2 pt-1 pb-3 rounded-none -translate-y-[100%] -translate-x-[50%];

--- a/apps/web/src/components/Menu.svelte
+++ b/apps/web/src/components/Menu.svelte
@@ -35,8 +35,10 @@
   }
 
   function select(option) {
-    value = option
-    dispatch('select', value)
+    if (option !== value) {
+      value = option
+      dispatch('select', value)
+    }
     toggleVisibility()
   }
 

--- a/apps/web/src/connected-components/GameMenu.svelte
+++ b/apps/web/src/connected-components/GameMenu.svelte
@@ -19,14 +19,15 @@
   const inviteAction = 'invite'
   const fullscreenAction = 'fullscreen'
   const indicatorsAction = 'indicators'
+  let value = null
 
   $: options = [
-    { icon: 'home', label: $_('actions.quit-game'), value: homeAction },
+    { icon: 'home', label: $_('actions.quit-game'), id: homeAction },
     ($currentGame?.availableSeats ?? 0) > 0
       ? {
           icon: 'connect_without_contact',
           label: $_('actions.invite-player'),
-          value: inviteAction
+          id: inviteAction
         }
       : undefined,
     {
@@ -34,7 +35,7 @@
       label: $_(
         $isFullscreen ? 'actions.leave-fullscreen' : 'actions.enter-fullscreen'
       ),
-      value: fullscreenAction
+      id: fullscreenAction
     },
     {
       icon: $areIndicatorsVisible ? 'label_off' : 'label',
@@ -43,23 +44,24 @@
           ? 'actions.hide-indicators'
           : 'actions.show-indicators'
       ),
-      value: indicatorsAction
+      id: indicatorsAction
     }
   ].filter(Boolean)
 
-  function handleSelect({ detail: { value } }) {
-    if (value === homeAction) {
+  function handleSelect() {
+    if (value?.id === homeAction) {
       if ($isFullscreen) {
         toggleFullscreen()
       }
       goto('/home')
-    } else if (value === inviteAction) {
+    } else if (value?.id === inviteAction) {
       dispatch('invite-player')
-    } else if (value === fullscreenAction) {
+    } else if (value?.id === fullscreenAction) {
       toggleFullscreen()
-    } else if (value === indicatorsAction) {
+    } else if (value?.id === indicatorsAction) {
       toggleIndicators()
     }
+    setTimeout(() => (value = null), 0)
   }
 </script>
 
@@ -69,5 +71,6 @@
   withArrow={false}
   valueAsText={false}
   {options}
+  bind:value
   on:select={handleSelect}
 />

--- a/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/+page.svelte
@@ -113,10 +113,11 @@
   />
 </aside>
 <main>
-  <!-- svelte-ignore a11y-autofocus a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y-autofocus -->
   <div
     class="interaction"
     tabindex="0"
+    role="textbox"
     autofocus
     bind:this={interaction}
     on:contextmenu|preventDefault

--- a/apps/web/src/stores/game-engine.js
+++ b/apps/web/src/stores/game-engine.js
@@ -218,6 +218,15 @@ export function initEngine({
     // sends local action from main scene to other players
     localAction$.pipe(filter(({ fromHand }) => !fromHand)).subscribe(send),
 
+    // send local selection to other players
+    selectedMeshes$.subscribe(selected => {
+      const selectedIds = []
+      for (const { id } of selected) {
+        selectedIds.push(id)
+      }
+      send({ selectedIds })
+    }),
+
     // prunes unused peer pointers if needed
     connected.subscribe(players => {
       if (players) {

--- a/apps/web/src/stores/game-engine.js
+++ b/apps/web/src/stores/game-engine.js
@@ -21,12 +21,18 @@ import {
   selectionManager
 } from '../3d/managers'
 import { actionIds, attachInputs } from '../utils'
-import { connected, lastMessageReceived, send } from './peer-channels'
+import {
+  connected,
+  lastDisconnectedId,
+  lastMessageReceived,
+  send
+} from './peer-channels'
 
 const engine$ = new BehaviorSubject(null)
 const fps$ = new BehaviorSubject(0)
 const localAction$ = new Subject()
 const remoteAction$ = new Subject()
+const remoteSelection$ = new Subject()
 const pointer$ = new Subject()
 const meshDetails$ = new Subject()
 const actionMenuProps$ = new Subject()
@@ -55,6 +61,12 @@ export const fps = fps$.asObservable()
  * @type {Observable<import('../3d/managers').Action>}
  */
 export const action = merge(localAction$, remoteAction$)
+
+/**
+ * Emits selections received by peer players
+ * @type {Observable<object>} TODOC playerId: string selectedIds: string[]
+ */
+export const remoteSelection = remoteSelection$.asObservable()
 
 /**
  * Emits mesh details when the player requested them.
@@ -140,8 +152,8 @@ export const highlightHand = highlightHand$.asObservable()
  * - creating a table and a light
  * - saving initial camera position
  * - binding to user input event to implement game interaction
- * - sending current player actions and point moves with other peers
- * - receiving peer messages to apply their actions and move their pointers
+ * - sending current player actions, selection and pointer moves to other peers
+ * - receiving peer messages to apply their actions, show their selection and move their pointerspeers
  * Clears all subscriptions on engine disposal.
  *
  * @param {object} params - parameters, as defined by createEngin(), in addition to:
@@ -205,6 +217,8 @@ export function initEngine({
     lastMessageReceived.subscribe(({ data, playerId }) => {
       if (data?.pointer) {
         indicatorManager.registerPointerIndicator(playerId, data.pointer)
+      } else if (Array.isArray(data?.selectedIds)) {
+        applyRemoteSelection(data.selectedIds, playerId)
       } else if (data?.meshId) {
         if (data.fn === 'draw') {
           handManager.applyDraw(...data.args, playerId)
@@ -226,6 +240,11 @@ export function initEngine({
       }
       send({ selectedIds })
     }),
+
+    // removes peer selection when they leave
+    lastDisconnectedId.subscribe(playerId =>
+      applyRemoteSelection([], playerId)
+    ),
 
     // prunes unused peer pointers if needed
     connected.subscribe(players => {
@@ -255,6 +274,11 @@ export function initEngine({
 
   engine$.next(engine)
   return engine
+}
+
+function applyRemoteSelection(selectedIds, playerId) {
+  selectionManager.apply(selectedIds, playerId)
+  remoteSelection$.next({ selectedIds, playerId })
 }
 
 /**

--- a/apps/web/src/utils/game.js
+++ b/apps/web/src/utils/game.js
@@ -26,11 +26,25 @@ export function findPlayerColor(game, playerId) {
 }
 
 /**
- * Mutates a player color so it could be used for highlighting meshes and actions.
- * @param {string} color - player's color as hexadecimal string.
- * @returns {string} the highlighted hexadecimal color string.
+ * Builds a map of colors by player id, which can be used for highlighting meshes and actions.
+ * @param {object} game - game date, including preferences and players arrays.
+ * @returns {Map<string, string>} the highlighted hexadecimal color strings by their player ids.
  */
-export function makeHighlightColor(color) {
+export function buildPlayerColors(game) {
+  return new Map(
+    game.players.map(({ id }) => [
+      id,
+      makeHighlightColor(findPlayerColor(game, id))
+    ])
+  )
+}
+
+/**
+ * Turns a plain color into a more bright and contrasted color for highlight purposes
+ * @param {string} color - hexadecimal color strings.
+ * @returns {string} hexadecimal color string for a righter equivalent.
+ */
+function makeHighlightColor(color) {
   return new Color(color)
     .set('hsl.l', 50)
     .toString({ format: 'hex', collapse: false })

--- a/apps/web/src/utils/game.js
+++ b/apps/web/src/utils/game.js
@@ -1,5 +1,3 @@
-import Color from 'colorjs.io'
-
 /**
  * Find game preferences of a given player.
  * @param {object} game - game date, including preferences and players arrays.
@@ -31,21 +29,5 @@ export function findPlayerColor(game, playerId) {
  * @returns {Map<string, string>} the highlighted hexadecimal color strings by their player ids.
  */
 export function buildPlayerColors(game) {
-  return new Map(
-    game.players.map(({ id }) => [
-      id,
-      makeHighlightColor(findPlayerColor(game, id))
-    ])
-  )
-}
-
-/**
- * Turns a plain color into a more bright and contrasted color for highlight purposes
- * @param {string} color - hexadecimal color strings.
- * @returns {string} hexadecimal color string for a righter equivalent.
- */
-function makeHighlightColor(color) {
-  return new Color(color)
-    .set('hsl.l', 50)
-    .toString({ format: 'hex', collapse: false })
+  return new Map(game.players.map(({ id }) => [id, findPlayerColor(game, id)]))
 }

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -5,7 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createEngine } from '../../src/3d'
 import { DrawBehaviorName } from '../../src/3d/behaviors'
-import { handManager, inputManager } from '../../src/3d/managers'
+import {
+  handManager,
+  inputManager,
+  selectionManager,
+  targetManager
+} from '../../src/3d/managers'
 import { createCard } from '../../src/3d/meshes'
 import { sleep } from '../../src/utils'
 import { expectAnimationEnd } from '../test-utils'
@@ -13,10 +18,15 @@ import { expectAnimationEnd } from '../test-utils'
 describe('createEngine()', () => {
   let engine
   const playerId = faker.datatype.uuid()
+  const peerId1 = faker.datatype.uuid()
+  const peerId2 = faker.datatype.uuid()
   const canvas = document.createElement('canvas')
   const interaction = document.createElement('div')
   const hand = document.createElement('div')
   const inputInit = vi.spyOn(inputManager, 'init')
+  const updateColors = vi.spyOn(selectionManager, 'updateColors')
+  const applySelection = vi.spyOn(selectionManager, 'apply')
+  const targetInit = vi.spyOn(targetManager, 'init')
 
   beforeEach(() => {
     Logger.LogLevels = 0
@@ -48,13 +58,16 @@ describe('createEngine()', () => {
       })
     )
     expect(inputInit).toHaveBeenCalledTimes(1)
+    expect(targetInit).not.toHaveBeenCalled()
+    expect(updateColors).not.toHaveBeenCalled()
+    expect(applySelection).not.toHaveBeenCalled()
   })
   // TODO input manager stopAll()
 
   describe('given an engine', () => {
     let displayLoadingUI
     let loadingObserver
-    const color = '#f0f'
+    const colorByPlayerId = new Map([[playerId, '#f0f']])
     const receiveLoading = vi.fn()
 
     beforeEach(() => {
@@ -73,8 +86,12 @@ describe('createEngine()', () => {
 
     afterEach(() => engine.onLoadingObservable.remove(loadingObserver))
 
-    it('can load() game data', async () => {
-      expect(receiveLoading).not.toHaveBeenCalled()
+    it('can load() game data, including colors and peers selections', async () => {
+      const selections = [
+        { playerId: peerId2, selectedIds: ['4'] },
+        { playerId, selectedIds: ['1', '2'] },
+        { playerId: peerId1, selectedIds: ['3'] }
+      ]
       const mesh = {
         shape: 'card',
         depth: 0.2,
@@ -86,12 +103,31 @@ describe('createEngine()', () => {
         y: 0,
         z: -10
       }
-      await engine.load({ meshes: [mesh], hands: [] }, playerId, color, false)
+      await engine.load(
+        { meshes: [mesh], hands: [], selections },
+        playerId,
+        colorByPlayerId,
+        false
+      )
       engine.scenes[1].onDataLoadedObservable.notifyObservers()
       expect(engine.scenes[1].getMeshById(mesh.id)).toBeDefined()
       expect(displayLoadingUI).not.toHaveBeenCalled()
       expect(engine.isLoading).toBe(false)
-      expect(receiveLoading).toHaveBeenCalledTimes(0)
+      expect(updateColors).toHaveBeenCalledWith(playerId, colorByPlayerId, 0.2)
+      expect(updateColors).toHaveBeenCalledTimes(1)
+      expect(receiveLoading).not.toHaveBeenCalled()
+      expect(targetInit).not.toHaveBeenCalled()
+      expect(applySelection).toHaveBeenNthCalledWith(
+        1,
+        selections[0].selectedIds,
+        peerId2
+      )
+      expect(applySelection).toHaveBeenNthCalledWith(
+        2,
+        selections[2].selectedIds,
+        peerId1
+      )
+      expect(applySelection).toHaveBeenCalledTimes(2)
     })
 
     it('can serialize() game data', () => {
@@ -122,7 +158,11 @@ describe('createEngine()', () => {
     })
 
     it('displays loading UI on initial load only', async () => {
-      expect(receiveLoading).not.toHaveBeenCalled()
+      const selections = [
+        { playerId: peerId2, selectedIds: ['4'] },
+        { playerId, selectedIds: ['1', '2'] },
+        { playerId: peerId1, selectedIds: ['3'] }
+      ]
       const mesh = {
         shape: 'card',
         depth: 0.2,
@@ -135,7 +175,12 @@ describe('createEngine()', () => {
         z: -10
       }
       expect(engine.isLoading).toBe(false)
-      await engine.load({ meshes: [mesh], hands: [] }, playerId, color, true)
+      await engine.load(
+        { meshes: [mesh], hands: [], selections },
+        playerId,
+        colorByPlayerId,
+        true
+      )
       expect(engine.isLoading).toBe(true)
       expect(receiveLoading).toHaveBeenCalledWith(true, expect.anything())
       expect(receiveLoading).toHaveBeenCalledTimes(1)
@@ -148,6 +193,23 @@ describe('createEngine()', () => {
       expect(handManager.enabled).toBe(false)
       expect(receiveLoading).toHaveBeenCalledWith(false, expect.anything())
       expect(receiveLoading).toHaveBeenCalledTimes(1)
+      expect(targetInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: colorByPlayerId.get(playerId)
+        })
+      )
+      expect(targetInit).toHaveBeenCalledTimes(1)
+      expect(applySelection).toHaveBeenNthCalledWith(
+        1,
+        selections[0].selectedIds,
+        peerId2
+      )
+      expect(applySelection).toHaveBeenNthCalledWith(
+        2,
+        selections[2].selectedIds,
+        peerId1
+      )
+      expect(applySelection).toHaveBeenCalledTimes(2)
     })
 
     it('enables hand manager on initial load', async () => {
@@ -158,7 +220,7 @@ describe('createEngine()', () => {
           hands: [{ playerId, meshes: [{ id: 'box', shape: 'card' }] }]
         },
         playerId,
-        color,
+        colorByPlayerId,
         true
       )
       expect(engine.isLoading).toBe(true)
@@ -197,10 +259,11 @@ describe('createEngine()', () => {
             hands: []
           },
           playerId,
-          color,
+          colorByPlayerId,
           true
         )
         engine.start()
+        updateColors.mockReset()
       })
 
       it('removes drawn mesh from main scene', async () => {
@@ -212,6 +275,24 @@ describe('createEngine()', () => {
         const game = engine.serialize()
         expect(getIds(game.meshes)).toEqual(['card1', 'card3'])
         expect(getIds(game.handMeshes)).toEqual(['card2'])
+      })
+
+      it('updates color on subsequent loads', async () => {
+        const updatedColorByPlayerId = new Map([
+          ...colorByPlayerId.entries(),
+          [faker.datatype.uuid(), '#123456']
+        ])
+        await engine.load(
+          { ...engine.serialize(), hands: [] },
+          playerId,
+          updatedColorByPlayerId
+        )
+        expect(updateColors).toHaveBeenCalledWith(
+          playerId,
+          updatedColorByPlayerId,
+          0.2
+        )
+        expect(updateColors).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -113,7 +113,7 @@ describe('createEngine()', () => {
       expect(engine.scenes[1].getMeshById(mesh.id)).toBeDefined()
       expect(displayLoadingUI).not.toHaveBeenCalled()
       expect(engine.isLoading).toBe(false)
-      expect(updateColors).toHaveBeenCalledWith(playerId, colorByPlayerId, 0.2)
+      expect(updateColors).toHaveBeenCalledWith(playerId, colorByPlayerId)
       expect(updateColors).toHaveBeenCalledTimes(1)
       expect(receiveLoading).not.toHaveBeenCalled()
       expect(targetInit).not.toHaveBeenCalled()
@@ -289,8 +289,7 @@ describe('createEngine()', () => {
         )
         expect(updateColors).toHaveBeenCalledWith(
           playerId,
-          updatedColorByPlayerId,
-          0.2
+          updatedColorByPlayerId
         )
         expect(updateColors).toHaveBeenCalledTimes(1)
       })

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -68,7 +68,6 @@ describe('SelectionManager', () => {
       const overlayAlpha = 0.7
       manager.updateColors(playerId, colorByPlayerId, overlayAlpha)
       expect(manager.color?.toHexString()).toEqual(`${color}FF`)
-      expect(manager.overlayColor?.toHexString()).toEqual(`${color}B3`)
     })
   })
 
@@ -409,7 +408,8 @@ function expectSelection(expectedMeshes, color) {
 function expectSelected(mesh, color, isSelected = true, message) {
   if (isSelected) {
     expect(mesh.renderOverlay, message).toBe(true)
-    expect(mesh.overlayColor?.toHexString()).toBe(`${color}33`)
+    expect(mesh.edgesColor?.toHexString()).toBe(`${color}FF`)
+    expect(mesh.overlayColor?.toHexString()).toBe(`${color}FF`)
   } else {
     expect(mesh.renderOverlay, message).toBeFalsy()
   }

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -14,6 +14,15 @@ describe('SelectionManager', () => {
   let scene
   let handScene
   const selectionChanged = vi.fn()
+  const playerId = 'player'
+  const peer1 = {
+    id: 'peer1',
+    color: faker.color.rgb().toUpperCase()
+  }
+  const peer2 = {
+    id: 'peer2',
+    color: faker.color.rgb().toUpperCase()
+  }
 
   configures3dTestEngine(created => {
     scene = created.scene
@@ -41,261 +50,367 @@ describe('SelectionManager', () => {
     })
   })
 
-  describe('selectWithinBox()', () => {
-    it('does nothing without init', () => {
-      manager.selectWithinBox()
-      expect(selectionChanged).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('select()', () => {
-    it('adds meshes to selection', () => {
-      const mesh = CreateBox('box1', {})
-      manager.select([mesh])
-      expect(manager.meshes.has(mesh)).toBe(true)
-      expect(manager.meshes.size).toBe(1)
-      expectSelected(mesh)
-      expect(selectionChanged).toHaveBeenCalledTimes(1)
-      expect(selectionChanged.mock.calls[0][0].has(mesh)).toBe(true)
-      expect(selectionChanged.mock.calls[0][0].size).toBe(1)
-    })
-
-    it('adds multiple meshes to selection', () => {
-      const mesh1 = CreateBox('box1', {})
-      const mesh2 = CreateBox('box2', {})
-      manager.select([mesh1, mesh2])
-      expect(manager.meshes.has(mesh1)).toBe(true)
-      expect(manager.meshes.has(mesh2)).toBe(true)
-      expect(manager.meshes.size).toBe(2)
-      expectSelected(mesh1)
-      expectSelected(mesh2)
-      expect(selectionChanged).toHaveBeenCalledTimes(1)
-    })
-
-    it('adds an entire stack to selection', () => {
-      const mesh1 = CreateBox('box1', {})
-      const mesh2 = CreateBox('box2', {})
-      mesh1.addBehavior(new StackBehavior({ stackIds: [mesh2.id] }))
-      manager.select([mesh1])
-      expect(manager.meshes.has(mesh1)).toBe(true)
-      expect(manager.meshes.has(mesh2)).toBe(true)
-      expect(manager.meshes.size).toBe(2)
-      expectSelected(mesh1)
-      expectSelected(mesh2)
-      expect(selectionChanged).toHaveBeenCalledTimes(1)
-    })
-
-    it('reorders selection based on elevation', () => {
-      const mesh1 = CreateBox('box1', {})
-      mesh1.setAbsolutePosition(new Vector3(0, 5, 0))
-      manager.select([mesh1])
-      expectSelection([mesh1])
-
-      const mesh2 = CreateBox('box2', {})
-      mesh2.setAbsolutePosition(new Vector3(0, -2, 0))
-      manager.select([mesh2])
-      expectSelection([mesh2, mesh1])
-
-      const mesh3 = CreateBox('box3', {})
-      mesh3.setAbsolutePosition(new Vector3(0, 7, 0))
-      manager.select([mesh3])
-      expectSelection([mesh2, mesh1, mesh3])
-
-      const mesh4 = CreateBox('box4', {})
-      mesh4.setAbsolutePosition(new Vector3(0, 2, 0))
-      manager.select([mesh4])
-      expectSelection([mesh2, mesh4, mesh1, mesh3])
-
-      expect(selectionChanged).toHaveBeenCalledTimes(4)
-      expect(selectionChanged.mock.calls[3][0].has(mesh1)).toBe(true)
-      expect(selectionChanged.mock.calls[3][0].has(mesh2)).toBe(true)
-      expect(selectionChanged.mock.calls[3][0].has(mesh3)).toBe(true)
-      expect(selectionChanged.mock.calls[3][0].has(mesh4)).toBe(true)
-      expect(selectionChanged.mock.calls[3][0].size).toBe(4)
-    })
-  })
-
-  describe('given some selected meshes', () => {
-    let meshes
-
-    beforeEach(() => {
-      meshes = ['box1', 'box2', 'box3'].map(id => {
-        const mesh = CreateBox(id, {})
-        return mesh
-      })
-      manager.select(meshes)
-      selectionChanged.mockReset()
-    })
-
-    it('automatically removes disposed meshes from selection', () => {
-      const [mesh1, mesh2, mesh3] = meshes
-      mesh1.dispose()
-      mesh2.dispose()
-      expect(manager.meshes.size).toBe(1)
-      expectSelected(mesh1, false)
-      expectSelected(mesh2, false)
-      expectSelected(mesh3, true)
-      expect(selectionChanged).toHaveBeenCalledTimes(2)
-    })
-
-    describe('select()', () => {
-      it('does not add the same mesh twice', () => {
-        manager.select([meshes[0]])
-        expect(manager.meshes.has(meshes[0])).toBe(true)
-        expect(manager.meshes.size).toBe(3)
-        expectSelected(meshes[0])
-        expect(selectionChanged).toHaveBeenCalledTimes(1)
-      })
-    })
-
-    describe('getSelection()', () => {
-      it('returns entire selection when it contains provided mesh', () => {
-        expectMeshes(manager.getSelection(meshes[0]), meshes)
-      })
-
-      it('returns provided mesh if it not selected', () => {
-        manager.clear()
-        manager.select([meshes[1], meshes[2]])
-        expectMeshes(manager.getSelection(meshes[0]), [meshes[0]])
-      })
-    })
-
-    describe('clear()', () => {
-      it('removes all meshes from selection', () => {
-        manager.clear()
-        expect(manager.meshes.size).toBe(0)
-        expectSelected(meshes[0], false)
-        expectSelected(meshes[1], false)
-        expect(selectionChanged).toHaveBeenCalledTimes(1)
-        expect(selectionChanged.mock.calls[0][0].size).toBe(0)
-      })
-
-      it('does not notify listener when clearing an empty selection', () => {
-        manager.clear()
-        expect(manager.meshes.size).toBe(0)
-        selectionChanged.mockReset()
-
-        manager.clear()
-        expect(manager.meshes.size).toBe(0)
-        expect(selectionChanged).not.toHaveBeenCalled()
-      })
-    })
-  })
-
   describe('init()', () => {
     it('assigns scenes', () => {
-      const color = faker.color.rgb().toUpperCase()
-      const overlayAlpha = 0.7
-      manager.init({ scene, handScene, color, overlayAlpha })
+      manager.init({ scene, handScene })
       expect(manager.scene).toEqual(scene)
       expect(manager.handScene).toEqual(handScene)
+    })
+  })
+
+  describe('updateColors()', () => {
+    it('assigns overlay and main colors', () => {
+      const color = faker.color.rgb().toUpperCase()
+      const colorByPlayerId = new Map([
+        [playerId, color],
+        [peer1.id, peer1.color]
+      ])
+      const overlayAlpha = 0.7
+      manager.updateColors(playerId, colorByPlayerId, overlayAlpha)
       expect(manager.color?.toHexString()).toEqual(`${color}FF`)
       expect(manager.overlayColor?.toHexString()).toEqual(`${color}B3`)
     })
   })
 
-  describe('given some meshes', () => {
-    let meshes
+  describe('given initialized', () => {
+    const colorByPlayerId = new Map([
+      [playerId, '#0000FF'],
+      [peer1.id, peer1.color],
+      [peer2.id, peer2.color]
+    ])
 
-    beforeAll(() =>
-      manager.init({ scene, handScene, color: '#0000ff', overlayAlpha: 0.3 })
-    )
+    beforeAll(() => {
+      manager.init({ scene, handScene })
+      manager.updateColors(playerId, colorByPlayerId, 0.2)
+    })
 
-    beforeEach(() => {
-      meshes = [
-        { id: 'box1', position: new Vector3(1, 1, 2), scene },
-        { id: 'box2', position: new Vector3(0, 0, 0), scene },
-        { id: 'box3', position: new Vector3(-5, -2, -2), scene },
-        { id: 'box4', position: new Vector3(5, 5, 5), scene },
-        { id: 'box5', position: new Vector3(10, 0, 0), scene },
-        { id: 'box6', position: new Vector3(10, 0, -10), scene: handScene },
-        { id: 'box7', position: new Vector3(0, 0, -10), scene: handScene },
-        { id: 'box8', position: new Vector3(-10, 0, -10), scene: handScene }
-      ].map(({ id, position, scene }) => {
-        const mesh = CreateBox(id, {}, scene)
-        mesh.setAbsolutePosition(position)
-        return mesh
+    describe('selectWithinBox()', () => {
+      it('does nothing without init', () => {
+        manager.selectWithinBox()
+        expect(selectionChanged).not.toHaveBeenCalled()
       })
     })
 
-    describe('selectById()', () => {
+    describe('select()', () => {
       it('adds meshes to selection', () => {
-        manager.selectById([meshes[0].id])
-        expect(manager.meshes.has(meshes[0])).toBe(true)
+        const mesh = CreateBox('box1', {})
+        manager.select([mesh])
+        expect(manager.meshes.has(mesh)).toBe(true)
         expect(manager.meshes.size).toBe(1)
-        expectSelected(meshes[0])
+        expectSelected(mesh, colorByPlayerId.get(playerId))
         expect(selectionChanged).toHaveBeenCalledTimes(1)
-        expect(selectionChanged.mock.calls[0][0].has(meshes[0])).toBe(true)
+        expect(selectionChanged.mock.calls[0][0].has(mesh)).toBe(true)
         expect(selectionChanged.mock.calls[0][0].size).toBe(1)
       })
 
       it('adds multiple meshes to selection', () => {
-        manager.selectById([meshes[0].id, meshes[1].id])
-        expect(manager.meshes.has(meshes[0])).toBe(true)
-        expect(manager.meshes.has(meshes[1])).toBe(true)
+        const mesh1 = CreateBox('box1', {})
+        const mesh2 = CreateBox('box2', {})
+        manager.select([mesh1, mesh2])
+        expect(manager.meshes.has(mesh1)).toBe(true)
+        expect(manager.meshes.has(mesh2)).toBe(true)
         expect(manager.meshes.size).toBe(2)
-        expectSelected(meshes[0])
-        expectSelected(meshes[1])
+        expectSelected(mesh1, colorByPlayerId.get(playerId))
+        expectSelected(mesh2, colorByPlayerId.get(playerId))
         expect(selectionChanged).toHaveBeenCalledTimes(1)
+      })
+
+      it('adds an entire stack to selection', () => {
+        const mesh1 = CreateBox('box1', {})
+        const mesh2 = CreateBox('box2', {})
+        mesh1.addBehavior(new StackBehavior({ stackIds: [mesh2.id] }))
+        manager.select([mesh1])
+        expect(manager.meshes.has(mesh1)).toBe(true)
+        expect(manager.meshes.has(mesh2)).toBe(true)
+        expect(manager.meshes.size).toBe(2)
+        expectSelected(mesh1, colorByPlayerId.get(playerId))
+        expectSelected(mesh2, colorByPlayerId.get(playerId))
+        expect(selectionChanged).toHaveBeenCalledTimes(1)
+      })
+
+      it('reorders selection based on elevation', () => {
+        const mesh1 = CreateBox('box1', {})
+        mesh1.setAbsolutePosition(new Vector3(0, 5, 0))
+        manager.select([mesh1])
+        expectSelection([mesh1], colorByPlayerId.get(playerId))
+
+        const mesh2 = CreateBox('box2', {})
+        mesh2.setAbsolutePosition(new Vector3(0, -2, 0))
+        manager.select([mesh2])
+        expectSelection([mesh2, mesh1], colorByPlayerId.get(playerId))
+
+        const mesh3 = CreateBox('box3', {})
+        mesh3.setAbsolutePosition(new Vector3(0, 7, 0))
+        manager.select([mesh3])
+        expectSelection([mesh2, mesh1, mesh3], colorByPlayerId.get(playerId))
+
+        const mesh4 = CreateBox('box4', {})
+        mesh4.setAbsolutePosition(new Vector3(0, 2, 0))
+        manager.select([mesh4])
+        expectSelection(
+          [mesh2, mesh4, mesh1, mesh3],
+          colorByPlayerId.get(playerId)
+        )
+
+        expect(selectionChanged).toHaveBeenCalledTimes(4)
+        expect(selectionChanged.mock.calls[3][0].has(mesh1)).toBe(true)
+        expect(selectionChanged.mock.calls[3][0].has(mesh2)).toBe(true)
+        expect(selectionChanged.mock.calls[3][0].has(mesh3)).toBe(true)
+        expect(selectionChanged.mock.calls[3][0].has(mesh4)).toBe(true)
+        expect(selectionChanged.mock.calls[3][0].size).toBe(4)
       })
     })
 
-    describe('drawSelectionBox()', () => {
-      it('allows selecting contained meshes on main scene', () => {
-        manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
-        manager.selectWithinBox()
-        expectSelection([meshes[1], meshes[0]])
-        expect(selectionChanged).toHaveBeenCalledTimes(1)
-        expect(selectionChanged.mock.calls[0][0].size).toBe(2)
-        expect(selectionChanged.mock.calls[0][0].has(meshes[0])).toBe(true)
-        expect(selectionChanged.mock.calls[0][0].has(meshes[1])).toBe(true)
+    describe('apply()', () => {
+      let meshes
+
+      beforeEach(() => {
+        meshes = [
+          CreateBox('box1', {}),
+          CreateBox('box2', {}),
+          CreateBox('box3', {})
+        ]
       })
 
-      it('append to selection', () => {
-        manager.select([meshes[4]])
-        manager.drawSelectionBox({ x: 1100, y: 550 }, { x: 1000, y: 400 })
-        manager.selectWithinBox()
-        expectSelection([meshes[4], meshes[1], meshes[0]])
+      it('does nothing without player', () => {
+        manager.apply([meshes[0].id, meshes[1].id])
+        expectSelected(meshes[0], null, false)
+        expectSelected(meshes[1], null, false)
+        expectSelection([], null)
+        expect(selectionChanged).not.toHaveBeenCalled()
       })
 
-      it('allows selecting contained meshes in hand', () => {
-        vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
-        manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
-        manager.selectWithinBox()
-        expectSelection([meshes[6], meshes[7]])
-        expect(selectionChanged).toHaveBeenCalledTimes(1)
-        expect(selectionChanged.mock.calls[0][0].size).toBe(2)
-        expect(selectionChanged.mock.calls[0][0].has(meshes[6])).toBe(true)
-        expect(selectionChanged.mock.calls[0][0].has(meshes[7])).toBe(true)
+      it('adds meshes to a peer selection', () => {
+        manager.apply([meshes[0].id, meshes[1].id], peer1.id)
+        expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
+        expectSelected(meshes[1], colorByPlayerId.get(peer1.id))
+        expectSelection([], null)
+        expect(meshes[2].renderOverlay).toBeUndefined()
+        expect(selectionChanged).not.toHaveBeenCalled()
       })
 
-      it('clears selection from hand when selecting in main scene', () => {
-        manager.select([meshes[6]])
-        manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
-        manager.selectWithinBox()
-        expectSelection([meshes[1], meshes[0]])
+      describe('given meshes selected by peer', () => {
+        beforeEach(() => {
+          manager.apply([meshes[0].id, meshes[1].id], peer1.id)
+          manager.select([meshes[2]])
+          selectionChanged.mockClear()
+        })
+
+        it('removes selected mesh', () => {
+          manager.apply([meshes[0].id], peer1.id)
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
+          expectSelected(meshes[1], null, false)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+
+        it('ignores meshes selected by peers', () => {
+          manager.apply([meshes[0].id], peer2.id)
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
+          expectSelected(meshes[1], colorByPlayerId.get(peer1.id), true)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+
+        it('ignores meshes from current selection', () => {
+          manager.apply([meshes[2].id], peer2.id)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('given some selected meshes', () => {
+      let meshes
+
+      beforeEach(() => {
+        meshes = ['box1', 'box2', 'box3'].map(id => CreateBox(id, {}))
+        manager.select(meshes)
+        selectionChanged.mockReset()
       })
 
-      it('clears selection from main when selecting in hand', () => {
-        manager.select([meshes[4]])
-        vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
-        manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
-        manager.selectWithinBox()
-        expectSelection([meshes[6], meshes[7]])
+      it('automatically removes disposed meshes from selection', () => {
+        const [mesh1, mesh2, mesh3] = meshes
+        mesh1.dispose()
+        mesh2.dispose()
+        expect(manager.meshes.size).toBe(1)
+        expectSelected(mesh1, colorByPlayerId.get(playerId), false)
+        expectSelected(mesh2, colorByPlayerId.get(playerId), false)
+        expectSelected(mesh3, colorByPlayerId.get(playerId), true)
+        expect(selectionChanged).toHaveBeenCalledTimes(2)
+      })
+
+      describe('select()', () => {
+        it('does not add the same mesh twice', () => {
+          manager.select([meshes[0]])
+          expect(manager.meshes.has(meshes[0])).toBe(true)
+          expect(manager.meshes.size).toBe(3)
+          expectSelected(meshes[0], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('getSelection()', () => {
+        it('returns entire selection when it contains provided mesh', () => {
+          expectMeshes(manager.getSelection(meshes[0]), meshes)
+        })
+
+        it('returns provided mesh if it not selected', () => {
+          manager.clear()
+          manager.select([meshes[1], meshes[2]])
+          expectMeshes(manager.getSelection(meshes[0]), [meshes[0]])
+        })
+      })
+
+      describe('clear()', () => {
+        it('removes all meshes from selection', () => {
+          manager.clear()
+          expect(manager.meshes.size).toBe(0)
+          expectSelected(meshes[0], null, false)
+          expectSelected(meshes[1], null, false)
+          expect(selectionChanged).toHaveBeenCalledTimes(1)
+          expect(selectionChanged.mock.calls[0][0].size).toBe(0)
+        })
+
+        it('does not notify listener when clearing an empty selection', () => {
+          manager.clear()
+          expect(manager.meshes.size).toBe(0)
+          selectionChanged.mockReset()
+
+          manager.clear()
+          expect(manager.meshes.size).toBe(0)
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('given some meshes', () => {
+      let meshes
+
+      beforeEach(() => {
+        meshes = [
+          { id: 'box1', position: new Vector3(1, 1, 2), scene },
+          { id: 'box2', position: new Vector3(0, 0, 0), scene },
+          { id: 'box3', position: new Vector3(-5, -2, -2), scene },
+          { id: 'box4', position: new Vector3(5, 5, 5), scene },
+          { id: 'box5', position: new Vector3(10, 0, 0), scene },
+          { id: 'box6', position: new Vector3(10, 0, -10), scene: handScene },
+          { id: 'box7', position: new Vector3(0, 0, -10), scene: handScene },
+          { id: 'box8', position: new Vector3(-10, 0, -10), scene: handScene }
+        ].map(({ id, position, scene }) => {
+          const mesh = CreateBox(id, {}, scene)
+          mesh.setAbsolutePosition(position)
+          return mesh
+        })
+      })
+
+      describe('selectById()', () => {
+        it('adds meshes to selection', () => {
+          manager.selectById([meshes[0].id])
+          expect(manager.meshes.has(meshes[0])).toBe(true)
+          expect(manager.meshes.size).toBe(1)
+          expectSelected(meshes[0], colorByPlayerId.get(playerId))
+          expect(selectionChanged).toHaveBeenCalledTimes(1)
+          expect(selectionChanged.mock.calls[0][0].has(meshes[0])).toBe(true)
+          expect(selectionChanged.mock.calls[0][0].size).toBe(1)
+        })
+
+        it('adds multiple meshes to selection', () => {
+          manager.selectById([meshes[0].id, meshes[1].id])
+          expect(manager.meshes.has(meshes[0])).toBe(true)
+          expect(manager.meshes.has(meshes[1])).toBe(true)
+          expect(manager.meshes.size).toBe(2)
+          expectSelected(meshes[0], colorByPlayerId.get(playerId))
+          expectSelected(meshes[1], colorByPlayerId.get(playerId))
+          expect(selectionChanged).toHaveBeenCalledTimes(1)
+        })
+
+        it('ignores meshes selected by peers', () => {
+          const [{ id }] = meshes
+          manager.apply([id], peer1.id)
+          manager.selectById([id])
+
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
+          expectSelection([], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('drawSelectionBox()', () => {
+        it('allows selecting contained meshes on main scene', () => {
+          manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
+          manager.selectWithinBox()
+          expectSelection([meshes[1], meshes[0]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).toHaveBeenCalledTimes(1)
+          expect(selectionChanged.mock.calls[0][0].size).toBe(2)
+          expect(selectionChanged.mock.calls[0][0].has(meshes[0])).toBe(true)
+          expect(selectionChanged.mock.calls[0][0].has(meshes[1])).toBe(true)
+        })
+
+        it('append to selection', () => {
+          manager.select([meshes[4]])
+          manager.drawSelectionBox({ x: 1100, y: 550 }, { x: 1000, y: 400 })
+          manager.selectWithinBox()
+          expectSelection(
+            [meshes[4], meshes[1], meshes[0]],
+            colorByPlayerId.get(playerId)
+          )
+        })
+
+        it('allows selecting contained meshes in hand', () => {
+          vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
+          manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
+          manager.selectWithinBox()
+          expectSelection([meshes[6], meshes[7]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).toHaveBeenCalledTimes(1)
+          expect(selectionChanged.mock.calls[0][0].size).toBe(2)
+          expect(selectionChanged.mock.calls[0][0].has(meshes[6])).toBe(true)
+          expect(selectionChanged.mock.calls[0][0].has(meshes[7])).toBe(true)
+        })
+
+        it('clears selection from hand when selecting in main scene', () => {
+          manager.select([meshes[6]])
+          manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
+          manager.selectWithinBox()
+          expectSelection([meshes[1], meshes[0]], colorByPlayerId.get(playerId))
+        })
+
+        it('clears selection from main when selecting in hand', () => {
+          manager.select([meshes[4]])
+          vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
+          manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
+          manager.selectWithinBox()
+          expectSelection([meshes[6], meshes[7]], colorByPlayerId.get(playerId))
+        })
+
+        it('ignores meshes selected by peers', () => {
+          const [mesh] = meshes
+          manager.apply([mesh.id], peer1.id)
+          manager.select([mesh])
+
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
+          expectSelection([], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
       })
     })
   })
 })
 
-function expectSelection(expectedMeshes) {
+function expectSelection(expectedMeshes, color) {
   expect([...manager.meshes].map(({ id }) => id)).toEqual(
     expectedMeshes.map(({ id }) => id)
   )
   for (const [rank, mesh] of expectedMeshes.entries()) {
-    expectSelected(mesh, true, `mesh #${rank} selection status`)
+    expectSelected(mesh, color, true, `mesh #${rank} selection status`)
   }
 }
 
-function expectSelected(mesh, isSelected = true, message) {
-  expect(mesh.renderOverlay, message).toBe(isSelected)
+function expectSelected(mesh, color, isSelected = true, message) {
+  if (isSelected) {
+    expect(mesh.renderOverlay, message).toBe(true)
+    expect(mesh.overlayColor?.toHexString()).toBe(`${color}33`)
+  } else {
+    expect(mesh.renderOverlay, message).toBeFalsy()
+  }
 }

--- a/apps/web/tests/components/Indicators.tools.svelte
+++ b/apps/web/tests/components/Indicators.tools.svelte
@@ -19,7 +19,7 @@
       items: [
         {
           screenPosition: { x: 150, y: 125 },
-          player: { username: 'Gaspard' },
+          player: { username: 'Gaspard', color: '#967d3e' },
           id: '123456.drop-zone.anchor-0',
           mesh: {}
         }
@@ -31,8 +31,8 @@
     props={{
       items: [
         {
-          screenPosition: { x: -150, y: -125 },
-          player: { username: 'Gaspard' },
+          screenPosition: { x: -150, y: 125 },
+          player: { username: 'Gaspard', color: '#567cdc' },
           id: 'pointer-123'
         }
       ]
@@ -56,7 +56,7 @@
       feedbacks: [
         {
           screenPosition: { x: 50, y: 200 },
-          player: { username: 'Jane' },
+          player: { username: 'Jane', color: '#ffa280' },
           id: '1234'
         }
       ]
@@ -77,19 +77,19 @@
       items: [
         {
           screenPosition: { x: 150, y: 125 },
-          player: { username: 'Gaspard' },
+          player: { username: 'Gaspard', color: 'cyan' },
           id: '123456.drop-zone.anchor-0',
           mesh: {}
         },
         {
-          screenPosition: { x: 150, y: 125 },
+          screenPosition: { x: 150, y: 140 },
           size: 3,
           id: 'card2.stack-size',
           mesh: {}
         },
         {
-          screenPosition: { x: -150, y: -125 },
-          player: { username: 'Gaspard' },
+          screenPosition: { x: -150, y: 125 },
+          player: { username: 'Gaspard', color: 'purple' },
           id: 'pointer-123'
         }
       ],
@@ -101,7 +101,7 @@
         },
         {
           screenPosition: { x: 100, y: 200 },
-          player: { username: 'Jane' },
+          player: { username: 'Jane', color: '#369d2b' },
           id: '2345'
         }
       ]

--- a/apps/web/tests/components/__snapshots__/Indicators.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Indicators.tools.shot
@@ -4,19 +4,19 @@ exports[`All kinds 1`] = `
 HTMLCollection [
   <div
     class="s-WFVnM7df3-nu centered"
-    style="top: 125px; left: 150px;"
+    style="top: 125px; left: 150px; --color: cyan;"
   >
     Gaspard
   </div>,
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 125px; left: 150px;"
+    style="top: 140px; left: 150px; --color: #7a7a7a;"
   >
     3
   </div>,
   <figure
-    class="s-engCJu8q-fNe positioned"
-    style="--dimension: 60px; --color: null; --top: -125px; --left: -150px; --border-width: 3px"
+    class="s-engCJu8q-fNe positioned colored"
+    style="--dimension: 60px; --color: purple; --top: 125px; --left: -150px; --border-width: 3px"
   >
     <img
       alt="avatar for Gaspard"
@@ -33,7 +33,7 @@ HTMLCollection [
   </figure>,
   <div
     class="s-8tykIykLMKjy"
-    style="top: 200px; left: 50px;"
+    style="top: 200px; left: 50px; --color: #ffffff;"
   >
     <span
       class="material-icons s-8tykIykLMKjy"
@@ -44,7 +44,7 @@ HTMLCollection [
   </div>,
   <div
     class="s-8tykIykLMKjy"
-    style="top: 200px; left: 100px;"
+    style="top: 200px; left: 100px; --color: #369d2b;"
   >
     <span
       class="material-icons s-8tykIykLMKjy"
@@ -59,7 +59,7 @@ HTMLCollection [
 exports[`Feedback for action 1`] = `
 <div
   class="s-8tykIykLMKjy"
-  style="top: 200px; left: 50px;"
+  style="top: 200px; left: 50px; --color: #ffffff;"
 >
   <span
     class="material-icons s-8tykIykLMKjy"
@@ -73,7 +73,7 @@ exports[`Feedback for action 1`] = `
 exports[`Feedback for player 1`] = `
 <div
   class="s-8tykIykLMKjy"
-  style="top: 200px; left: 50px;"
+  style="top: 200px; left: 50px; --color: #ffa280;"
 >
   <span
     class="material-icons s-8tykIykLMKjy"
@@ -87,7 +87,7 @@ exports[`Feedback for player 1`] = `
 exports[`For player 1`] = `
 <div
   class="s-WFVnM7df3-nu centered"
-  style="top: 125px; left: 150px;"
+  style="top: 125px; left: 150px; --color: #967d3e;"
 >
   Gaspard
 </div>
@@ -97,13 +97,13 @@ exports[`Multiple 1`] = `
 HTMLCollection [
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 100px; left: 50px;"
+    style="top: 100px; left: 50px; --color: #7a7a7a;"
   >
     5
   </div>,
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 200px; left: 150px;"
+    style="top: 200px; left: 150px; --color: #7a7a7a;"
   >
     27
   </div>,
@@ -112,8 +112,8 @@ HTMLCollection [
 
 exports[`Peer pointer 1`] = `
 <figure
-  class="s-engCJu8q-fNe positioned"
-  style="--dimension: 60px; --color: null; --top: -125px; --left: -150px; --border-width: 3px"
+  class="s-engCJu8q-fNe positioned colored"
+  style="--dimension: 60px; --color: #567cdc; --top: 125px; --left: -150px; --border-width: 3px"
 >
   <img
     alt="avatar for Gaspard"
@@ -133,7 +133,7 @@ exports[`Peer pointer 1`] = `
 exports[`Single 1`] = `
 <div
   class="s-WFVnM7df3-nu"
-  style="top: 100px; left: 50px;"
+  style="top: 100px; left: 50px; --color: #7a7a7a;"
 >
   5
 </div>

--- a/apps/web/tests/utils/game.test.js
+++ b/apps/web/tests/utils/game.test.js
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildPlayerColors,
   findPlayerColor,
-  findPlayerPreferences,
-  makeHighlightColor
+  findPlayerPreferences
 } from '../../src/utils/game'
 
 describe('Game utils', () => {
@@ -52,17 +52,54 @@ describe('Game utils', () => {
     })
   })
 
-  describe('makeHighlightColor()', () => {
+  describe('buildPlayerColors()', () => {
+    it('builds a map of player colors', () => {
+      expect(
+        buildPlayerColors({
+          players: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+          preferences: [
+            { playerId: 'a', color: '#ff0000' },
+            { playerId: 'c', color: '#0000ff' },
+            { playerId: 'd', color: '#00ff00' }
+          ]
+        })
+      ).toEqual(
+        new Map([
+          ['a', '#ff0000'],
+          ['b', '#ff4500'],
+          ['c', '#0000ff']
+        ])
+      )
+    })
+
     it('does not change already light color', () => {
-      expect(makeHighlightColor('#ff0000')).toEqual('#ff0000')
+      const playerId = 'a'
+      expect(
+        buildPlayerColors({
+          players: [{ id: playerId }],
+          preferences: [{ playerId, color: '#ff0000' }]
+        })
+      ).toEqual(new Map([[playerId, '#ff0000']]))
     })
 
     it('returns an expanded hex color string', () => {
-      expect(makeHighlightColor('#f00')).toEqual('#ff0000')
+      const playerId = 'a'
+      expect(
+        buildPlayerColors({
+          players: [{ id: playerId }],
+          preferences: [{ playerId, color: '#f00' }]
+        })
+      ).toEqual(new Map([[playerId, '#ff0000']]))
     })
 
     it('increases color lightness', () => {
-      expect(makeHighlightColor('#123456')).toEqual('#2c80d3')
+      const playerId = 'a'
+      expect(
+        buildPlayerColors({
+          players: [{ id: playerId }],
+          preferences: [{ playerId, color: '#123456' }]
+        })
+      ).toEqual(new Map([[playerId, '#2c80d3']]))
     })
   })
 })

--- a/apps/web/tests/utils/game.test.js
+++ b/apps/web/tests/utils/game.test.js
@@ -71,35 +71,5 @@ describe('Game utils', () => {
         ])
       )
     })
-
-    it('does not change already light color', () => {
-      const playerId = 'a'
-      expect(
-        buildPlayerColors({
-          players: [{ id: playerId }],
-          preferences: [{ playerId, color: '#ff0000' }]
-        })
-      ).toEqual(new Map([[playerId, '#ff0000']]))
-    })
-
-    it('returns an expanded hex color string', () => {
-      const playerId = 'a'
-      expect(
-        buildPlayerColors({
-          players: [{ id: playerId }],
-          preferences: [{ playerId, color: '#f00' }]
-        })
-      ).toEqual(new Map([[playerId, '#ff0000']]))
-    })
-
-    it('increases color lightness', () => {
-      const playerId = 'a'
-      expect(
-        buildPlayerColors({
-          players: [{ id: playerId }],
-          preferences: [{ playerId, color: '#123456' }]
-        })
-      ).toEqual(new Map([[playerId, '#2c80d3']]))
-    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ importers:
 
   apps/cli:
     specifiers:
+      '@tabulous/cli': ^0.0.1
       '@urql/core': ^3.0.5
       add: ^2.0.6
       ajv: ^8.11.0
@@ -51,6 +52,7 @@ importers:
       strip-ansi: ^7.0.1
       undici: ^5.12.0
     dependencies:
+      '@tabulous/cli': 'link:'
       '@urql/core': 3.0.5_graphql@16.6.0
       add: 2.0.6
       ajv: 8.11.0
@@ -140,7 +142,6 @@ importers:
       autoprefixer: ^10.4.13
       chalk: ^5.1.2
       chalk-template: ^0.4.0
-      colorjs.io: 0.4.1-patch.1
       cookie: ^0.5.0
       dotenv: ^16.0.3
       earcut: ^2.2.4
@@ -199,7 +200,6 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.18
       chalk: 5.1.2
       chalk-template: 0.4.0
-      colorjs.io: 0.4.1-patch.1
       cookie: 0.5.0
       dotenv: 16.0.3
       earcut: 2.2.4
@@ -730,7 +730,7 @@ packages:
     resolution: {integrity: sha512-69JnK7Cot+ktn7LD5TikP3b7psBPX55tYpQa8WSumt8r117PCa2zwHnImfBtRWYExreJlI48hr0WZaVrTBGj7w==}
     dependencies:
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       fast-uri: 2.1.0
 
   /@fastify/cors/8.1.1:
@@ -1473,8 +1473,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -1978,10 +1980,6 @@ packages:
 
   /colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
-
-  /colorjs.io/0.4.1-patch.1:
-    resolution: {integrity: sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA==}
-    dev: true
 
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -2838,7 +2836,7 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.1.0
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       fast-deep-equal: 3.1.3
       fast-uri: 2.1.0
       rfdc: 1.3.0


### PR DESCRIPTION
### :book: What's in there?

Now that each player has its own color, we can start displaying their respective selections.

[peer-selection.webm](https://user-images.githubusercontent.com/186268/201526286-91b13b5b-ae3b-4358-99d6-51ff9be3d9fe.webm)

Please note that, while meshes selected by someone else can not be selected, they are still interactive (will be prevented in another piece of work).

Are included here:

- fix(web): can't type 'h' in invite dialogue (considered as shortcut)
- feat(web): displays and keeps in sync peers selection
- feat(web): sends active selection to peers
- feat(web): adds player colors to indicators
- refactor(web): renders mesh edges when selecting them. Does not alter color player.
- refactor(server): uses more contrasted colors.
- chore(cli): migrates code from istanbul to c8 coverage tool

### :test_tube: How to test?

1. Make a new game that has several seats
2. Invite other players
   > each players gets one of the 8 colors randomly assigned
3. Select some meshes before other player connect
   > your selection appears with your color, and is more visible
4. Let other peers connect
   > they will see your selection, and won't be able to select these meshes
5. Let other peers select some meshes
   > you should see their selection, with their own colors, and these meshes are not selectable for you
6. Let another peer disconnect
   > their selection is cleared.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
