### PR TITLE
feat(web): selects meshes by clicking on their size/quantity indicator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,6 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - detailable/stackable behavior: preview a stack of meshes
 - hide/distinguish non-connected participants
 - is this right? given an active selection, when it anchors with other items, then items are part of the selection
-- click on stack size to select all/select stack on push?
 - option to invite players with url
 - distribute multiple meshes to players' hand
 - shortcuts cheatsheet

--- a/apps/web/src/components/Label.svelte
+++ b/apps/web/src/components/Label.svelte
@@ -1,13 +1,23 @@
 <script>
   export let content
+  export let onClick
   export let screenPosition = { x: 0, y: 0 }
   export let color = '#7a7a7a'
   export let centered = false
+
+  function interact() {
+    onClick?.()
+  }
 </script>
 
 <div
   class:centered
-  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}"
+  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}; pointer-events:{onClick
+    ? 'auto'
+    : 'none'};"
+  on:click={interact}
+  on:keydown={interact}
+  on:pointerdown|stopPropagation
 >
   {content}
 </div>
@@ -15,7 +25,7 @@
 <style lang="postcss">
   div {
     @apply absolute transform-gpu -translate-y-1/2 -translate-x-1
-            pointer-events-none 
+            select-none 
             text-lg text-$primary-lightest opacity-85
             py-1 pr-2 pl-5 rounded z-10;
     clip-path: polygon(1rem 0%, 100% 0, 100% 100%, 1rem 100%, 0% 50%);

--- a/apps/web/src/routes/(auth)/game/[gameId]/GameHand.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/GameHand.svelte
@@ -23,7 +23,12 @@
   })
 </script>
 
-<aside class:highlight class:visible style="--color: {color}">
+<aside
+  class:highlight
+  class:visible
+  style="--color: {color}"
+  on:pointerdown|stopPropagation
+>
   <MinimizableSection
     placement="bottom"
     tabs={[{ icon: 'front_hand', key: $_('shortcuts.hand') }]}

--- a/apps/web/src/routes/(auth)/game/[gameId]/Indicators.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/Indicators.svelte
@@ -26,10 +26,11 @@
   }
 </script>
 
-{#each items as { screenPosition, id, mesh, player, ...rest } ({ id, screenPosition })}
+{#each items as { screenPosition, id, mesh, player, onClick, ...rest } ({ id, screenPosition })}
   {#if mesh}
     <Label
       {screenPosition}
+      {onClick}
       centered={!!player}
       content={computeLabel(player, rest)}
       color={player?.color}

--- a/apps/web/src/stores/indicators.js
+++ b/apps/web/src/stores/indicators.js
@@ -1,5 +1,6 @@
 import { BehaviorSubject, map, merge, of, withLatestFrom } from 'rxjs'
 
+import { selectionManager } from '../3d/managers'
 import { getPixelDimension, observeDimension } from '../utils/dom'
 import {
   actionMenuProps,
@@ -79,7 +80,8 @@ export const visibleIndicators = merge(
       handPosition
     )
   ),
-  map(enrichWithPlayerData)
+  map(enrichWithPlayerData),
+  map(enrichWithInteraction)
 )
 
 /**
@@ -132,6 +134,16 @@ function enrichWithPlayerData(indicators) {
     }
     return indicator
   })
+}
+
+function enrichWithInteraction(indicators) {
+  return indicators.map(indicator => ({
+    ...indicator,
+    onClick:
+      indicator.mesh && !selectionManager.meshes.has(indicator.mesh)
+        ? () => selectionManager.select([indicator.mesh])
+        : null
+  }))
 }
 
 function memorizeAndMergeFeedback(indicators) {

--- a/apps/web/tests/routes/(auth)/game/[gameid]/Indicators.tools.svelte
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/Indicators.tools.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Tool, ToolBox } from '@atelier-wb/svelte'
+  import { recordEvent, Tool, ToolBox } from '@atelier-wb/svelte'
   import Indicators from '@src/routes/(auth)/game/[gameId]/Indicators.svelte'
 </script>
 
@@ -12,7 +12,13 @@
     name="Single"
     props={{
       items: [
-        { screenPosition: { x: 50, y: 100 }, size: 5, id: 'card1', mesh: {} }
+        {
+          screenPosition: { x: 50, y: 100 },
+          size: 5,
+          id: 'card1',
+          mesh: {},
+          onClick: () => recordEvent('select')
+        }
       ]
     }}
   />

--- a/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Indicators.tools.shot
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Indicators.tools.shot
@@ -4,13 +4,13 @@ exports[`All kinds 1`] = `
 HTMLCollection [
   <div
     class="s-WFVnM7df3-nu centered"
-    style="top: 125px; left: 150px; --color: cyan;"
+    style="top: 125px; left: 150px; --color: cyan; pointer-events: none;"
   >
     Gaspard
   </div>,
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 140px; left: 150px; --color: #7a7a7a;"
+    style="top: 140px; left: 150px; --color: #7a7a7a; pointer-events: none;"
   >
     3
   </div>,
@@ -88,7 +88,7 @@ exports[`Feedback for player 1`] = `
 exports[`For player 1`] = `
 <div
   class="s-WFVnM7df3-nu centered"
-  style="top: 125px; left: 150px; --color: #967d3e;"
+  style="top: 125px; left: 150px; --color: #967d3e; pointer-events: none;"
 >
   Gaspard
 </div>
@@ -98,13 +98,13 @@ exports[`Multiple 1`] = `
 HTMLCollection [
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 100px; left: 50px; --color: #7a7a7a;"
+    style="top: 100px; left: 50px; --color: #7a7a7a; pointer-events: none;"
   >
     5
   </div>,
   <div
     class="s-WFVnM7df3-nu"
-    style="top: 200px; left: 150px; --color: #7a7a7a;"
+    style="top: 200px; left: 150px; --color: #7a7a7a; pointer-events: none;"
   >
     27
   </div>,
@@ -135,7 +135,7 @@ exports[`Peer pointer 1`] = `
 exports[`Single 1`] = `
 <div
   class="s-WFVnM7df3-nu"
-  style="top: 100px; left: 50px; --color: #7a7a7a;"
+  style="top: 100px; left: 50px; --color: #7a7a7a; pointer-events: auto;"
 >
   5
 </div>


### PR DESCRIPTION
### :book: What's in there?

Quantifiable and stackable meshes have a quantity/size indicator. It seems natural to select them when clicking on it.
However indicators were made non-interactive to avoid "hiding" their mesh, preventing mouse interaction (rotate, flip, move...). Therefore, once a mesh is selected, its indicator is not interactive any more.

[select-with-indicators.webm](https://user-images.githubusercontent.com/186268/208267788-a305d5d6-a939-49dc-b9b7-34260f5b0c22.webm)

- feat(web): selects meshes by clicking on their size/quantity indicator

### :test_tube: How to test?

1. stack a couple meshes
   > They should have an indicator now
1. click on the indicator
   > It select the whole stack
1. interacts with the current selection (move, flip, rotate...)
   > Selected meshes apply your commands
1. click on the indicator 
   > the indicator does not capture clicks: you can move/flip/rotate the underneath meshes

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
