### PR TITLE
feat(server): introduces game guests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,7 @@
 # TODO
 
+collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
+
 ## Brittle tests
 
 - tests/atelier/tools.test.js > Toolshot > components/RadialMenu.tools.svelte
@@ -96,7 +98,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - hide/distinguish non-connected participants
 - is this right? given an active selection, when it anchors with other items, then items are part of the selection
 - click on stack size to select all/select stack on push?
-- collect player preferences when joining a game (requires to alter & reload game when joining rather than inviting)
 - option to invite players with url
 - distribute multiple meshes to players' hand
 - shortcuts cheatsheet

--- a/apps/server/migrations/002-guests.js
+++ b/apps/server/migrations/002-guests.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+export async function apply(repositories) {
+  await iteratePage(repositories.games, async game => {
+    if (!Array.isArray(game.guestIds)) {
+      game.guestIds = []
+      await repositories.games.save(game)
+    }
+  })
+}
+
+async function iteratePage(repository, apply, { from = 0 } = {}) {
+  const { total, results } = await repository.list({ from })
+  for (const obj of results) {
+    await apply(obj)
+  }
+  const next = from + results.length
+  if (total > next) {
+    await iteratePage(repository, apply, { from: next })
+  }
+}

--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -5,10 +5,11 @@ import { isAuthenticated } from './utils.js'
 
 export default {
   loaders: {
+    /**
+     * Loads player and guest details on the fly.
+     * Disable cache since playing statuses are volatile
+     */
     Game: {
-      /**
-       * Loads player details of each game.
-       */
       players: {
         async loader(queries) {
           return Promise.all(
@@ -18,10 +19,18 @@ export default {
             )
           )
         },
-        // disable cache since playing statuses are volatile
-        opts: {
-          cache: false
-        }
+        opts: { cache: false }
+      },
+      guests: {
+        async loader(queries) {
+          return Promise.all(
+            queries.map(
+              ({ obj: { guestIds, guests } }) =>
+                guests ?? services.getPlayerById(guestIds)
+            )
+          )
+        },
+        opts: { cache: false }
       }
     }
   },

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -6,6 +6,7 @@ type Game {
   locales: ItemLocales!
   created: Float!
   players: [Player]!
+  guests: [Player]!
   meshes: [Mesh]!
   messages: [Message]
   cameras: [CameraPosition]

--- a/apps/server/tests/fixtures/invalid-games/throwing-on-player/index.js
+++ b/apps/server/tests/fixtures/invalid-games/throwing-on-player/index.js
@@ -2,9 +2,6 @@ export function build() {
   return { meshes: [] }
 }
 
-export function addPlayer(game) {
-  if (game.playerIds.length > 1) {
-    throw new Error('internal addPlayer error')
-  }
-  return game
+export function addPlayer() {
+  throw new Error('internal addPlayer error')
 }

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -86,6 +86,9 @@ fragment fullGame on Game {
   players {
     ...lightPlayer
   }
+  guests {
+    ...lightPlayer
+  }
   availableSeats
   meshes {
     ...mesh
@@ -132,6 +135,9 @@ fragment lightGame on Game {
   created
   kind
   players {
+    ...lightPlayer
+  }
+  guests {
     ...lightPlayer
   }
   locales {

--- a/apps/web/src/locales/fr.yaml
+++ b/apps/web/src/locales/fr.yaml
@@ -58,6 +58,7 @@ labels:
   oauth-provider: Vous avez relié ce compte à votre adresse "{email}"
   old-enough: Je déclare avoir plus de 15 ans ou être autorisé(e) par l’un de mes parents
   peer-players: avec {names}
+  peer-guests: 'invités: {names}'
   player-joined: '{player.username} a rejoint la partie !'
   player-left: '{player.username} a quitté la partie'
   terms-accepted: J'ai lu et accepté les Conditions Générales d'Utilisation

--- a/apps/web/src/routes/home/GameLink.svelte
+++ b/apps/web/src/routes/home/GameLink.svelte
@@ -10,10 +10,14 @@
 
   const dispatch = createEventDispatcher()
   const owned = game.players[0]?.id === playerId
-  $: isSingle = game.players.length === 1
-  $: peerNames = game.players
-    .filter(player => player && player.id !== playerId)
-    .map(({ username }) => username)
+  $: peerNames = extractNames(game.players)
+  $: guestNames = extractNames(game.guests)
+
+  function extractNames(array) {
+    return array
+      .filter(player => player && player.id !== playerId)
+      .map(({ username }) => username)
+  }
 
   function handleDelete(event) {
     dispatch('delete', game)
@@ -43,9 +47,12 @@
       />{/if}
   </span>
   <span class="created">{$_('{ created, date, short-date }', game)}</span>
-  {#if !isSingle}
-    <span class="players"
-      >{$_('labels.peer-players', { names: peerNames.join(', ') })}</span
+  {#if peerNames.length}
+    <span>{$_('labels.peer-players', { names: peerNames.join(', ') })}</span>
+  {/if}
+  {#if guestNames.length}
+    <span class="guests"
+      >{$_('labels.peer-guests', { names: guestNames.join(', ') })}</span
     >
   {/if}
 </article>
@@ -62,6 +69,10 @@
 
   .title {
     @apply inline-flex flex-nowrap items-center gap-4 mb-2;
+  }
+
+  .guests {
+    @apply text-$primary;
   }
 
   h3 {

--- a/apps/web/tests/integration/home.spec.js
+++ b/apps/web/tests/integration/home.spec.js
@@ -45,6 +45,7 @@ describe('Home page', () => {
       created: recent,
       kind: 'dune-imperium',
       players: [{ id: '1789', username: 'Dams' }, player],
+      guests: [],
       locales: { fr: { title: 'Dune Imperium' } }
     },
     {
@@ -52,6 +53,7 @@ describe('Home page', () => {
       created: recent2,
       kind: 'terraforming-mars',
       players: [player],
+      guests: [],
       locales: { fr: { title: 'Terraforming Mars' } }
     },
     {
@@ -59,6 +61,7 @@ describe('Home page', () => {
       created: faker.date.recent(3, recent2).getTime(),
       kind: 'terraforming-mars',
       players: [{ id: '1789', username: 'Dams' }],
+      guests: [],
       locales: { fr: { title: 'Terraforming Mars' } }
     }
   ]

--- a/apps/web/tests/routes/(auth)/game/new/+page.tools.svelte
+++ b/apps/web/tests/routes/(auth)/game/new/+page.tools.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Tool, ToolBox } from '@atelier-wb/svelte'
+  import NewGamePage from '@src/routes/(auth)/game/new/+page.svelte'
+  import { setSvelteUrl } from '@tests/atelier/setup'
+</script>
+
+<ToolBox
+  component={NewGamePage}
+  name="Routes/game/new"
+  setup={() => setSvelteUrl('game/new?name=klondike')}
+>
+  <Tool name="Error" />
+</ToolBox>

--- a/apps/web/tests/routes/home/+page.tools.svelte
+++ b/apps/web/tests/routes/home/+page.tools.svelte
@@ -85,6 +85,7 @@
         player,
         { id: '8850', username: 'Célia', playing: false }
       ],
+      guests: [{ id: '3432', username: 'Hugo', playing: false }],
       locales: { fr: { title: '6 qui prend !' } }
     },
     {
@@ -92,6 +93,7 @@
       created: 1659424383964,
       kind: '32-cards',
       players: [player],
+      guests: [],
       locales: { fr: { title: 'Jeu de 32 cartes' } }
     }
   ]

--- a/apps/web/tests/routes/home/GameLink.tools.svelte
+++ b/apps/web/tests/routes/home/GameLink.tools.svelte
@@ -7,11 +7,17 @@
     { id: '485d5a8d-5a6b-4fa9-b54c-2020bab66368', username: 'Sarah' },
     { id: 'dfd83db5-978d-42e3-bf5c-8922f387ea59', username: 'Timothé' }
   ]
+  const guests = [
+    { id: 'e02ce071-5dfe-407b-acb4-13ae0eb1aa04', username: 'John' },
+    { id: 'd8a5d584-5a6b-4fa9-b54c-2020bab66863', username: 'Georges' }
+  ]
   const game = {
     id: 'fb236220-62a3-4c97-b938-716512386153',
     kind: 'riichi',
     locales: { fr: { title: 'Richii Mahjong' } },
-    created: 1619983503676
+    created: 1619983503676,
+    players: [],
+    guests: []
   }
 </script>
 
@@ -27,7 +33,10 @@
   events={['delete']}
   layout="centered"
 >
-  <Tool name="Owned" props={{ playerId: players[0].id }} />
+  <Tool
+    name="Owned"
+    props={{ playerId: players[0].id, game: { ...game, players, guests } }}
+  />
   <Tool
     name="Single owned"
     props={{
@@ -36,4 +45,5 @@
     }}
   />
   <Tool name="Invited" props={{ playerId: players[1].id }} />
+  <Tool name="Guests only" props={{ game: { ...game, guests } }} />
 </ToolBox>

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -524,6 +524,7 @@ exports[`Authenticated 1`] = `
           02 août, 09:13
         </span>
          
+         
       </article>
       <!--&lt;GameLink&gt;-->
       
@@ -550,9 +551,15 @@ exports[`Authenticated 1`] = `
         </span>
          
         <span
-          class="players s-QQoQzhRq8NK6"
+          class="s-QQoQzhRq8NK6"
         >
           avec Dams, Célia
+        </span>
+         
+        <span
+          class="guests s-QQoQzhRq8NK6"
+        >
+          invités: Hugo
         </span>
       </article>
       <!--&lt;GameLink&gt;-->


### PR DESCRIPTION
### :book: What's in there?

At some point, we need players to provide some input when they join a game for the first time.
This implies they are added to the game the first time they load a game after creation (for the owner) or after an invite (for peers).

With this PR, creating a game and inviting to a game assigns the player to the `guestIds` list. They'll be moved from `guestIds` to `playerIds` the first time they would load it.

It makes also sure that guests are notified as regular peers: when their games are added, modified or deleted.

This change has no impact on the client side, except a minor visual difference between peer players and peer guests on the home page.

Are included here:

- feat(server): introduces guestIds field for games
- feat(server): exposes game's guests
- feat(server): adds player to game on first load instead of invite/creation
- feat(web): distinguishes guests from players
- tests(web): tools for new game page

### :test_tube: How to test?

1. Run database migration: `pnpm migrate`
2. Log in as player A, create a new game
   > The game loads a before
3. Log in as player B in a different browser
4. Player A invites player B
   > Player B's home page has a new game
5. Player A goes back to home page
   > Player B appears as guest on the created game
6. Player B joins the game
   > On Player A's home page, Player B appears now as a peer
7. Player B leaves game
   > They appear as peer on the created game
8. Player A removes game
   > It disappears from Player B's home page

[guest-list.webm](https://user-images.githubusercontent.com/186268/203121231-ed8d7f7c-0ccd-42f3-b127-b2794ecda3cc.webm)



<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
