### PR TITLE
chore(server): removes signal type and make it optional

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 
 ## Refactor
 
-- graphQL: remove signal type and make signal optional
 - add tests for web/src/utils/peer-connection
 - use node 18 when msw/interceptor will [handle it](https://github.com/mswjs/interceptors/pull/283)
 - ts-check all the things!

--- a/apps/server/src/graphql/signals-resolver.js
+++ b/apps/server/src/graphql/signals-resolver.js
@@ -53,7 +53,10 @@ export default {
         pubsub.publish({
           topic: `sendSignal-${player.id}`,
           payload: {
-            awaitSignal: { type: 'ready', from: 'server', signal: '{}' }
+            awaitSignal: {
+              from: 'server',
+              data: JSON.stringify({ type: 'ready' })
+            }
           }
         })
         services.setPlaying(player.id, true)

--- a/apps/server/src/graphql/signals.graphql
+++ b/apps/server/src/graphql/signals.graphql
@@ -1,13 +1,11 @@
 type Signal {
-  type: String!
   from: ID!
-  signal: String!
+  data: String!
 }
 
 input SignalInput {
-  type: String!
   to: ID!
-  signal: String!
+  data: String!
 }
 
 extend type Mutation {

--- a/apps/web/src/graphql/signals.graphql
+++ b/apps/web/src/graphql/signals.graphql
@@ -1,13 +1,12 @@
 mutation sendSignal($signal: SignalInput) {
   sendSignal(signal: $signal) {
-    type
+    from
   }
 }
 
 subscription awaitSignal {
   awaitSignal {
     from
-    type
-    signal
+    data
   }
 }

--- a/apps/web/tests/integration/game.spec.js
+++ b/apps/web/tests/integration/game.spec.js
@@ -89,7 +89,7 @@ describe('Game page', () => {
     onSubscription(({ payload: { query } }) => {
       if (query.startsWith('subscription awaitSignal')) {
         sendToSubscription({
-          data: { awaitSignal: { type: 'ready', signal: '{}' } }
+          data: { awaitSignal: { data: JSON.stringify({ type: 'ready' }) } }
         })
       }
     })


### PR DESCRIPTION
### :book: What's in there?

While refactoring the WebRTC client used, I realized that signals already have a type property, to distinguish offers, answers and candidates (no type). There is no need of an extra type property in exchanged GraphQL messages.

Are included here:

- chore(server): removes signal type and make it optional
- chore(web): removes signal type and make it optional

### :test_tube: How to test?

Once merged (because it requires server changes), creates a multi-player game, and make sure all players can connect with video and audio.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
