### PR TITLE
feat(web): displays loader while creating new game

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -94,7 +94,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - detailable/stackable behavior: preview a stack of meshes
 - hide/distinguish non-connected participants
-- loading spinner on game/new
 - is this right? given an active selection, when it anchors with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
 - collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)

--- a/apps/web/src/routes/(auth)/game/new/+page.svelte
+++ b/apps/web/src/routes/(auth)/game/new/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Button, Header } from '@src/components'
+  import { Button, Header, Progress } from '@src/components'
   import { createGame } from '@src/stores'
   import { translateError } from '@src/utils'
   import { onMount } from 'svelte'
@@ -43,8 +43,12 @@
   <section>
     {#if error}
       <p>{error}</p>
+      <a href="/home"><Button text={$_('labels.home')} icon="arrow_back" /></a>
+    {:else}
+      <div>
+        <Progress />
+      </div>
     {/if}
-    <a href="/home"><Button text={$_('labels.home')} icon="arrow_back" /></a>
   </section>
 </main>
 
@@ -54,10 +58,14 @@
   }
 
   section {
-    @apply flex flex-col lg:w-3/4 lg:mx-auto;
+    @apply flex flex-col lg:w-3/4 lg:mx-auto py-8;
   }
 
   p {
-    @apply text-2xl pt-8 pb-4;
+    @apply text-2xl pb-4;
+  }
+
+  div {
+    @apply flex flex-col items-center;
   }
 </style>

--- a/apps/web/tests/atelier/setup.js
+++ b/apps/web/tests/atelier/setup.js
@@ -1,6 +1,16 @@
 import '../../src/common'
 import './styles.postcss'
 
-import { init } from '../../node_modules/@sveltejs/kit/src/runtime/client/singletons'
+import * as svelteClient from '../../node_modules/@sveltejs/kit/src/runtime/client/singletons'
 
-init({ client: {} })
+svelteClient.init({ client: {} })
+
+/**
+ * Allows configuring svelte's page store with a given url
+ * @param {string} url - relative url for this page.
+ */
+export function setSvelteUrl(url) {
+  const fullUrl = new URL(url, 'https://example.com')
+  svelteClient.stores.url.set(fullUrl)
+  svelteClient.stores.page.set({ url: fullUrl })
+}

--- a/apps/web/tests/routes/(auth)/game/new/+page.test.js
+++ b/apps/web/tests/routes/(auth)/game/new/+page.test.js
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import NewGamePage from '@src/routes/(auth)/game/new/+page.svelte'
 import { createGame } from '@src/stores'
-import { render } from '@testing-library/svelte'
+import { render, screen } from '@testing-library/svelte'
 import { sleep } from '@tests/test-utils'
 import { get } from 'svelte/store'
 import html from 'svelte-htm'
@@ -20,6 +20,12 @@ describe('/game/new route', () => {
 
   beforeEach(vi.resetAllMocks)
 
+  it('displays loader while creating game', async () => {
+    get(page).url.searchParams.set('name', game.name)
+    render(html`<${NewGamePage} />`)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
   it('displays error when too many games where created', async () => {
     get(page).url.searchParams.set('name', game.name)
     createGame.mockRejectedValueOnce(
@@ -27,6 +33,7 @@ describe('/game/new route', () => {
     )
     const { container } = render(html`<${NewGamePage} />`)
     await sleep()
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     expect(createGame).toHaveBeenCalledWith(game.name)
     expect(container).toMatchSnapshot()
     expect(goto).not.toHaveBeenCalled()
@@ -37,6 +44,7 @@ describe('/game/new route', () => {
     createGame.mockRejectedValueOnce(new Error('Access to game is restricted'))
     const { container } = render(html`<${NewGamePage} />`)
     await sleep()
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     expect(createGame).toHaveBeenCalledWith(game.name)
     expect(container).toMatchSnapshot()
     expect(goto).not.toHaveBeenCalled()


### PR DESCRIPTION
### :book: What's in there?

The new game page, despite being transient, is still visible, and does not have any loading state. Yet.

Are included here:

- feat(web): displays loader while creating new game.

### :test_tube: How to test?

1. from the home page, creates a new game
   > while waiting for the game to be created on server side, a loading spinner is visible.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
