### PR TITLE
feat(web): ignores meshes selected by peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ You need [git], [Node.js 16][node], [PNPM] and [Redis]
 
 1. Your favorite browser should open and display a warning about self-signed SSL certificate. Bypass it, and start developping.
 
+### Test
+
+The entire unit test suite (all projects) runs with `pnpm t`/`pnpm test`.
+
+Run a given project unit test suite with `pnpm test:FOLDER_NAME` (`pnpm test:web`, `pnpm test:server`...).
+
+Run a given project watch mode with `pnpm dev:FOLDER_NAME` (`pnpm dev:web`, `pnpm dev:server`...).
+
+Run a single test file with `pnpm --filter FOLDER_NAME test/dev FILE_NAME` (`pnpm --filter web dev 3d/engine`, `pnpm --filter server test players-resolver`...).
+
 ### Production
 
 All the magic happens during continuous integration/deployment:

--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
 - bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
-- make peers' selection uncontrollable
 - detailable/stackable behavior: preview a stack of meshes
 - hide non-connected participants
 - loading spinner on game/new

--- a/apps/web/src/3d/managers/input.js
+++ b/apps/web/src/3d/managers/input.js
@@ -4,6 +4,7 @@ import { Scene } from '@babylonjs/core/scene.js'
 import { makeLogger } from '../../utils/logger'
 import { distance } from '../../utils/math'
 import { screenToGround } from '../utils/vector'
+import { selectionManager } from './selection'
 
 const logger = makeLogger('input')
 
