### PR TITLE
refactor(web): reworked indicators

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
   ```
 
 - expectEvents tests/3d/managers/input.test.js:1591:19
+
   ```
   1589|     expect(hovers).toHaveLength(counts.hovers ?? 0)
   1590|     expect(wheels).toHaveLength(counts.wheels ?? 0)
@@ -18,6 +19,7 @@
       |                   ^
   1592|     expect(keys).toHaveLength(counts.keys ?? 0)
   ```
+
 - tests/3d/managers/input.test.js > InputManager > given an initialized manager > handles multiple pointers double taps
 
   ```
@@ -51,30 +53,64 @@
       }
   ```
 
+- tests/3d/managers/input.test.js > InputManager > given an initialized manager > starts and stops pinch operation''
+
+  ```
+  AssertionError: expected [ { type: 'longPointer', …(3) } ] to have a length of +0 but got 1
+  ❯ expectEvents tests/3d/managers/input.test.js:1614:19
+      1612|     expect(hovers).toHaveLength(counts.hovers ?? 0)
+      1613|     expect(wheels).toHaveLength(counts.wheels ?? 0)
+      1614|     expect(longs).toHaveLength(counts.longs ?? 0)
+        |                   ^
+      1615|     expect(keys).toHaveLength(counts.keys ?? 0)
+      1616|   }
+  ❯ tests/3d/managers/input.test.js:869:9
+
+    - Expected   "0"
+    + Received   "1"
+  ```
+
+- tests/3d/managers/hand.test.js > HandManager > given an initialized manager > given some meshs in hand > moves mesh to hand by dragging
+
+  ```
+  AssertionError: expected -3.5 to be close to -5.25, received difference is 1.75, but expected 0.005
+  ❯ expectCloseVector tests/test-utils.js:144:29
+      142|
+      143| export function expectCloseVector(actual, [x, y, z], message) {
+      144|   expect(actual.x, message).toBeCloseTo(x)
+        |                             ^
+      145|   expect(actual.y, message).toBeCloseTo(y)
+      146|   expect(actual.z, message).toBeCloseTo(z)
+  ❯ Module.expectPosition tests/test-utils.js:132:3
+  ❯ tests/3d/managers/hand.test.js:707:9
+
+    - Expected   "-5.25"
+    + Received   "-3.5"
+  ```
+
 - tests/connected-components/InvitePlayerDialogue.test.js > InvitePlayerDialogue connected component > debounce searches
 
-```
-AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
-❯ tests/connected-components/InvitePlayerDialogue.test.js:56:27
-    54|     }
-    55|     expect(searchPlayers).toHaveBeenNthCalledWith(1, 'an')
-    56|     expect(searchPlayers).toHaveBeenNthCalledWith(2, 'anima')
-      |                           ^
-    57|     expect(searchPlayers).toHaveBeenCalledTimes(2)
-    58|   })
+  ```
+  AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
+  ❯ tests/connected-components/InvitePlayerDialogue.test.js:56:27
+      54|     }
+      55|     expect(searchPlayers).toHaveBeenNthCalledWith(1, 'an')
+      56|     expect(searchPlayers).toHaveBeenNthCalledWith(2, 'anima')
+        |                           ^
+      57|     expect(searchPlayers).toHaveBeenCalledTimes(2)
+      58|   })
 
-  - Expected  - 1
-  + Received  + 1
+    - Expected  - 1
+    + Received  + 1
 
-    Array [
-  -   "anima",
-  +   "anim",
-    ]
-```
+      Array [
+    -   "anima",
+    +   "anim",
+      ]
+  ```
 
 ## Refactor
 
-- vitest@0.25.8: issue when loading peer deps, resolve in [next release](https://github.com/vitest-dev/vitest/pull/2463)
 - @urql/core@3.1.1: receiveGameListUpdates subscribtion fails because urql's stringification sends the whole games.graphql file instead of the subscription as a payload. This is because [these lines](https://github.com/urql-graphql/urql/pull/2871/files#diff-425e8fcb48a8df1865f99ca1fb981873c6d0ef33ee3856e18f85a8b449bb81b7R41-R42)
 - add tests for web/src/utils/peer-connection
 - use node 18 when msw/interceptor will [handle it](https://github.com/mswjs/interceptors/pull/283)
@@ -105,6 +141,14 @@ AssertionError: expected 2nd "spy" call to have been called with [ 'anima' ]
 - "box" space for unusued/undesired meshes
 - command to "switch place" around the table, for games like Belote
 - fullscreen and default key (F11)
+- hide media dropdown unless hovering?
+
+23:09:47,374 Uncaught InternalError: too much recursion
+Immutable 10
+players-9eebbfcf.js:315:100318 (https://github.com/ReactiveX/rxjs/blob/630d2b009b5ae4e8f2a62d9740738c1ec317c2d5/src/internal/scheduler/intervalProvider.ts#L22)
+Immutable 128
+
+This is bound to rxjs asyncScheduler, which depends on the operator used (probably time operators)
 
 ## Server
 

--- a/apps/cli/src/commands/show-player.js
+++ b/apps/cli/src/commands/show-player.js
@@ -17,7 +17,7 @@ import {
  * @typedef {object} PlayerDetails
  * @property {string} id
  * @property {string} username
- * @property {boolean} playing
+ * @property {number} currentGameId
  * @property {string} provider
  * @property {string} email
  * @property {boolean} termsAccepted
@@ -83,7 +83,7 @@ function formatPlayerDetails({
   username,
   email,
   provider,
-  playing,
+  currentGameId,
   termsAccepted
 }) {
   return chalkTemplate`{dim id:}             ${id} ${isAdmin ? '🥷' : ''}
