### PR TITLE
feat(web): updates player avatar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,9 +96,8 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - detailable/stackable behavior: preview a stack of meshes
-- hide non-connected participants
+- hide/distinguish non-connected participants
 - loading spinner on game/new
-- updates avatar
 - is this right? given an active selection, when it anchors with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -109,7 +109,7 @@ export default {
           throw new Error('Username already used')
         }
         const update = { id: player.id, username: sanitizedUsername }
-        if (avatar) {
+        if (avatar !== undefined) {
           update.avatar = avatar
         }
         const updated = await services.upsertPlayer(update)

--- a/apps/server/src/services/players.js
+++ b/apps/server/src/services/players.js
@@ -51,7 +51,11 @@ export async function upsertPlayer(userDetails) {
     delete userDetails.provider
     delete userDetails.providerId
     if (userDetails.avatar === 'gravatar') {
-      userDetails.avatar = await findGravatar(userDetails)
+      const existing = await repositories.players.getById(userDetails.id)
+      userDetails.avatar = await findGravatar({
+        ...(existing || {}),
+        ...userDetails
+      })
     }
     delete userDetails.email
   }

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -56,6 +56,31 @@ describe('given initialized repository', () => {
       })
     })
 
+    it('fetches user gavatar when requested', async () => {
+      const details = {
+        id: faker.datatype.uuid(),
+        avatar: 'gravatar',
+        email: ' Damien.SimoninFeugas@gmail.com ',
+        username: faker.name.fullName()
+      }
+      expect(await upsertPlayer(details)).toEqual({
+        ...details,
+        avatar: `https://www.gravatar.com/avatar/0440c0a8bc7e7dbbb8cec0585ca3c25c?s=96&r=g&d=404`
+      })
+    })
+
+    it('does no fetch user gavatar without email', async () => {
+      const details = {
+        id: faker.datatype.uuid(),
+        avatar: 'gravatar',
+        username: faker.name.fullName()
+      }
+      expect(await upsertPlayer(details)).toEqual({
+        ...details,
+        avatar: undefined
+      })
+    })
+
     it('creates new account from provider', async () => {
       const creation = {
         providerId: faker.datatype.uuid(),
@@ -64,9 +89,36 @@ describe('given initialized repository', () => {
         email: faker.internet.email(),
         username: faker.name.fullName()
       }
-      const created = await upsertPlayer(creation)
-      expect(created).toEqual({
+      expect(await upsertPlayer(creation)).toEqual({
         ...creation,
+        id: expect.any(String)
+      })
+    })
+
+    it('default to an existing gravatar when creating from provider', async () => {
+      const creation = {
+        providerId: faker.datatype.uuid(),
+        provider: 'oauth',
+        email: ' Damien.SimoninFeugas@gmail.com ',
+        username: faker.name.fullName()
+      }
+      expect(await upsertPlayer(creation)).toEqual({
+        ...creation,
+        avatar: `https://www.gravatar.com/avatar/0440c0a8bc7e7dbbb8cec0585ca3c25c?s=96&r=g&d=404`,
+        id: expect.any(String)
+      })
+    })
+
+    it('does not use an unexisting gavatar', async () => {
+      const creation = {
+        providerId: faker.datatype.uuid(),
+        provider: 'oauth',
+        email: ' MyEmailAddress@example.com ',
+        username: faker.name.fullName()
+      }
+      expect(await upsertPlayer(creation)).toEqual({
+        ...creation,
+        avatar: undefined,
         id: expect.any(String)
       })
     })
@@ -81,8 +133,7 @@ describe('given initialized repository', () => {
         email: faker.internet.email(),
         username
       }
-      const created = await upsertPlayer(creation)
-      expect(created).toEqual({
+      expect(await upsertPlayer(creation)).toEqual({
         ...creation,
         username: expect.stringMatching(new RegExp(`^${username}-\\d+`)),
         id: expect.any(String)

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -56,7 +56,7 @@ describe('given initialized repository', () => {
       })
     })
 
-    it('fetches user gavatar when requested', async () => {
+    it('fetches user gravatar when requested', async () => {
       const details = {
         id: faker.datatype.uuid(),
         avatar: 'gravatar',
@@ -69,7 +69,21 @@ describe('given initialized repository', () => {
       })
     })
 
-    it('does no fetch user gavatar without email', async () => {
+    it('fetches user gravatar when requested on an existing account', async () => {
+      const original = await repositories.players.save({
+        username: faker.name.fullName(),
+        email: 'damien.simoninfeugas@gmail.com',
+        playing: false
+      })
+      expect(
+        await upsertPlayer({ id: original.id, avatar: 'gravatar' })
+      ).toEqual({
+        ...original,
+        avatar: `https://www.gravatar.com/avatar/0440c0a8bc7e7dbbb8cec0585ca3c25c?s=96&r=g&d=404`
+      })
+    })
+
+    it('does no fetch user gravatar without email', async () => {
       const details = {
         id: faker.datatype.uuid(),
         avatar: 'gravatar',
@@ -109,7 +123,7 @@ describe('given initialized repository', () => {
       })
     })
 
-    it('does not use an unexisting gavatar', async () => {
+    it('does not use an unexisting gravatar', async () => {
       const creation = {
         providerId: faker.datatype.uuid(),
         provider: 'oauth',

--- a/apps/web/playwright.config.js
+++ b/apps/web/playwright.config.js
@@ -1,5 +1,5 @@
 const isCI = !!process.env.CI
-const isDebug = !!process.env.PWDEBUG
+const isDebug = !!process.env.PWDEBUG || !!process.env.DEBUG
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {

--- a/apps/web/src/components/ConfirmDialogue.svelte
+++ b/apps/web/src/components/ConfirmDialogue.svelte
@@ -6,11 +6,13 @@
   import Dialogue from './Dialogue.svelte'
 
   export let open
-  export let message
+  export let message = ''
+  export let cancelText = $_('actions.cancel')
+  export let confirmText = $_('actions.confirm')
 
+  const dispatch = createEventDispatcher()
   let confirmed = null
   let cancelButtonRef = null
-  const dispatch = createEventDispatcher()
 
   $: if (cancelButtonRef) {
     cancelButtonRef.focus()
@@ -20,6 +22,7 @@
     event.stopImmediatePropagation()
     dispatch('close', confirmed ?? false)
     confirmed = null
+    open = false
   }
 </script>
 
@@ -29,12 +32,12 @@
   <svelte:fragment slot="buttons">
     <Button
       secondary
-      text={$_('actions.cancel')}
+      text={cancelText}
       bind:ref={cancelButtonRef}
       on:click={() => (open = false)}
     />
     <Button
-      text={$_('actions.confirm')}
+      text={confirmText}
       on:click={() => {
         confirmed = true
         open = false

--- a/apps/web/src/components/Dialogue.svelte
+++ b/apps/web/src/components/Dialogue.svelte
@@ -34,14 +34,14 @@
     }
   }
 
-  function handleKeyup({ key }) {
+  function handleKey({ key }) {
     if (key === 'Escape') {
       close()
     }
   }
 </script>
 
-<svelte:body on:keyup={handleKeyup} />
+<svelte:body on:keyup={handleKey} />
 <Portal>
   {#if open}
     <div class="filter" transition:fade />
@@ -50,7 +50,7 @@
       transition:fade
       on:click={close}
       on:keydown|stopPropagation
-      on:keyup={handleKeyup}
+      on:keyup={handleKey}
     >
       {#if closable}
         <span class="close-container">
@@ -60,7 +60,7 @@
       <article
         role="dialog"
         on:click|stopPropagation
-        on:keyup|stopPropagation={handleKeyup}
+        on:keyup|stopPropagation={handleKey}
       >
         <Pane>
           <header class="heading">{title}</header>
@@ -97,7 +97,7 @@
   }
 
   .content {
-    @apply overflow-y-auto;
+    @apply overflow-y-auto mt-4;
   }
 
   header {
@@ -105,6 +105,6 @@
   }
 
   footer {
-    @apply mt-4 text-center;
+    @apply mt-8 text-center;
   }
 </style>

--- a/apps/web/src/components/PlayerThumbnail.svelte
+++ b/apps/web/src/components/PlayerThumbnail.svelte
@@ -31,6 +31,7 @@
     width={dimension}
     height={dimension}
     alt="avatar for {player?.username}"
+    referrerpolicy="no-referrer"
     on:load={() => (hasImage = true)}
   />
   {#if !hasImage}

--- a/apps/web/src/graphql/players.graphql
+++ b/apps/web/src/graphql/players.graphql
@@ -43,8 +43,8 @@ mutation acceptTerms {
   }
 }
 
-mutation updateCurrentPlayer($username: String) {
-  updateCurrentPlayer(username: $username) {
+mutation updateCurrentPlayer($username: String, $avatar: String) {
+  updateCurrentPlayer(username: $username, avatar: $avatar) {
     ...player
   }
 }

--- a/apps/web/src/locales/fr.yaml
+++ b/apps/web/src/locales/fr.yaml
@@ -1,7 +1,9 @@
 fps _: 'FPS : {value}'
 
 actions:
+  back: Retour
   cancel: Non
+  change-avatar: Changer
   confirm: Oui
   enter-fullscreen: Plein-écran
   go-to-account: Paramètres
@@ -17,6 +19,7 @@ actions:
   log-out: Quitter
   new-game: Nouveau
   quit-game: Quitter le jeu
+  save: Sauver
   scroll-to-top: Défiler jusqu'en haut
   show-indicators: Afficher les indicateurs
 errors:
@@ -70,6 +73,7 @@ page-titles:
   log-in: Tabulous • Connection
   terms-of-service: Tabulous • Mentions Légales & Conditions Générales d'Utilisation
 placeholders:
+  avatar: Url
   password: Mot de passe
   playerId: Identifiant
   username: Pseudo
@@ -78,6 +82,7 @@ titles:
   auth-provider: Votre compte
   camera-controls: Contrôler la caméra
   catalog: Jeux disponibles
+  change-avatar: Choisissez votre nouvel avatar
   confirm-game-deletion: Suppression de la partie
   create-game: Nouvelle partie
   your-games: Parties en cours
@@ -92,6 +97,7 @@ titles:
   welcome: Bienvenue sur Tabulous !
 tooltips:
   add-to-selection: Ajouter à la sélection
+  change-avatar: Si vous avez associé un gravatar à votre email, tappez "gravatar". Videz le champ pour supprimer votre avatar.
   clear-selection: Vider la sélection
   detail: Voir en détail
   draw: Piocher dans votre main

--- a/apps/web/src/routes/(auth)/account/+page.svelte
+++ b/apps/web/src/routes/(auth)/account/+page.svelte
@@ -5,10 +5,11 @@
 
   import { invalidateAll } from '$app/navigation'
 
-  import { Input, PlayerThumbnail, Progress } from '../../../components'
+  import { Button, Input, PlayerThumbnail, Progress } from '../../../components'
   import { Header } from '../../../connected-components'
   import { updateCurrentPlayer } from '../../../stores'
   import { translateError } from '../../../utils'
+  import AvatarDialogue from './AvatarDialogue.svelte'
 
   /** @type {import('./$types').PageData} */
   export let data = {}
@@ -17,6 +18,8 @@
   let user = data.session.player
   let isSaving = false
   let usernameError = null
+  let openAvatarDialogue = false
+  let avatar = user.avatar
 
   const saveSubscription = username$
     .pipe(
@@ -39,6 +42,13 @@
 
   function handleSave({ target }) {
     username$.next(target.value)
+  }
+
+  async function handleCloseAvatarDialogue({ detail: confirmed }) {
+    if (confirmed) {
+      user.avatar = (await updateCurrentPlayer(user.username, avatar)).avatar
+    }
+    avatar = user.avatar
   }
 </script>
 
@@ -82,7 +92,18 @@
         {/if}
       </span>
       <span>{$_('labels.avatar')}</span>
-      <PlayerThumbnail player={user} dimension={150} />
+      <span class="aligned">
+        <PlayerThumbnail player={user} dimension={150} />
+        <Button
+          text={$_('actions.change-avatar')}
+          on:click={() => (openAvatarDialogue = true)}
+        />
+        <AvatarDialogue
+          bind:open={openAvatarDialogue}
+          bind:avatar
+          on:close={handleCloseAvatarDialogue}
+        />
+      </span>
     </fieldset>
   </section>
 </main>
@@ -114,6 +135,10 @@
 
   .with-progress {
     @apply grid grid-cols-[1fr,auto] items-center;
+  }
+
+  .aligned {
+    @apply flex items-center gap-4;
   }
 
   .error {

--- a/apps/web/src/routes/(auth)/account/AvatarDialogue.svelte
+++ b/apps/web/src/routes/(auth)/account/AvatarDialogue.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { createEventDispatcher } from 'svelte'
+  import { _ } from 'svelte-intl'
+
+  import { ConfirmDialogue, Input } from '../../../components'
+
+  export let open
+  export let avatar
+
+  const dispatch = createEventDispatcher()
+
+  function handleKey(event) {
+    if (event.key === 'Enter') {
+      dispatch('close', true)
+      open = false
+    }
+  }
+</script>
+
+<ConfirmDialogue
+  on:close
+  bind:open
+  title={$_('titles.change-avatar')}
+  confirmText={$_('actions.save')}
+  cancelText={$_('actions.back')}
+>
+  <Input
+    bind:value={avatar}
+    placeholder={$_('placeholders.avatar')}
+    on:keyup={handleKey}
+  />
+  <span>{$_('tooltips.change-avatar')}</span>
+</ConfirmDialogue>
+
+<style lang="postcss">
+  span {
+    @apply text-xs;
+  }
+</style>

--- a/apps/web/src/routes/home/+page.svelte
+++ b/apps/web/src/routes/home/+page.svelte
@@ -4,7 +4,7 @@
 
   import { CatalogItem, ConfirmDialogue, GameLink } from '../../components'
   import { Header } from '../../connected-components'
-  import { deleteGame, receiveGameListUpdates,toastInfo } from '../../stores'
+  import { deleteGame, receiveGameListUpdates, toastInfo } from '../../stores'
 
   /** @type {import('./$types').PageData} */
   export let data = {}

--- a/apps/web/src/stores/players.js
+++ b/apps/web/src/stores/players.js
@@ -78,8 +78,9 @@ export async function acceptTerms() {
 /**
  * Updates user details for the current player.
  * @param {string} username - the desired username, if any.
+ * @param {string} avatar - the desired avatar, if any.
  * @returns {Promise<object>} the current player, updated.
  */
-export async function updateCurrentPlayer(username) {
-  return runMutation(graphQL.updateCurrentPlayer, { username })
+export async function updateCurrentPlayer(username, avatar) {
+  return runMutation(graphQL.updateCurrentPlayer, { username, avatar })
 }

--- a/apps/web/tests/components/__snapshots__/Indicators.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Indicators.tools.shot
@@ -22,6 +22,7 @@ HTMLCollection [
       alt="avatar for Gaspard"
       class="s-engCJu8q-fNe"
       height="60"
+      referrerpolicy="no-referrer"
       width="60"
     />
      
@@ -119,6 +120,7 @@ exports[`Peer pointer 1`] = `
     alt="avatar for Gaspard"
     class="s-engCJu8q-fNe"
     height="60"
+    referrerpolicy="no-referrer"
     width="60"
   />
    

--- a/apps/web/tests/components/__snapshots__/PlayerAvatar.tools.shot
+++ b/apps/web/tests/components/__snapshots__/PlayerAvatar.tools.shot
@@ -13,6 +13,7 @@ exports[`Local 1`] = `
       alt="avatar for Joe le clodo"
       class="s-engCJu8q-fNe hasImage"
       height="150"
+      referrerpolicy="no-referrer"
       src="/tests/components/avatar.png"
       width="150"
     />
@@ -48,6 +49,7 @@ exports[`No video 1`] = `
       alt="avatar for Joe le clodo"
       class="s-engCJu8q-fNe hasImage"
       height="150"
+      referrerpolicy="no-referrer"
       src="/tests/components/avatar.png"
       width="150"
     />
@@ -80,6 +82,7 @@ exports[`No video nor avatar 1`] = `
       alt="avatar for Joe le clodo"
       class="s-engCJu8q-fNe"
       height="150"
+      referrerpolicy="no-referrer"
       width="150"
     />
      

--- a/apps/web/tests/components/__snapshots__/PlayerThumbnail.tools.shot
+++ b/apps/web/tests/components/__snapshots__/PlayerThumbnail.tools.shot
@@ -9,6 +9,7 @@ exports[`Avatar 1`] = `
     alt="avatar for Joe le clodo"
     class="s-engCJu8q-fNe hasImage"
     height="150"
+    referrerpolicy="no-referrer"
     src="/tests/components/avatar.png"
     width="150"
   />
@@ -25,6 +26,7 @@ exports[`Positioned text 1`] = `
     alt="avatar for Joe le clodo"
     class="s-engCJu8q-fNe"
     height="60"
+    referrerpolicy="no-referrer"
     width="60"
   />
    
@@ -45,6 +47,7 @@ exports[`Positionned avatar 1`] = `
     alt="avatar for Joe le clodo"
     class="s-engCJu8q-fNe hasImage"
     height="60"
+    referrerpolicy="no-referrer"
     src="/tests/components/avatar.png"
     width="60"
   />
@@ -61,6 +64,7 @@ exports[`Small text 1`] = `
     alt="avatar for Joe le clodo"
     class="s-engCJu8q-fNe"
     height="50"
+    referrerpolicy="no-referrer"
     width="50"
   />
    
@@ -81,6 +85,7 @@ exports[`Text 1`] = `
     alt="avatar for Joe le clodo"
     class="s-engCJu8q-fNe"
     height="150"
+    referrerpolicy="no-referrer"
     width="150"
   />
    

--- a/apps/web/tests/integration/account.spec.js
+++ b/apps/web/tests/integration/account.spec.js
@@ -50,6 +50,51 @@ describe('Account page', () => {
     await expect(accountPage.avatarImage).toHaveAttribute('src', player.avatar)
   })
 
+  it('can configure gravatar', async ({ page }) => {
+    const gravatar = `https://www.gravatar.com/avatar/0440c0a8bc7e7dbbb8cec0585ca3c25c?s=96`
+    const { setTokenCookie } = await mockGraphQl(page, {
+      getCurrentPlayer: {
+        token: faker.datatype.uuid(),
+        player,
+        turnCredentials: {
+          username: 'bob',
+          credentials: faker.internet.password()
+        }
+      },
+      updateCurrentPlayer: { ...player, avatar: gravatar }
+    })
+    await setTokenCookie()
+
+    const accountPage = new AccountPage(page)
+    await accountPage.goTo()
+    await accountPage.getStarted()
+    await accountPage.saveAvatar('gravatar')
+    await expect(accountPage.usernameInput).toHaveValue(player.username)
+    await expect(accountPage.avatarImage).toHaveAttribute('src', gravatar)
+  })
+
+  it('can clear avatar', async ({ page }) => {
+    const { setTokenCookie } = await mockGraphQl(page, {
+      getCurrentPlayer: {
+        token: faker.datatype.uuid(),
+        player,
+        turnCredentials: {
+          username: 'bob',
+          credentials: faker.internet.password()
+        }
+      },
+      updateCurrentPlayer: { ...player, avatar: null }
+    })
+    await setTokenCookie()
+
+    const accountPage = new AccountPage(page)
+    await accountPage.goTo()
+    await accountPage.getStarted()
+    await accountPage.saveAvatar(null)
+    await expect(accountPage.usernameInput).toHaveValue(player.username)
+    await expect(accountPage.avatarImage).toBeHidden()
+  })
+
   it('navigates back to home page', async ({ page }) => {
     const { setTokenCookie } = await mockGraphQl(page, {
       getCurrentPlayer: {

--- a/apps/web/tests/integration/pages/account.js
+++ b/apps/web/tests/integration/pages/account.js
@@ -32,23 +32,53 @@ export const AccountPage = mixin(
       this.usernameInput = page.locator(`input[name="username"]`)
       /** @type {Locator} */
       this.avatarImage = page.locator(`section img`)
+      /** @type {Locator} */
+      this.openAvatarDialogueButton = page.locator(`role=button`, {
+        hasText: translate('actions.change-avatar')
+      })
+      /** @type {Locator} */
+      this.avatarDialogue = page.locator(`role=dialog`)
+      /** @type {Locator} */
+      this.avatarInput = this.avatarDialogue.locator('role=textbox')
+      /** @type {Locator} */
+      this.avatarSaveButon = this.avatarDialogue.locator('role=button', {
+        hasText: translate('actions.save')
+      })
     }
 
     /**
      * Navigates to the page.
-     * @async
+     * @returns {Promise<void>}
      */
     async goTo() {
       await this.page.goto('/account')
-      await this.page.waitForLoadState()
+      await this.page.waitForLoadState('networkidle')
     }
 
     /**
      * Expects catalog heading visibility.
-     * @async
+     * @returns {Promise<void>}
      */
     async getStarted() {
       await expect(this.heading).toBeVisible()
+    }
+
+    /**
+     * Opens the avatar dialogue, type the provided value, and save.
+     * @param {string | null} avatar - new avatar saved. Use null to clear.
+     * @returns {Promise<void>}
+     */
+    async saveAvatar(avatar) {
+      await this.openAvatarDialogueButton.click()
+      await expect(this.avatarDialogue).toBeVisible()
+      await this.avatarInput.press('Control+a')
+      if (avatar === null) {
+        await this.avatarInput.press('Backspace')
+      } else {
+        await this.avatarInput.type(avatar)
+      }
+      await this.avatarSaveButon.click()
+      await expect(this.avatarDialogue).not.toBeVisible()
     }
   },
   AuthenticatedHeaderMixin,

--- a/apps/web/tests/integration/pages/game.js
+++ b/apps/web/tests/integration/pages/game.js
@@ -44,7 +44,7 @@ export const GamePage = mixin(
      */
     async goTo(gameId) {
       await this.page.goto(`/game/${gameId}`)
-      await this.page.waitForLoadState()
+      await this.page.waitForLoadState('networkidle')
     }
 
     /**

--- a/apps/web/tests/integration/pages/home.js
+++ b/apps/web/tests/integration/pages/home.js
@@ -60,7 +60,7 @@ export const HomePage = mixin(
      */
     async goTo() {
       await this.page.goto('/home')
-      await this.page.waitForLoadState()
+      await this.page.waitForLoadState('networkidle')
     }
 
     /**

--- a/apps/web/tests/integration/pages/login.js
+++ b/apps/web/tests/integration/pages/login.js
@@ -40,6 +40,7 @@ export class LoginPage {
    * Expects connect buttons heading visibility.
    */
   async getStarted() {
+    await this.page.waitForLoadState('networkidle')
     await expect(this.googleButton).toBeVisible()
     await expect(this.githubButton).toBeVisible()
     await expect(this.passwordDetails).toBeVisible()

--- a/apps/web/tests/integration/pages/new-game.js
+++ b/apps/web/tests/integration/pages/new-game.js
@@ -27,7 +27,7 @@ export const NewGamePage = mixin(
      */
     async goTo(gameKind) {
       await this.page.goto(`/game/new?name=${gameKind}`)
-      await this.page.waitForLoadState()
+      await this.page.waitForLoadState('networkidle')
     }
   },
   AuthenticatedHeaderMixin,

--- a/apps/web/tests/routes/(auth)/account/AvatarDialogue.tools.svelte
+++ b/apps/web/tests/routes/(auth)/account/AvatarDialogue.tools.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Tool, ToolBox } from '@atelier-wb/svelte'
+
+  import AvatarDialogue from '../../../../src/routes/(auth)/account/AvatarDialogue.svelte'
+</script>
+
+<ToolBox
+  component={AvatarDialogue}
+  name="Routes/account/Avatar dialogue"
+  props={{
+    open: true,
+    avatar: 'https://avatars.dicebear.com/api/micah/tabulous-avatar-4.svg'
+  }}
+  events={['close']}
+>
+  <Tool name="Default" />
+  <Tool name="Empty" props={{ open: true, avatar: null }} />
+</ToolBox>

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
@@ -68,6 +68,7 @@ exports[`Manual account 1`] = `
               alt="avatar for Jane Doe"
               class="s-engCJu8q-fNe hasImage"
               height="30"
+              referrerpolicy="no-referrer"
               src="https://avatars.dicebear.com/api/micah/tabulous-avatar-4.svg"
               width="30"
             />
@@ -156,6 +157,7 @@ exports[`Manual account 1`] = `
           alt="avatar for Jane Doe"
           class="s-engCJu8q-fNe hasImage"
           height="150"
+          referrerpolicy="no-referrer"
           src="https://avatars.dicebear.com/api/micah/tabulous-avatar-4.svg"
           width="150"
         />
@@ -235,6 +237,7 @@ exports[`OAuth account 1`] = `
               alt="avatar for John Clark"
               class="s-engCJu8q-fNe hasImage"
               height="30"
+              referrerpolicy="no-referrer"
               src="https://avatars.dicebear.com/api/micah/tabulous-avatar-10.svg"
               width="30"
             />
@@ -323,6 +326,7 @@ exports[`OAuth account 1`] = `
           alt="avatar for John Clark"
           class="s-engCJu8q-fNe hasImage"
           height="150"
+          referrerpolicy="no-referrer"
           src="https://avatars.dicebear.com/api/micah/tabulous-avatar-10.svg"
           width="150"
         />

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
@@ -149,21 +149,45 @@ exports[`Manual account 1`] = `
         Avatar : 
       </span>
        
-      <figure
-        class="s-engCJu8q-fNe"
-        style="--dimension: 150px; --color: undefined; --top: undefinedpx; --left: undefinedpx; --border-width: 5px"
+      <span
+        class="aligned s-GQCXmK5OKySU"
       >
-        <img
-          alt="avatar for Jane Doe"
-          class="s-engCJu8q-fNe hasImage"
-          height="150"
-          referrerpolicy="no-referrer"
-          src="https://avatars.dicebear.com/api/micah/tabulous-avatar-4.svg"
-          width="150"
-        />
+        <figure
+          class="s-engCJu8q-fNe"
+          style="--dimension: 150px; --color: undefined; --top: undefinedpx; --left: undefinedpx; --border-width: 5px"
+        >
+          <img
+            alt="avatar for Jane Doe"
+            class="s-engCJu8q-fNe hasImage"
+            height="150"
+            referrerpolicy="no-referrer"
+            src="https://avatars.dicebear.com/api/micah/tabulous-avatar-4.svg"
+            width="150"
+          />
+           
+        </figure>
+        <!--&lt;PlayerThumbnail&gt;-->
          
-      </figure>
-      <!--&lt;PlayerThumbnail&gt;-->
+        <button
+          class="s-NMyTiX1zi6rz"
+        >
+          
+          <span
+            class="text s-NMyTiX1zi6rz"
+          >
+            Changer
+          </span>
+          
+          
+        </button>
+        <!--&lt;Button&gt;-->
+         
+         
+        <!--&lt;Portal&gt;-->
+        <!--&lt;Dialogue&gt;-->
+        <!--&lt;ConfirmDialogue&gt;-->
+        <!--&lt;AvatarDialogue&gt;-->
+      </span>
     </fieldset>
   </section>
 </main>
@@ -318,21 +342,45 @@ exports[`OAuth account 1`] = `
         Avatar : 
       </span>
        
-      <figure
-        class="s-engCJu8q-fNe"
-        style="--dimension: 150px; --color: undefined; --top: undefinedpx; --left: undefinedpx; --border-width: 5px"
+      <span
+        class="aligned s-GQCXmK5OKySU"
       >
-        <img
-          alt="avatar for John Clark"
-          class="s-engCJu8q-fNe hasImage"
-          height="150"
-          referrerpolicy="no-referrer"
-          src="https://avatars.dicebear.com/api/micah/tabulous-avatar-10.svg"
-          width="150"
-        />
+        <figure
+          class="s-engCJu8q-fNe"
+          style="--dimension: 150px; --color: undefined; --top: undefinedpx; --left: undefinedpx; --border-width: 5px"
+        >
+          <img
+            alt="avatar for John Clark"
+            class="s-engCJu8q-fNe hasImage"
+            height="150"
+            referrerpolicy="no-referrer"
+            src="https://avatars.dicebear.com/api/micah/tabulous-avatar-10.svg"
+            width="150"
+          />
+           
+        </figure>
+        <!--&lt;PlayerThumbnail&gt;-->
          
-      </figure>
-      <!--&lt;PlayerThumbnail&gt;-->
+        <button
+          class="s-NMyTiX1zi6rz"
+        >
+          
+          <span
+            class="text s-NMyTiX1zi6rz"
+          >
+            Changer
+          </span>
+          
+          
+        </button>
+        <!--&lt;Button&gt;-->
+         
+         
+        <!--&lt;Portal&gt;-->
+        <!--&lt;Dialogue&gt;-->
+        <!--&lt;ConfirmDialogue&gt;-->
+        <!--&lt;AvatarDialogue&gt;-->
+      </span>
     </fieldset>
   </section>
 </main>

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/AvatarDialogue.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/AvatarDialogue.tools.shot
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Default 1`] = `undefined`;
+
+exports[`Empty 1`] = `undefined`;

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -441,6 +441,7 @@ exports[`Authenticated 1`] = `
               alt="avatar for Jane Doe"
               class="s-engCJu8q-fNe"
               height="30"
+              referrerpolicy="no-referrer"
               width="30"
             />
              

--- a/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
@@ -2342,6 +2342,7 @@ exports[`Connected 1`] = `
               alt="avatar for Jane Doe"
               class="s-engCJu8q-fNe"
               height="30"
+              referrerpolicy="no-referrer"
               width="30"
             />
              

--- a/apps/web/tests/stores/players.test.js
+++ b/apps/web/tests/stores/players.test.js
@@ -125,10 +125,12 @@ describe('acceptTerms()', () => {
 describe('updateCurrentPlayer()', () => {
   it('returns player on success', async () => {
     const username = faker.name.fullName()
+    const avatar = faker.internet.avatar()
     runMutation.mockResolvedValueOnce(player)
-    expect(await updateCurrentPlayer(username)).toEqual(player)
+    expect(await updateCurrentPlayer(username, avatar)).toEqual(player)
     expect(runMutation).toHaveBeenCalledWith(graphQL.updateCurrentPlayer, {
-      username
+      username,
+      avatar
     })
     expect(runMutation).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
### :book: What's in there?

It's now possible to change one's avatar! User must provide the url of their new avatar. 
Then can clear the value (to have their username displayed instead), or use the special value "gravatar" to get their gravatar based on their email (when defined).

[set-avatar.webm](https://user-images.githubusercontent.com/186268/202847271-f22cb962-fffa-4251-a338-22dfa78f863f.webm)


Are included here:

- fix(web): google avatars appear broken
- feat(server): defaults to gravatar on player creation
- feat(web): supports changing avatar's url
- fix(ci): playwright tests can be flaky

### :test_tube: How to test?

1. Connects with a manual account
   > you land on the home page
1. With the top-right player menu, navigate to account page
   > the page displays username, avatar, and a new button to change it
1. Click on the change avatar button
   > a dialogue opens. It can be closed with Escape, with the top-right close button, or the "Retour" button
1. Provide a valid image url
1. Hit the "Enter" key, or click "Sauver" button
   > the dialogue closes. Player avatar and thumbnail are updated with the new value

### :up: Notes to reviewers

- Google avatar URLs are returning 403 with the [wrong referer](https://stackoverflow.com/a/61042200/1182976).
- Playwright test needs to await for network idle, because svelte component may not be hydrated quick enough.