@@ -462,7 +463,10 @@ export const inputManager = new InputManager()
 
 function findPickedMesh(scene, { x, y }) {
   return scene
-    .multiPickWithRay(scene.createPickingRay(x, y), mesh => mesh.isPickable)
+    .multiPickWithRay(
+      scene.createPickingRay(x, y),
+      mesh => mesh.isPickable && !selectionManager.isSelectedByPeer(mesh)
+    )
     .sort((a, b) => a.distance - b.distance)[0]?.pickedMesh
 }
 

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -47,6 +47,8 @@ class SelectionManager {
   init({ scene, handScene }) {
     this.scene = scene
     this.handScene = handScene
+    this.color = Color4.FromHexString('#00ff00ff')
+    this.colorByPlayerId = new Map()
   }
 
   /**
@@ -248,6 +250,15 @@ class SelectionManager {
     if (selection.size) {
       this.selectionByPeerId.set(playerId, selection)
     }
+  }
+
+  isSelectedByPeer(mesh) {
+    for (const selection of this.selectionByPeerId.values()) {
+      if (selection.has(mesh)) {
+        return true
+      }
+    }
+    return false
   }
 }
 

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -169,10 +169,10 @@ export function attachInputs({
           resetMenu()
           const kind = pointerKind(event, button, pointers)
           if (mesh) {
-            if (!selectionManager.meshes.has(mesh)) {
-              selectionManager.clear()
-            }
             if (kind === 'left') {
+              if (!selectionManager.meshes.has(mesh)) {
+                selectionManager.clear()
+              }
               logger.info(
                 { mesh, button, long, pointers, event },
                 `start moving mesh ${mesh.id}`

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -187,36 +187,6 @@ describe('SelectionManager', () => {
         expect(meshes[2].renderOverlay).toBeUndefined()
         expect(selectionChanged).not.toHaveBeenCalled()
       })
-
-      describe('given meshes selected by peer', () => {
-        beforeEach(() => {
-          manager.apply([meshes[0].id, meshes[1].id], peer1.id)
-          manager.select([meshes[2]])
-          selectionChanged.mockClear()
-        })
-
-        it('removes selected mesh', () => {
-          manager.apply([meshes[0].id], peer1.id)
-          expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
-          expectSelected(meshes[1], null, false)
-          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
-          expect(selectionChanged).not.toHaveBeenCalled()
-        })
-
-        it('ignores meshes selected by peers', () => {
-          manager.apply([meshes[0].id], peer2.id)
-          expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
-          expectSelected(meshes[1], colorByPlayerId.get(peer1.id), true)
-          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
-          expect(selectionChanged).not.toHaveBeenCalled()
-        })
-
-        it('ignores meshes from current selection', () => {
-          manager.apply([meshes[2].id], peer2.id)
-          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
-          expect(selectionChanged).not.toHaveBeenCalled()
-        })
-      })
     })
 
     describe('given some selected meshes', () => {
@@ -237,6 +207,19 @@ describe('SelectionManager', () => {
         expectSelected(mesh2, colorByPlayerId.get(playerId), false)
         expectSelected(mesh3, colorByPlayerId.get(playerId), true)
         expect(selectionChanged).toHaveBeenCalledTimes(2)
+      })
+
+      describe('isSelectedByPeer()', () => {
+        it('returns false for meshes of the active selection', () => {
+          expect(manager.isSelectedByPeer(meshes[0])).toBe(false)
+          expect(manager.isSelectedByPeer(meshes[1])).toBe(false)
+          expect(manager.isSelectedByPeer(meshes[2])).toBe(false)
+        })
+
+        it('returns false for unselected meshes', () => {
+          expect(manager.isSelectedByPeer(meshes[3])).toBe(false)
+          expect(manager.isSelectedByPeer(meshes[4])).toBe(false)
+        })
       })
 
       describe('select()', () => {
@@ -279,6 +262,60 @@ describe('SelectionManager', () => {
           manager.clear()
           expect(manager.meshes.size).toBe(0)
           expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('given some meshes selected by peer', () => {
+      let meshes
+
+      beforeEach(() => {
+        meshes = ['box1', 'box2', 'box3', 'box4', 'box5'].map(id =>
+          CreateBox(id, {})
+        )
+        manager.apply([meshes[0].id, meshes[1].id], peer1.id)
+        manager.select([meshes[2]])
+        manager.apply([meshes[3].id], peer2.id)
+        selectionChanged.mockReset()
+      })
+
+      describe('apply()', () => {
+        it('removes selected mesh', () => {
+          manager.apply([meshes[0].id], peer1.id)
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
+          expectSelected(meshes[1], null, false)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+
+        it('ignores meshes selected by peers', () => {
+          manager.apply([meshes[0].id], peer2.id)
+          expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
+          expectSelected(meshes[1], colorByPlayerId.get(peer1.id), true)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+
+        it('ignores meshes from current selection', () => {
+          manager.apply([meshes[2].id], peer2.id)
+          expectSelection([meshes[2]], colorByPlayerId.get(playerId))
+          expect(selectionChanged).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('isSelectedByPeer()', () => {
+        it('returns true for peer-selected meshes', () => {
+          expect(manager.isSelectedByPeer(meshes[0])).toBe(true)
+          expect(manager.isSelectedByPeer(meshes[1])).toBe(true)
+          expect(manager.isSelectedByPeer(meshes[3])).toBe(true)
+        })
+
+        it('returns false for meshes of the active selection', () => {
+          expect(manager.isSelectedByPeer(meshes[2])).toBe(false)
+        })
+
+        it('returns false for unselected meshes', () => {
+          expect(manager.isSelectedByPeer(meshes[4])).toBe(false)
         })
       })
     })

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -1205,10 +1205,12 @@ describe('Game interaction model', () => {
     })
 
     it('pans camera on right click drag', () => {
+      selectionManager.select([meshes[0]])
       cameraManager.pan.mockResolvedValue()
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
         event: { pointerType: 'mouse' },
+        mesh: meshes[1],
         button: 2
       })
       inputManager.onDragObservable.notifyObservers({
@@ -1227,6 +1229,7 @@ describe('Game interaction model', () => {
       expect(cameraManager.zoom).not.toHaveBeenCalled()
       expect(drawSelectionBox).not.toHaveBeenCalled()
       expect(selectWithinBox).not.toHaveBeenCalled()
+      expect(selectionManager.meshes.size).toBe(1)
     })
 
     it.each([
@@ -1265,9 +1268,11 @@ describe('Game interaction model', () => {
         button: 0
       }
     ])('rotates camera on $title drag', ({ event, button }) => {
+      selectionManager.select([meshes[0]])
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
         event,
+        mesh: meshes[1],
         button
       })
       inputManager.onDragObservable.notifyObservers({
@@ -1286,6 +1291,7 @@ describe('Game interaction model', () => {
       expect(cameraManager.zoom).not.toHaveBeenCalled()
       expect(drawSelectionBox).not.toHaveBeenCalled()
       expect(selectWithinBox).not.toHaveBeenCalled()
+      expect(selectionManager.meshes.size).toBe(1)
     })
 
     it.each([
@@ -1309,14 +1315,16 @@ describe('Game interaction model', () => {
     })
 
     it('zooms camera on mouse wheel', () => {
+      selectionManager.select([meshes[0]])
       const preventDefault = vi.fn()
       const event = { deltaY: Math.floor(Math.random() * 100), preventDefault }
-      inputManager.onWheelObservable.notifyObservers({ event })
+      inputManager.onWheelObservable.notifyObservers({ event, mesh: meshes[1] })
       expect(cameraManager.zoom).toHaveBeenCalledTimes(1)
       expect(cameraManager.zoom).toHaveBeenCalledWith(event.deltaY * 0.1)
       expect(cameraManager.rotate).not.toHaveBeenCalled()
       expect(cameraManager.pan).not.toHaveBeenCalled()
       expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(selectionManager.meshes.size).toBe(1)
     })
 
     it('zooms camera on pinch', () => {


### PR DESCRIPTION
### :book: What's in there?

Here is the final touch for peers selections: once a mesh is selected by a peer, it can not be selected by others any more.

[peer-uncontrollable-selection.webm](https://user-images.githubusercontent.com/186268/201535141-068b13cd-4c5f-4c07-8cba-93cf7d902441.webm)


- fix(web): selection resets when panning/rotating camera above another mesh
- feat(web): ignores meshes selected by peers

### :test_tube: How to test?

1. Make a new game that has several seats
1. Invite other players, let them connect
1. Select some meshes
   > your selection appears with your color, for you and peers
1. Peers try selecting, moving, opening game menu, applying short-cuts on your selected meshes
   > none of the above works. 