@@ -91,7 +91,7 @@ function formatPlayerDetails({
 {dim email:}          ${email || 'none'}
 {dim provider:}       ${provider || 'manual'}
 {dim terms accepted:} ${!!termsAccepted}
-{dim is playing:}     ${!!playing}`
+{dim is playing:}     ${currentGameId || 'none'}`
 }
 
 function formatGames({ id, games }) {

--- a/apps/cli/src/util/find-user.js
+++ b/apps/cli/src/util/find-user.js
@@ -14,7 +14,7 @@ const findUserQuery = gql`
       avatar
       provider
       termsAccepted
-      playing
+      currentGameId
     }
   }
 `

--- a/apps/cli/tests/commands/show-player.test.js
+++ b/apps/cli/tests/commands/show-player.test.js
@@ -98,7 +98,7 @@ describe('Show player command', () => {
       expect(rawOutput).toContain(`username:       ${player.username}`)
       expect(rawOutput).toContain(`email:          ${player.email}`)
       expect(rawOutput).toContain(`provider:       manual`)
-      expect(rawOutput).toContain(`is playing:     false`)
+      expect(rawOutput).toContain(`is playing:     none`)
       expect(rawOutput).toContain(`terms accepted: false`)
       expect(rawOutput).toContain(`total games:    0`)
     })
@@ -116,6 +116,7 @@ describe('Show player command', () => {
     })
 
     it('handles booleans, provider, admin, email', async () => {
+      const gameId = faker.datatype.uuid()
       mockQuery
         .mockResolvedValueOnce({
           searchPlayers: [
@@ -123,7 +124,7 @@ describe('Show player command', () => {
               ...player,
               isAdmin: true,
               termsAccepted: false,
-              playing: true,
+              currentGameId: gameId,
               provider: 'github',
               email: undefined
             }
@@ -133,7 +134,7 @@ describe('Show player command', () => {
       const rawOutput = stripAnsi(
         applyFormaters(await showPlayer(['-u', player.username])).join('\n')
       )
-      expect(rawOutput).toContain(`is playing:     true`)
+      expect(rawOutput).toContain(`is playing:     ${gameId}`)
       expect(rawOutput).toContain(`terms accepted: false`)
       expect(rawOutput).toContain(`provider:       github`)
       expect(rawOutput).toContain(`email:          none`)

--- a/apps/server/src/utils/games.js
+++ b/apps/server/src/utils/games.js
@@ -26,7 +26,7 @@ import { shuffle } from './collections.js'
  * Use bags to randomize meshes, and use slots to assign them to given positions (and with specific properties).
  * Slot will stack onto meshes already there, optionnaly snapping them to an anchor.
  * Meshes remaining in bags after processing all slots will be removed.
- * @property {import('../services/games').Mesh[]} meshes? - all meshes.
+ * @property {Mesh[]} meshes? - all meshes.
  * @property {Map<string, string[]>} bags? - map of randomized bags, as a list of mesh ids.
  * @property {Slot[]} slots? - a list of position slots
  */
@@ -58,7 +58,7 @@ import { shuffle } from './collections.js'
  * @async
  * @param {string} kind - created game's kind.
  * @param {GameDescriptor} descriptor - to create game from.
- * @returns {import('../services/games').Mesh[]} a list of serialized 3D meshes.
+ * @returns {Mesh[]} a list of serialized 3D meshes.
  */
 export async function createMeshes(kind, descriptor) {
   const { slots, bags, meshes } = await descriptor.build()
@@ -270,7 +270,7 @@ export function findOrCreateHand(game, playerId) {
  * Finds a mesh by id.
  * @param {string} id - desired mesh id.
  * @param {*} meshes - mesh list to search in.
- * @returns {import('../services/games').Mesh|null} corresponding mesh, if any.
+ * @returns {Mesh|null} corresponding mesh, if any.
  */
 export function findMeshById(id, meshes) {
   return meshes?.find(mesh => mesh.id === id) ?? null
@@ -285,7 +285,7 @@ function drawMesh(stackMesh, meshes) {
 
 /**
  * Stack all provided meshes, in order (the first becomes stack base).
- * @param {import('../services/games').Mesh[]} meshes - stacked meshes.
+ * @param {Mesh[]} meshes - stacked meshes.
  */
 export function stackMeshes(meshes) {
   const stackIds = meshes.slice(1).map(({ id }) => id)
@@ -300,8 +300,8 @@ export function stackMeshes(meshes) {
  * If the anchor is already used, tries to stack the meshes (the current snapped mesh must be in provided meshes).
  * Abort the operation when meshes can't be stacked.
  * @param {string} anchorId - desired anchor id.
- * @param {import('../services/games').Mesh} mesh? - snapped mesh, if any.
- * @param {import('../services/games').Mesh[]} meshes - all meshes to search the anchor in.
+ * @param {Mesh} mesh? - snapped mesh, if any.
+ * @param {Mesh[]} meshes - all meshes to search the anchor in.
  * @return {boolean} true if the mesh could be snapped or stacked. False otherwise.
  */
 export function snapTo(anchorId, mesh, meshes) {
@@ -321,6 +321,23 @@ export function snapTo(anchorId, mesh, meshes) {
   return true
 }
 
+/**
+ * Unsnapps a mesh from a given anchor.
+ * @param {string} anchorId - desired anchor id.
+ * @param {Mesh[]} meshes - all meshes to search the anchor in.
+ * @returns {Mesh|null} unsnapped meshes, or undefined if the anchor does not exist,
+ * has no snapped mesh, or has an unexisting snapped mesh
+ */
+export function unsnap(anchorId, meshes) {
+  const anchor = findAnchor(anchorId, meshes)
+  if (!anchor || !anchor.snappedId) {
+    return null
+  }
+  const id = anchor.snappedId
+  anchor.snappedId = null
+  return findMeshById(id, meshes)
+}
+
 function canStack(base, mesh) {
   return Boolean(base?.stackable) && Boolean(mesh?.stackable)
 }
@@ -337,8 +354,8 @@ export function mergeProps(object, props) {
 
 /**
  * Decrements a quantifiable mesh, by creating another one (when relevant)
- * @param {import('../services/games').Mesh} mesh - quantifiable mesh
- * @returns {import('../services/games').Mesh} the created object, if relevant
+ * @param {Mesh} mesh - quantifiable mesh
+ * @returns {Mesh} the created object, if relevant
  */
 export function decrement(mesh) {
   if (mesh?.quantifiable?.quantity > 1) {

--- a/apps/server/tests/utils/games.test.js
+++ b/apps/server/tests/utils/games.test.js
@@ -13,8 +13,8 @@ import {
   findOrCreateHand,
   getParameterSchema,
   snapTo,
-  stackMeshes
-} from '../../src/utils/games.js'
+  stackMeshes,
+  unsnap} from '../../src/utils/games.js'
 import { cloneAsJSON } from '../test-utils.js'
 
 describe('createMeshes()', () => {
@@ -776,6 +776,52 @@ describe('snapTo()', () => {
     const state = cloneAsJSON(meshes)
     expect(snapTo('anchor1', null, meshes)).toBe(false)
     expect(state).toEqual(meshes)
+  })
+})
+
+describe('unsnap()', () => {
+  let meshes
+
+  beforeEach(() => {
+    meshes = [
+      {
+        id: 'mesh1',
+        anchorable: {
+          anchors: [{ id: 'anchor1', snappedId: 'mesh2' }, { id: 'anchor2' }]
+        }
+      },
+      {
+        id: 'mesh2',
+        anchorable: {
+          anchors: [
+            { id: 'anchor3', snappedId: 'mesh3' },
+            { id: 'anchor4', snappedId: 'unknown' }
+          ]
+        }
+      },
+      {
+        id: 'mesh3'
+      }
+    ]
+  })
+
+  it('returns nothing on unknown anchor', () => {
+    expect(unsnap('unknown', meshes)).toBeNull()
+  })
+
+  it('returns nothing on anchor with no snapped mesh', () => {
+    expect(unsnap('anchor2', meshes)).toBeNull()
+  })
+  it('returns nothing on anchor with unknown snapped mesh', () => {
+    expect(unsnap('anchor4', meshes)).toBeNull()
+  })
+
+  it('returns mesh and unsnapps it', () => {
+    expect(unsnap('anchor3', meshes)).toEqual(meshes[2])
+    expect(meshes[1].anchorable.anchors).toEqual([
+      { id: 'anchor3', snappedId: null },
+      { id: 'anchor4', snappedId: 'unknown' }
+    ])
   })
 })
 

--- a/apps/web/src/3d/behaviors/targetable.js
+++ b/apps/web/src/3d/behaviors/targetable.js
@@ -95,6 +95,7 @@ export class TargetBehavior {
   addZone(mesh, properties) {
     mesh.visibility = 0
     mesh.isPickable = false
+    mesh.scalingDeterminant = 1.01
     const zone = {
       mesh,
       targetable: this,

--- a/apps/web/src/3d/managers/indicator.js
+++ b/apps/web/src/3d/managers/indicator.js
@@ -3,6 +3,7 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { Observable } from '@babylonjs/core/Misc/observable.js'
 
 import { makeLogger } from '../../utils/logger'
+import { getDimensions } from '../utils/mesh'
 import { getMeshScreenPosition, getScreenPosition } from '../utils/vector'
 
 const logger = makeLogger('indicator')
@@ -173,7 +174,8 @@ function handleFrame(manager) {
 }
 
 function setMeshPosition(indicator) {
-  const { x, y } = getMeshScreenPosition(indicator.mesh)
+  const { depth } = getDimensions(indicator.mesh)
+  const { x, y } = getMeshScreenPosition(indicator.mesh, [0, 0, depth / 2])
   const hasChanged =
     x !== indicator.screenPosition?.x || y !== indicator.screenPosition?.y
   if (hasChanged) {

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -157,9 +157,9 @@ class SelectionManager {
   selectWithinBox() {}
 
   /**
-   * Adds meshes into selection (if not already in).
+   * Adds meshes into selection (if not already in), including their stack.
    * Ignores mesh already selected by other players.
-   * @param {Mesh[]} - array of meshes added to the active selection
+   * @param {Mesh[]} - array of meshes added to the active selection.
    * @param {Color4} [color] - color used to highlight mesh, default to manager's color.
    */
   select(meshes, color) {
@@ -173,6 +173,28 @@ class SelectionManager {
         mesh,
         color ?? this.color
       )
+    }
+    if (this.meshes.size !== oldSize) {
+      reorderSelection(this)
+    }
+  }
+
+  /**
+   * Removes meshes from the selection, including their stack.
+   * Ignores meshes selected by other players.
+   * @param {Mesh[]} meshes - array of meshes to remove from the active selection.
+   */
+  unselect(meshes) {
+    const unselected = []
+    const oldSize = this.meshes.size
+    const otherSelections = [...this.selectionByPeerId.values()]
+    for (const mesh of meshes) {
+      if (!otherSelections.find(selection => selection.has(mesh))) {
+        unselected.push(...(mesh.metadata?.stack ?? [mesh]))
+      }
+    }
+    for (const mesh of unselected) {
+      removeFromSelection(this.meshes, mesh)
     }
     if (this.meshes.size !== oldSize) {
       reorderSelection(this)

--- a/apps/web/src/3d/managers/target.js
+++ b/apps/web/src/3d/managers/target.js
@@ -1,5 +1,5 @@
 import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial.js'
-import { Color3, Color4 } from '@babylonjs/core/Maths/math.color.js'
+import { Color4 } from '@babylonjs/core/Maths/math.color.js'
 
 import { makeLogger } from '../../utils/logger'
 import { distance } from '../../utils/math'
@@ -38,8 +38,9 @@ class TargetManager {
   init({ scene, playerId, color }) {
     this.scene = scene
     this.playerId = playerId
+    this.color = Color4.FromHexString(color)
     this.material = new StandardMaterial('target-material', scene)
-    this.material.diffuseColor = Color3.FromHexString(color)
+    this.material.diffuseColor = this.color
     this.material.alpha = 0.5
   }
 
@@ -214,7 +215,7 @@ function findAndHighlightZone(manager, candidates, dragged, kind) {
     const { targetable, zone } = match
     const droppables = manager.droppablesByDropZone.get(zone) ?? []
     manager.droppablesByDropZone.set(zone, [...droppables, dragged])
-    highlightZone(zone, manager.material)
+    highlightZone(zone, manager.material, manager.color)
     logger.info(
       { zone, dragged },
       `found drop zone ${targetable.mesh?.id} for ${dragged?.id} (${kind})`
@@ -235,16 +236,13 @@ function sortCandidates(candidates) {
   )
 }
 
-function highlightZone(zone, material) {
+function highlightZone(zone, material, color) {
   if (zone?.mesh?.visibility === 0) {
     zone.mesh.material = material
     zone.mesh.visibility = 1
     zone.mesh.enableEdgesRendering()
     zone.mesh.edgesWidth = 5.0
-    zone.mesh.edgesColor = Color4.FromArray([
-      ...material.diffuseColor.asArray(),
-      1
-    ])
+    zone.mesh.edgesColor = color
   }
 }
 

--- a/apps/web/src/3d/utils/vector.js
+++ b/apps/web/src/3d/utils/vector.js
@@ -58,14 +58,19 @@ export function isPositionAboveTable(scene, position) {
 
 /**
  * Returns screen coordinate of a given mesh.
- * @param {import('@babylonjs/core').Mesh} mesh - the tested mesh
- * @returns {ScreenPosition|null} this mesh's screen position
+ * @param {import('@babylonjs/core').Mesh} mesh - the tested mesh.
+ * @param {number[]} [offset = [0, 0, 0]] - optional offset (3D coordinates) applied.
+ * @returns {ScreenPosition|null} this mesh's screen position.
  */
-export function getMeshScreenPosition(mesh) {
+export function getMeshScreenPosition(mesh, offset = [0, 0, 0]) {
   if (!mesh || !mesh.getScene()?.activeCamera) {
     return null
   }
-  return getScreenPosition(mesh.getScene(), mesh.getAbsolutePosition())
+  const position = mesh.getAbsolutePosition().clone()
+  return getScreenPosition(
+    mesh.getScene(),
+    position.addInPlaceFromFloats(...offset)
+  )
 }
 
 /**

--- a/apps/web/src/components/Label.svelte
+++ b/apps/web/src/components/Label.svelte
@@ -3,7 +3,6 @@
   export let onClick
   export let screenPosition = { x: 0, y: 0 }
   export let color = '#7a7a7a'
-  export let centered = false
 
   function interact() {
     onClick?.()
@@ -11,7 +10,6 @@
 </script>
 
 <div
-  class:centered
   style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}; pointer-events:{onClick
     ? 'auto'
     : 'none'};"
@@ -24,25 +22,21 @@
 
 <style lang="postcss">
   div {
-    @apply absolute transform-gpu -translate-y-1/2 -translate-x-1
+    @apply absolute transform-gpu 
             select-none 
-            text-lg text-$primary-lightest opacity-85
-            py-1 pr-2 pl-5 rounded z-10;
-    clip-path: polygon(1rem 0%, 100% 0, 100% 100%, 1rem 100%, 0% 50%);
+            text-lg text-$primary-lightest opacity-90
+            rounded-md
+            p-2 pt-1 pb-3 -translate-y-[100%] -translate-x-[50%];
     background-color: var(--color);
-
-    &.centered {
-      @apply p-2 pt-1 pb-3 rounded-none -translate-y-[100%] -translate-x-[50%];
-      --offset: 85%;
-      clip-path: polygon(
-        0% 0%,
-        100% 0%,
-        100% var(--offset),
-        65% var(--offset),
-        50% 100%,
-        35% var(--offset),
-        0% var(--offset)
-      );
-    }
+    --offset: 85%;
+    clip-path: polygon(
+      0% 0%,
+      100% 0%,
+      100% var(--offset),
+      70% var(--offset),
+      50% 100%,
+      30% var(--offset),
+      0% var(--offset)
+    );
   }
 </style>

--- a/apps/web/src/routes/(auth)/game/[gameId]/Indicators.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/Indicators.svelte
@@ -31,7 +31,6 @@
     <Label
       {screenPosition}
       {onClick}
-      centered={!!player}
       content={computeLabel(player, rest)}
       color={player?.color}
     />

--- a/apps/web/src/stores/indicators.js
+++ b/apps/web/src/stores/indicators.js
@@ -139,10 +139,15 @@ function enrichWithPlayerData(indicators) {
 function enrichWithInteraction(indicators) {
   return indicators.map(indicator => ({
     ...indicator,
-    onClick:
-      indicator.mesh && !selectionManager.meshes.has(indicator.mesh)
-        ? () => selectionManager.select([indicator.mesh])
-        : null
+    onClick: indicator.mesh
+      ? () => {
+          if (selectionManager.meshes.has(indicator.mesh)) {
+            selectionManager.unselect([indicator.mesh])
+          } else {
+            selectionManager.select([indicator.mesh])
+          }
+        }
+      : null
   }))
 }
 

--- a/apps/web/tests/3d/managers/indicator.test.js
+++ b/apps/web/tests/3d/managers/indicator.test.js
@@ -12,7 +12,11 @@ import {
   vi
 } from 'vitest'
 
-import { configures3dTestEngine, waitNextRender } from '../../test-utils'
+import {
+  configures3dTestEngine,
+  expectScreenPosition,
+  waitNextRender
+} from '../../test-utils'
 
 describe('IndicatorManager', () => {
   let scene
@@ -55,14 +59,14 @@ describe('IndicatorManager', () => {
         expect(manager.registerMeshIndicator(indicator)).toEqual(indicator)
         expect(manager.isManaging(indicator)).toBe(true)
         expect(manager.getById(indicator.id)).toEqual(indicator)
-        expectChanged([{ id: mesh.id, screenPosition: { x: 1024, y: 512 } }])
+        expectChanged([{ id: mesh.id, screenPosition: { x: 1024, y: 500.85 } }])
       })
 
       it('automatically unregisters a mesh upon disposal', () => {
         const indicator = { id: mesh.id, mesh }
         manager.registerMeshIndicator(indicator)
         expect(manager.isManaging(indicator)).toBe(true)
-        expectChanged([{ id: mesh.id, screenPosition: { x: 1024, y: 512 } }])
+        expectChanged([{ id: mesh.id, screenPosition: { x: 1024, y: 500.85 } }])
 
         mesh.dispose()
         expect(manager.isManaging(indicator)).toBe(false)
@@ -179,9 +183,9 @@ describe('IndicatorManager', () => {
         indicator2.mesh.setAbsolutePosition(new Vector3(10, 0, 10))
         await waitNextRender(scene)
         expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(512)
-        expect(indicator2.screenPosition?.x).toBeCloseTo(1248.979)
-        expect(indicator2.screenPosition?.y).toBeCloseTo(304.146)
+        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
+        expect(indicator2.screenPosition?.x).toBeCloseTo(1248.18)
+        expect(indicator2.screenPosition?.y).toBeCloseTo(294.53)
         expectChanged([...indicators, ...pointers])
       })
 
@@ -189,13 +193,13 @@ describe('IndicatorManager', () => {
         const [indicator1] = indicators
         await waitNextRender(scene)
         expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(512)
+        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
         expect(changeReceived).not.toHaveBeenCalled()
 
         indicator1.mesh.setAbsolutePosition(new Vector3(1, 0, 1))
         await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(1048.036)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(489.793)
+        expect(indicator1.screenPosition?.x).toBeCloseTo(1047.94)
+        expect(indicator1.screenPosition?.y).toBeCloseTo(478.82)
         expectChanged([...indicators, ...pointers])
       })
 
@@ -203,13 +207,13 @@ describe('IndicatorManager', () => {
         const [indicator1, indicator2] = indicators
         await waitNextRender(scene)
         expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(512)
+        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
         expect(changeReceived).not.toHaveBeenCalled()
 
         indicator1.mesh.setAbsolutePosition(new Vector3(200, 0, 200))
         await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(2938.06)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(-1256.36)
+        expect(indicator1.screenPosition?.x).toBeCloseTo(2935.17)
+        expect(indicator1.screenPosition?.y).toBeCloseTo(-1258.1)
         expectChanged([indicator2, ...pointers])
       })
 
@@ -306,9 +310,20 @@ describe('IndicatorManager', () => {
       expect(changeReceived).toHaveBeenCalledTimes(1)
       const changed = changeReceived.mock.calls[0][0]
       expect(changed).toHaveLength(indicators.length)
-      // do not compare mesh because vi fail to serialize them
-      // eslint-disable-next-line no-unused-vars
-      expect(changed).toMatchObject(indicators.map(({ mesh, ...rest }) => rest))
+      for (const [
+        rank,
+        // do not compare mesh because vi fail to serialize them
+        // eslint-disable-next-line no-unused-vars
+        { mesh, screenPosition, ...rest }
+      ] of indicators.entries()) {
+        expect(changed[rank]).toMatchObject(rest)
+        expectScreenPosition(
+          changed[rank].screenPosition,
+          screenPosition,
+          `indicator #${rank}`
+        )
+      }
+      expect()
       changeReceived.mockReset()
     }
   })

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -1048,7 +1048,7 @@ describe('MoveManager', () => {
     behavior.onDropObservable.add(drop => drops.push(drop))
     targetable.addBehavior(behavior, true)
 
-    const target = CreateBox(`target-${rank}`, {})
+    const target = CreateBox(`target-${rank}`, { height: 0.1 })
     target.setAbsolutePosition(position)
     behavior.addZone(target, { extent: 0.5 })
     return target

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -42,7 +42,7 @@ describe('TargetManager', () => {
 
   describe('given an initialized manager', () => {
     const playerId = faker.datatype.uuid()
-    const color = '#00FF00'
+    const color = '#00FF00FF'
 
     beforeAll(() => manager.init({ scene, playerId, color, overlayAlpha: 0.2 }))
 
@@ -458,7 +458,7 @@ describe('TargetManager', () => {
     behavior.onDropObservable.add(drop => drops.push(drop))
     targetable.addBehavior(behavior, true)
 
-    const target = CreateBox(id, {}, usedScene ?? scene)
+    const target = CreateBox(id, { height: 0.1 }, usedScene ?? scene)
     target.setAbsolutePosition(position)
     return behavior.addZone(target, { extent: 0.5, ...properties })
   }

--- a/apps/web/tests/components/__snapshots__/Breadcrumb.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Breadcrumb.tools.shot
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Components/Confirm Dialogue 1`] = `
+<dl>
+  <dt>
+    Raoul Wolfoni
+  </dt>
+  <dd>
+    Faut reconnaître, c'est du brutal !
+  </dd>
+  <dt>
+    Paul Wolfoni
+  </dt>
+  <dd>
+    Vous avez raison, il est curieux hein ?
+  </dd>
+  <dt>
+    Mr Fernand
+  </dt>
+  <dd>
+    J'ai connu une polonaise qu'en prenait au petit déjeuner. Faut quand même
+      admettre que c'est plutôt une boisson d'homme.
+    
+  </dd>
+  <dt>
+    Raoul Wolfoni
+  </dt>
+  <dd>
+    Tu sais pas ce qu'il me rappelle ? C't'espèce de drôlerie qu'on buvait
+      dans une petite taule de bien ho har pas tellement loin de saigon. Les
+      volets rouges et la taulière, une blonde komac. Comment qu'elle s'appelait
+      non de dieu ?
+    
+  </dd>
+  <dt>
+    Mr Fernand
+  </dt>
+  <dd>
+    Lulu la nantaise.
+  </dd>
+</dl>
+`;
+
 exports[`Empty 1`] = `undefined`;
 
 exports[`Multiple entries 1`] = `

--- a/apps/web/tests/components/__snapshots__/ConfirmDialogue.tools.shot
+++ b/apps/web/tests/components/__snapshots__/ConfirmDialogue.tools.shot
@@ -40,3 +40,75 @@ exports[`Components/Confirm Dialogue 1`] = `
   </dd>
 </dl>
 `;
+
+exports[`Empty 1`] = `undefined`;
+
+exports[`Multiple entries 1`] = `
+<ol
+  class="s-x5nEMCoiqeIy"
+>
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    <a
+      class="s-x5nEMCoiqeIy"
+      href="/"
+    >
+      home
+    </a>
+  </li>
+   
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    &gt;
+  </li>
+  
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    <a
+      class="s-x5nEMCoiqeIy"
+      href="/account"
+    >
+      account
+    </a>
+  </li>
+   
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    &gt;
+  </li>
+  
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    <a
+      class="s-x5nEMCoiqeIy"
+    >
+      details
+    </a>
+  </li>
+   
+  
+</ol>
+`;
+
+exports[`Single entry 1`] = `
+<ol
+  class="s-x5nEMCoiqeIy"
+>
+  <li
+    class="s-x5nEMCoiqeIy"
+  >
+    <a
+      class="s-x5nEMCoiqeIy"
+    >
+      home
+    </a>
+  </li>
+   
+  
+</ol>
+`;

--- a/apps/web/tests/components/__snapshots__/Dialogue.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Dialogue.tools.shot
@@ -15,3 +15,210 @@ exports[`Components/Dialogue 1`] = `
   </div>
 </main>
 `;
+
+exports[`Primary image icon only 1`] = `
+<button
+  class="s-NMyTiX1zi6rz"
+>
+  <span
+    class="icon s-NMyTiX1zi6rz"
+  >
+    <svg
+      height="20"
+      slot="icon"
+      viewBox="0 0 14 14"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 .175c-3.872 0-7 3.128-7 7 0 3.084 2.013 5.71 4.79 6.65.35.066.482-.153.482-.328v-1.181c-1.947.415-2.363-.941-2.363-.941-.328-.81-.787-1.028-.787-1.028-.634-.438.044-.416.044-.416.7.044 1.071.722 1.071.722.635 1.072 1.641.766 2.035.59.066-.459.24-.765.437-.94-1.553-.175-3.193-.787-3.193-3.456 0-.766.262-1.378.721-1.881-.065-.175-.306-.897.066-1.86 0 0 .59-.197 1.925.722a6.754 6.754 0 0 1 1.75-.24c.59 0 1.203.087 1.75.24 1.335-.897 1.925-.722 1.925-.722.372.963.131 1.685.066 1.86.46.48.722 1.115.722 1.88 0 2.691-1.641 3.282-3.194 3.457.24.219.481.634.481 1.29v1.926c0 .197.131.415.481.328C11.988 12.884 14 10.259 14 7.175c0-3.872-3.128-7-7-7z"
+        fill="currentColor"
+      />
+    </svg>
+    <!--&lt;Github-logo.svg.rollup-plugin&gt;-->
+  </span>
+  
+  
+  
+</button>
+`;
+
+exports[`Primary with icon only 1`] = `
+<button
+  class="s-NMyTiX1zi6rz"
+>
+  <span
+    class="material-icons s-NMyTiX1zi6rz"
+  >
+    videogame_asset
+  </span>
+  
+  
+  
+</button>
+`;
+
+exports[`Primary with text 1`] = `
+<button
+  class="s-NMyTiX1zi6rz"
+>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`Primary with text and icon 1`] = `
+<button
+  class="s-NMyTiX1zi6rz"
+>
+  <span
+    class="material-icons s-NMyTiX1zi6rz"
+  >
+    emoji_people
+  </span>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`Primary with text and image icon 1`] = `
+<button
+  class="s-NMyTiX1zi6rz"
+>
+  <span
+    class="icon s-NMyTiX1zi6rz"
+  >
+    <svg
+      height="20"
+      slot="icon"
+      viewBox="0 0 14 14"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 .175c-3.872 0-7 3.128-7 7 0 3.084 2.013 5.71 4.79 6.65.35.066.482-.153.482-.328v-1.181c-1.947.415-2.363-.941-2.363-.941-.328-.81-.787-1.028-.787-1.028-.634-.438.044-.416.044-.416.7.044 1.071.722 1.071.722.635 1.072 1.641.766 2.035.59.066-.459.24-.765.437-.94-1.553-.175-3.193-.787-3.193-3.456 0-.766.262-1.378.721-1.881-.065-.175-.306-.897.066-1.86 0 0 .59-.197 1.925.722a6.754 6.754 0 0 1 1.75-.24c.59 0 1.203.087 1.75.24 1.335-.897 1.925-.722 1.925-.722.372.963.131 1.685.066 1.86.46.48.722 1.115.722 1.88 0 2.691-1.641 3.282-3.194 3.457.24.219.481.634.481 1.29v1.926c0 .197.131.415.481.328C11.988 12.884 14 10.259 14 7.175c0-3.872-3.128-7-7-7z"
+        fill="currentColor"
+      />
+    </svg>
+    <!--&lt;Github-logo.svg.rollup-plugin&gt;-->
+  </span>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`Secondary with icon only 1`] = `
+<button
+  class="secondary s-NMyTiX1zi6rz"
+>
+  <span
+    class="material-icons s-NMyTiX1zi6rz"
+  >
+    videogame_asset
+  </span>
+  
+  
+  
+</button>
+`;
+
+exports[`Secondary with text 1`] = `
+<button
+  class="secondary s-NMyTiX1zi6rz"
+>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`Secondary with text and icon 1`] = `
+<button
+  class="secondary s-NMyTiX1zi6rz"
+>
+  <span
+    class="material-icons s-NMyTiX1zi6rz"
+  >
+    emoji_people
+  </span>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`Transparent with text 1`] = `
+<button
+  class="transparent s-NMyTiX1zi6rz"
+>
+  
+  <span
+    class="text s-NMyTiX1zi6rz"
+  >
+    Hello!
+  </span>
+  
+  
+</button>
+`;
+
+exports[`With badge 1`] = `
+HTMLCollection [
+  <div>
+    Vous avez...
+  </div>,
+  <button
+    class="s-NMyTiX1zi6rz"
+  >
+    <span
+      class="material-icons s-NMyTiX1zi6rz"
+    >
+      email
+    </span>
+    
+    <span
+      class="text s-NMyTiX1zi6rz"
+    >
+      Inbox
+    </span>
+    
+    <span
+      class="badge s-NMyTiX1zi6rz"
+    >
+      5
+    </span>
+    
+  </button>,
+  <div>
+    Nouveau(x) message(s).
+  </div>,
+]
+`;

--- a/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Indicators.tools.shot
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Indicators.tools.shot
@@ -3,7 +3,7 @@
 exports[`All kinds 1`] = `
 HTMLCollection [
   <div
-    class="s-WFVnM7df3-nu centered"
+    class="s-WFVnM7df3-nu"
     style="top: 125px; left: 150px; --color: cyan; pointer-events: none;"
   >
     Gaspard
@@ -87,7 +87,7 @@ exports[`Feedback for player 1`] = `
 
 exports[`For player 1`] = `
 <div
-  class="s-WFVnM7df3-nu centered"
+  class="s-WFVnM7df3-nu"
   style="top: 125px; left: 150px; --color: #967d3e; pointer-events: none;"
 >
   Gaspard

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -123,13 +123,13 @@ describe('Indicators store', () => {
         {
           id: `${card5.id}.stack-size`,
           size: 3,
-          screenPosition: { x: 1024, y: 511.8 },
+          screenPosition: { x: 1024, y: 464.99 },
           onClick: expect.any(Function)
         },
         {
           id: `${card2.id}.quantity`,
           size: 5,
-          screenPosition: { x: 1048.22, y: 512 },
+          screenPosition: { x: 1047.83, y: 465.21 },
           onClick: expect.any(Function)
         }
       ])
@@ -149,13 +149,13 @@ describe('Indicators store', () => {
         {
           id: `${card4.id}.stack-size`,
           size: 3,
-          screenPosition: { x: 1024, y: 511.8 },
+          screenPosition: { x: 1024, y: 464.99 },
           onClick: expect.any(Function)
         },
         {
           id: `${card5.id}.stack-size`,
           size: 2,
-          screenPosition: { x: 999.78, y: 511.9 },
+          screenPosition: { x: 1000.16, y: 465.1 },
           onClick: expect.any(Function)
         }
       ])
@@ -217,7 +217,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
       })
@@ -236,7 +236,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
       })
@@ -265,12 +265,12 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1145.099, y: 512 }
+            screenPosition: { x: 1143.16, y: 465.21 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
         actionMenuProps.next({ interactedMesh: card4 })
@@ -278,12 +278,12 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1145.099, y: 512 }
+            screenPosition: { x: 1143.16, y: 465.21 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
       })
@@ -299,7 +299,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
       })
@@ -350,12 +350,12 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1024, y: 511.796 }
+            screenPosition: { x: 1024, y: 464.99 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 999.78, y: 511.898 }
+            screenPosition: { x: 1000.16, y: 465.1 }
           }
         ])
       })
@@ -370,7 +370,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
       })
@@ -384,7 +384,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
         toggleIndicators()
@@ -400,7 +400,7 @@ describe('Indicators store', () => {
           {
             id: `${card5.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 902.9, y: 512 }
+            screenPosition: { x: 904.84, y: 465.21 }
           }
         ])
         await card1.metadata.flipAll()
@@ -408,7 +408,7 @@ describe('Indicators store', () => {
           {
             id: `${card1.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1024, y: 512 }
+            screenPosition: { x: 1024, y: 465.21 }
           }
         ])
       })
@@ -421,7 +421,7 @@ describe('Indicators store', () => {
         expectIndicators([
           {
             id: `${players[0].id}.drop-zone.anchor-0`,
-            screenPosition: { x: 1024, y: 512 }
+            screenPosition: { x: 1024, y: 500.74 }
           }
         ])
       })
@@ -439,19 +439,19 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1024, y: 511.796 }
+            screenPosition: { x: 1024, y: 464.99 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 1024, y: 404.123 }
+            screenPosition: { x: 1024, y: 360.69 }
           }
         ]
 
         await waitNextRender(scene)
         expectIndicators(indicators)
 
-        await notifyHandResize(renderHeight * 0.51)
+        await notifyHandResize(renderHeight * 0.6)
         expectIndicators(indicators.slice(1))
       })
     })
@@ -476,12 +476,12 @@ describe('Indicators store', () => {
           {
             id: `${players[0].id}.drop-zone.anchor-0`,
             player: players[0],
-            screenPosition: { x: 1024, y: 512 }
+            screenPosition: { x: 1024, y: 500.74 }
           },
           {
             id: `${players[1].id}.drop-zone.anchor-0`,
             player: players[1],
-            screenPosition: { x: 1048.22, y: 512 }
+            screenPosition: { x: 1048.13, y: 500.74 }
           }
         ])
       })

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -161,7 +161,7 @@ describe('Indicators store', () => {
       ])
     })
 
-    it('selects mesh when interacting with their indicators, and removes interactivity', async () => {
+    it('selects and unselects meshes when with their indicators', async () => {
       cards[0]
         .getBehaviorByName(StackBehaviorName)
         .fromState({ stackIds: ['card2', 'card4'] })
@@ -174,8 +174,8 @@ describe('Indicators store', () => {
       expect(selectionManager.meshes.has(cards[3])).toBe(true)
       expect(selectionManager.meshes.has(cards[4])).toBe(false)
 
-      await waitNextRender(scene)
-      expect(get(visibleIndicators$)[0]).toHaveProperty('onClick', null)
+      get(visibleIndicators$)[0].onClick()
+      expect(selectionManager.meshes.size).toBe(0)
     })
 
     it('has feedback', async () => {


### PR DESCRIPTION
### :book: What's in there?

Stack and quantifiable indicators have significant drawbacks: their recent interaction isn't natural (can only select, then no interaction), and they often mask a good chunk of their mesh.

Are included here:

- fix(cli): can not show player details
- feat(web): unselects meshes from their indicator
- refactor(web): improves target overlay colors
- refactor(web): moves mesh indicators so they don't hide their mesh
- chore(server): adds unsnap game utility

### :test_tube: How to test?

Try 32 card game to see the new position of stacked indicator, and click it to select, then unselect the entire stack.

For the cli, just run `tabulous show-player -u <username>`. If will fail on outdated `playing`  GraphQL property without this fix.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
