### PR TITLE
feat(web): improves selection (notably when dragging)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,14 +18,10 @@
 
 ## UI
 
-- bug: can interact with a single mesh being moved by peer
-- bug: animating visibility from 0 to 1 creates trouble with texture alpha channel
-- bug: attached, unselected mesh are not ignored during dragging
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - rework lights & shadows
 - detailable/stackable behavior: preview a stack of meshes
 - hide/distinguish non-connected participants
-- is this right? given an active selection, when it anchors with other items, then items are part of the selection
 - option to invite players with url
 - distribute multiple meshes to players' hand
 - shortcuts cheatsheet

--- a/apps/games/chess/logic/builders/board.js
+++ b/apps/games/chess/logic/builders/board.js
@@ -8,9 +8,7 @@ export function buildBoard() {
     faceUV: faceUVs.board,
     y: sizes.board.height / 2,
     ...sizes.board,
-    lockable: { isLocked: true },
-    anchorable: { anchors: buildAnchors() },
-    movable: {}
+    anchorable: { anchors: buildAnchors() }
   }
 }
 

--- a/apps/games/draughts/logic/builders/board.js
+++ b/apps/games/draughts/logic/builders/board.js
@@ -8,9 +8,7 @@ export function buildBoard() {
     faceUV: faceUVs.board,
     y: sizes.board.height / 2,
     ...sizes.board,
-    lockable: { isLocked: true },
-    anchorable: { anchors: buildPawnAnchors() },
-    movable: {}
+    anchorable: { anchors: buildPawnAnchors() }
   }
 }
 

--- a/apps/web/src/3d/behaviors/drawable.js
+++ b/apps/web/src/3d/behaviors/drawable.js
@@ -113,18 +113,19 @@ export class DrawBehavior extends AnimateBehavior {
       state: { duration },
       mesh,
       isAnimated,
-      moveAnimation
+      moveAnimation,
+      fadeAnimation
     } = this
     if (isAnimated || !mesh) {
       return
     }
     this.isAnimated = true
     const attach = detachFromParent(mesh)
-    const { moveKeys } = await buildAnimationKeys(mesh, true)
+    const { moveKeys, fadeKeys } = await buildAnimationKeys(mesh, true)
     await runAnimation(
       this,
       () => attach(),
-      // { animation: fadeAnimation, duration, keys: fadeKeys }, // bug: trouble with alpha texture
+      { animation: fadeAnimation, duration, keys: fadeKeys },
       { animation: moveAnimation, duration, keys: moveKeys }
     )
   }

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -20,6 +20,7 @@ import {
   runAnimation
 } from '../utils/behaviors'
 import {
+  altitudeGap,
   applyGravity,
   getCenterAltitudeAbove,
   sortByElevation
@@ -612,7 +613,7 @@ function invertStack(behavior) {
 function getFinalAltitudeAboveStack(stack) {
   let y = stack[0].absolutePosition.y - getDimensions(stack[0]).height * 0.5
   for (const mesh of stack) {
-    y += getDimensions(mesh).height + 0.001
+    y += getDimensions(mesh).height + altitudeGap
   }
   return y
 }

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -191,8 +191,8 @@ export function createEngine({
   function handleLeave(event) {
     inputManager.stopAll(event)
   }
-  debug && scene.debugLayer.show({ embedMode: true })
-  debugHand && handScene.debugLayer.show({ embedMode: true })
+  debug && scene.debugLayer.show({ embedMode: true, enablePopup: true })
+  debugHand && handScene.debugLayer.show({ embedMode: true, enablePopup: true })
   // new AxesViewer(scene)
 
   const dispose = engine.dispose

--- a/apps/web/src/3d/managers/hand.js
+++ b/apps/web/src/3d/managers/hand.js
@@ -324,6 +324,7 @@ function handDrag(manager, { type, mesh, event }) {
           { mesh: movedMesh, x, z },
           `play mesh ${movedMesh.id} from hand by dragging`
         )
+        const wasSelected = selectionManager.meshes.has(movedMesh)
         const mesh = createMainMesh(manager, movedMesh, { x, z })
         let dropZone
         if (droppedList.length) {
@@ -349,6 +350,9 @@ function handDrag(manager, { type, mesh, event }) {
           targetManager.dropOn(dropZone, { immediate: true })
           mesh.setAbsolutePosition()
         } else {
+          if (wasSelected) {
+            selectionManager.select([mesh])
+          }
           recordDraw(mesh)
         }
       }

--- a/apps/web/src/3d/managers/hand.js
+++ b/apps/web/src/3d/managers/hand.js
@@ -351,7 +351,7 @@ function handDrag(manager, { type, mesh, event }) {
           mesh.setAbsolutePosition()
         } else {
           if (wasSelected) {
-            selectionManager.select([mesh])
+            selectionManager.select(mesh)
           }
           recordDraw(mesh)
         }

--- a/apps/web/src/3d/managers/input.js
+++ b/apps/web/src/3d/managers/input.js
@@ -125,9 +125,14 @@ class InputManager {
     // dynamically creates stopDrag to keep dragOrigin hidden
     this.stopDrag = event => {
       if (dragOrigin) {
+        const meshId = dragOrigin.mesh?.id
         const data = {
           type: 'dragStop',
           ...dragOrigin,
+          // in case mesh was moved between scenes by dragging, return the new one
+          mesh: meshId
+            ? scene.getMeshById(meshId) ?? handScene?.getMeshById(meshId)
+            : undefined,
           event,
           pointers: pointers.size,
           timestamp: Date.now()
@@ -137,9 +142,7 @@ class InputManager {
         pointers.clear()
         logger.info(
           data,
-          `end dragging ${dragOrigin.mesh?.id ?? ''} with button ${
-            dragOrigin.button
-          }`
+          `end dragging ${meshId ?? ''} with button ${dragOrigin.button}`
         )
         this.onDragObservable.notifyObservers(data)
       }

--- a/apps/web/src/3d/utils/gravity.js
+++ b/apps/web/src/3d/utils/gravity.js
@@ -13,12 +13,19 @@ import { getDimensions } from './mesh'
 const logger = makeLogger('gravity')
 
 /**
+ * Gap between meshes when computing altitude above specific positions.
+ */
+export const altitudeGap = 0.01
+
+/**
  * Returns the absolute altitude (Y axis) above a given mesh, including minimum spacing.
  * @param {import('@babel/core').Mesh} mesh - related mesh.
  * @returns {number} resulting Y coordinate.
  */
 export function getAltitudeAbove(mesh) {
-  return mesh.absolutePosition.y + getDimensions(mesh).height * 0.5 + 0.001
+  return (
+    mesh.absolutePosition.y + getDimensions(mesh).height * 0.5 + altitudeGap
+  )
 }
 
 /**

--- a/apps/web/src/stores/indicators.js
+++ b/apps/web/src/stores/indicators.js
@@ -155,10 +155,11 @@ function enrichWithInteraction(indicators) {
     ...indicator,
     onClick: indicator.mesh
       ? () => {
+          const selected = indicator.mesh.metadata.stack ?? indicator.mesh
           if (selectionManager.meshes.has(indicator.mesh)) {
-            selectionManager.unselect([indicator.mesh])
+            selectionManager.unselect(selected)
           } else {
-            selectionManager.select([indicator.mesh])
+            selectionManager.select(selected)
           }
         }
       : null

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -116,16 +116,16 @@ export function attachInputs({
     taps$.subscribe({
       next: ({ mesh, button, event, pointers, fromHand }) => {
         resetMenu()
+        const kind = pointerKind(event, button, pointers)
         if (mesh) {
           if (!selectionManager.meshes.has(mesh)) {
             selectionManager.clear()
           }
-          const kind = pointerKind(event, button, pointers)
           if (kind === 'right') {
             logger.info({ mesh, event }, `display menu for mesh ${mesh.id}`)
             actionMenuProps$.next(computeMenuProps(mesh, fromHand))
           }
-        } else {
+        } else if (kind === 'left') {
           selectionManager.clear()
         }
       }

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -194,7 +194,7 @@ export function attachInputs({
                 if (!selectionManager.meshes.has(mesh)) {
                   selectionManager.clear()
                   shouldDeselect = true
-                  selectionManager.select([mesh])
+                  selectionManager.select(mesh)
                 }
                 logger.info(
                   { mesh, button, long, pointers, event, shouldDeselect },
@@ -267,7 +267,7 @@ export function attachInputs({
               moveManager.stop()
               if (shouldDeselect) {
                 shouldDeselect = false
-                selectionManager.unselect([mesh])
+                selectionManager.unselect(mesh)
               }
             }
             selectionPosition = null
@@ -445,9 +445,14 @@ export function attachInputs({
         }
         if (
           fn === 'push' &&
+          !shouldDeselect &&
           [...selectionManager.meshes].some(({ id }) => args[0] === id)
         ) {
-          selectionManager.selectById([meshId])
+          const mesh = engine.scenes.reduce(
+            (mesh, scene) => mesh || scene.getMeshById(meshId),
+            null
+          )
+          setTimeout(() => selectionManager.select(mesh.metadata?.stack), 0)
         }
       }
     })
@@ -647,9 +652,9 @@ const menuActions = [
       title: 'tooltips.decrement',
       badge: 'shortcuts.pop',
       onClick: async ({ detail } = {}) =>
-        selectionManager.select([
+        selectionManager.select(
           await triggerAction(mesh, 'decrement', detail?.quantity, true)
-        ]),
+        ),
       max: computesQuantity(mesh, params)
     })
   },

--- a/apps/web/tests/3d/behaviors/quantifiable.test.js
+++ b/apps/web/tests/3d/behaviors/quantifiable.test.js
@@ -410,7 +410,7 @@ describe('QuantityBehavior', () => {
       const meshCount = scene.meshes.length
       behavior.fromState({ quantity })
       expectQuantity(mesh, quantity)
-      selectionManager.select([mesh])
+      selectionManager.select(mesh)
 
       moveManager.start(mesh, {})
 

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -668,6 +668,45 @@ describe('HandManager', () => {
         expect(extractDrawnState().flippable.isFlipped).toBe(true)
       })
 
+      it('keeps selected mesh while dragging to main', async () => {
+        const mesh = handCards[1]
+
+        let movedPosition = new Vector3(
+          mesh.absolutePosition.x,
+          mesh.absolutePosition.y + 2,
+          mesh.absolutePosition.z + cardDepth
+        )
+        mesh.setAbsolutePosition(movedPosition)
+        selectionManager.select([mesh])
+        inputManager.onDragObservable.notifyObservers({
+          type: 'dragStart',
+          mesh,
+          event: { x: 289.7, y: 175 }
+        })
+        await waitForLayout()
+        expect(handScene.getMeshById(mesh.id)?.id).toBeUndefined()
+        expect(selectionManager.meshes.has(mesh)).toBe(false)
+
+        const newMesh = scene.getMeshById(mesh.id)
+        expect(newMesh?.id).toBeDefined()
+        expect(selectionManager.meshes.has(newMesh)).toBe(true)
+        expectPosition(newMesh, [6, 2.005, 0])
+        expect(actionRecorded).toHaveBeenCalledWith(
+          {
+            meshId: newMesh.id,
+            fn: 'draw',
+            args: [expect.any(Object)],
+            fromHand: false
+          },
+          expect.anything()
+        )
+        expect(actionRecorded).toHaveBeenCalledTimes(1)
+        expectCloseVector(
+          extractDrawnState(),
+          newMesh.absolutePosition.asArray()
+        )
+      })
+
       it(
         'moves mesh to hand by dragging',
         async () => {

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -145,30 +145,34 @@ describe('HandManager', () => {
       expect(manager.transitionMargin).toEqual(transitionMargin)
     })
 
-    it('performs initial layout', async () => {
-      manager.init({
-        scene,
-        handScene,
-        overlay,
-        gap,
-        horizontalPadding,
-        verticalPadding,
-        duration,
-        transitionMargin
-      })
-      const cards = [
-        { id: 'box1', x: 1, y: 1, z: -1 },
-        { id: 'box2', x: 0, y: 0, z: 0 },
-        { id: 'box3', x: -5, y: 0, z: -2 }
-      ].map(state => createMesh(state, handScene))
-      await waitForLayout()
-      const z = computeZ()
-      expectPosition(cards[2], [-gap - cardWidth, 0.005, z])
-      expectPosition(cards[1], [0, 0.005, z])
-      expectPosition(cards[0], [gap + cardWidth, 0.005, z])
-      expect(actionRecorded).not.toHaveBeenCalled()
-      expect(registerFeedbackSpy).not.toHaveBeenCalled()
-    })
+    it(
+      'performs initial layout',
+      async () => {
+        manager.init({
+          scene,
+          handScene,
+          overlay,
+          gap,
+          horizontalPadding,
+          verticalPadding,
+          duration,
+          transitionMargin
+        })
+        const cards = [
+          { id: 'box1', x: 1, y: 1, z: -1 },
+          { id: 'box2', x: 0, y: 0, z: 0 },
+          { id: 'box3', x: -5, y: 0, z: -2 }
+        ].map(state => createMesh(state, handScene))
+        await waitForLayout()
+        const z = computeZ()
+        expectPosition(cards[2], [-gap - cardWidth, 0.005, z])
+        expectPosition(cards[1], [0, 0.005, z])
+        expectPosition(cards[0], [gap + cardWidth, 0.005, z])
+        expect(actionRecorded).not.toHaveBeenCalled()
+        expect(registerFeedbackSpy).not.toHaveBeenCalled()
+      },
+      { retry: 3 }
+    )
   })
 
   describe('given an initialized manager', () => {
@@ -677,7 +681,7 @@ describe('HandManager', () => {
           mesh.absolutePosition.z + cardDepth
         )
         mesh.setAbsolutePosition(movedPosition)
-        selectionManager.select([mesh])
+        selectionManager.select(mesh)
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -1003,7 +1003,7 @@ describe('HandManager', () => {
         expectMeshFeedback(
           registerFeedbackSpy,
           'push',
-          [-3.890000104904175, 0.010999999999995451, 0]
+          [-3.890000104904175, 0.019999999999995452, 0]
         )
       })
 

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -138,7 +138,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select([zone1.targetable.mesh])
+        selectionManager.select(zone1.targetable.mesh)
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
@@ -315,7 +315,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select([zone1.targetable.mesh])
+        selectionManager.select(zone1.targetable.mesh)
         const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 

--- a/apps/web/tests/3d/utils/gravity.test.js
+++ b/apps/web/tests/3d/utils/gravity.test.js
@@ -3,6 +3,7 @@ import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder'
 import { faker } from '@faker-js/faker'
 import {
+  altitudeGap,
   applyGravity,
   getCenterAltitudeAbove,
   getDimensions,
@@ -84,7 +85,7 @@ describe('applyGravity() 3D utility', () => {
     box2.setAbsolutePosition(new Vector3(x, 3, z))
     let pos = applyGravity(box)
     expect(pos.x).toEqual(x)
-    expect(pos.y).toBeCloseTo(4)
+    expect(pos.y).toBeCloseTo(4 + altitudeGap)
     expect(pos.z).toEqual(z)
   })
 
@@ -95,7 +96,7 @@ describe('applyGravity() 3D utility', () => {
     box2.setAbsolutePosition(new Vector3(x - 0.5, 2, z - 0.5))
     let pos = applyGravity(box)
     expect(pos.x).toEqual(x)
-    expect(pos.y).toBeCloseTo(3)
+    expect(pos.y).toBeCloseTo(3 + altitudeGap)
     expect(pos.z).toEqual(z)
   })
 
@@ -108,7 +109,7 @@ describe('applyGravity() 3D utility', () => {
     box3.setAbsolutePosition(new Vector3(x + 0.5, 3, z))
     let pos = applyGravity(box)
     expect(pos.x).toEqual(x)
-    expect(pos.y).toBeCloseTo(5)
+    expect(pos.y).toBeCloseTo(5 + altitudeGap)
     expect(pos.z).toEqual(z)
   })
 })
@@ -285,7 +286,7 @@ describe('getCenterAltitudeAbove() 3D utility', () => {
     box.absolutePosition.y = 20
     const box2 = CreateBox('box2', { height: 3 })
     expect(getCenterAltitudeAbove(box, box2)).toEqual(
-      20 + 4 / 2 + 3 / 2 + 0.001
+      20 + 4 / 2 + 3 / 2 + altitudeGap
     )
   })
 })

--- a/apps/web/tests/3d/utils/scene-loader.test.js
+++ b/apps/web/tests/3d/utils/scene-loader.test.js
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { customShapeManager, handManager } from '@src/3d/managers'
 import { createCustom } from '@src/3d/meshes'
 import {
+  altitudeGap,
   createTable,
   getAnimatableBehavior,
   loadMeshes,
@@ -644,17 +645,25 @@ describe('loadMeshes() 3D utility', () => {
 
     const mesh2 = scene.getMeshById('card2')
     expect(mesh2).not.toBeNull()
-    expectPosition(mesh2, [pos1.x + shift, pos1.y + height + 0.001, pos1.z])
+    expectPosition(mesh2, [
+      pos1.x + shift,
+      pos1.y + height + altitudeGap,
+      pos1.z
+    ])
 
     const mesh4 = scene.getMeshById('card4')
     expect(mesh4).not.toBeNull()
-    expectPosition(mesh4, [pos1.x - shift, pos1.y + height + 0.001, pos1.z])
+    expectPosition(mesh4, [
+      pos1.x - shift,
+      pos1.y + height + altitudeGap,
+      pos1.z
+    ])
 
     const mesh3 = scene.getMeshById('card3')
     expect(mesh3).not.toBeNull()
     expectPosition(mesh3, [
       pos1.x - shift,
-      pos1.y + (height + 0.001) * 2,
+      pos1.y + (height + altitudeGap) * 2,
       pos1.z
     ])
   })

--- a/apps/web/tests/routes/(auth)/game/[gameid]/InvitePlayerDialogue.test.js
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/InvitePlayerDialogue.test.js
@@ -36,25 +36,29 @@ describe('InvitePlayerDialogue connected component', () => {
     expect(searchPlayers).not.toHaveBeenCalled()
   })
 
-  it('debounce searches', async () => {
-    searchPlayers.mockResolvedValue([])
-    const inputs = [
-      { key: 'a', delay: 10 },
-      { key: 'n', delay: 110 },
-      { key: 'i', delay: 10 },
-      { key: 'm', delay: 10 },
-      { key: 'a', delay: 110 }
-    ]
-    render(html`<${InvitePlayerDialogue} open game=${game} />`)
-    const input = screen.getByRole('textbox')
-    for (const { key, delay } of inputs) {
-      await userEvent.type(input, key)
-      await sleep(delay)
-    }
-    expect(searchPlayers).toHaveBeenNthCalledWith(1, 'an')
-    expect(searchPlayers).toHaveBeenNthCalledWith(2, 'anima')
-    expect(searchPlayers).toHaveBeenCalledTimes(2)
-  })
+  it(
+    'debounce searches',
+    async () => {
+      searchPlayers.mockResolvedValue([])
+      const inputs = [
+        { key: 'a', delay: 10 },
+        { key: 'n', delay: 110 },
+        { key: 'i', delay: 10 },
+        { key: 'm', delay: 10 },
+        { key: 'a', delay: 110 }
+      ]
+      render(html`<${InvitePlayerDialogue} open game=${game} />`)
+      const input = screen.getByRole('textbox')
+      for (const { key, delay } of inputs) {
+        await userEvent.type(input, key)
+        await sleep(delay)
+      }
+      expect(searchPlayers).toHaveBeenNthCalledWith(1, 'an')
+      expect(searchPlayers).toHaveBeenNthCalledWith(2, 'anima')
+      expect(searchPlayers).toHaveBeenCalledTimes(2)
+    },
+    { retry: 3 }
+  )
 
   it('searches for candidate players and displays them', async () => {
     searchPlayers.mockResolvedValueOnce(candidates)

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -162,7 +162,7 @@ describe('Indicators store', () => {
       ])
     })
 
-    it('selects and unselects meshes when with their indicators', async () => {
+    it('selects and unselects stacked meshes when with their indicators', async () => {
       cards[0]
         .getBehaviorByName(StackBehaviorName)
         .fromState({ stackIds: ['card2', 'card4'] })
@@ -174,6 +174,19 @@ describe('Indicators store', () => {
       expect(selectionManager.meshes.has(cards[2])).toBe(false)
       expect(selectionManager.meshes.has(cards[3])).toBe(true)
       expect(selectionManager.meshes.has(cards[4])).toBe(false)
+
+      get(visibleIndicators$)[0].onClick()
+      expect(selectionManager.meshes.size).toBe(0)
+    })
+
+    it('selects and unselects quantifiable meshes when with their indicators', async () => {
+      cards[0]
+        .getBehaviorByName(QuantityBehaviorName)
+        .fromState({ quantity: 4 })
+      await waitNextRender(scene)
+
+      get(visibleIndicators$)[0].onClick()
+      expect(selectionManager.meshes.has(cards[0])).toBe(true)
 
       get(visibleIndicators$)[0].onClick()
       expect(selectionManager.meshes.size).toBe(0)

--- a/apps/web/tests/stores/indicators.test.js
+++ b/apps/web/tests/stores/indicators.test.js
@@ -124,7 +124,7 @@ describe('Indicators store', () => {
         {
           id: `${card5.id}.stack-size`,
           size: 3,
-          screenPosition: { x: 1024, y: 464.99 },
+          screenPosition: { x: 1024, y: 464.81 },
           onClick: expect.any(Function)
         },
         {
@@ -150,13 +150,13 @@ describe('Indicators store', () => {
         {
           id: `${card4.id}.stack-size`,
           size: 3,
-          screenPosition: { x: 1024, y: 464.99 },
+          screenPosition: { x: 1024, y: 464.81 },
           onClick: expect.any(Function)
         },
         {
           id: `${card5.id}.stack-size`,
           size: 2,
-          screenPosition: { x: 1000.16, y: 465.1 },
+          screenPosition: { x: 1000.16, y: 465 },
           onClick: expect.any(Function)
         }
       ])
@@ -393,12 +393,12 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1024, y: 464.99 }
+            screenPosition: { x: 1024, y: 464.81 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 1000.16, y: 465.1 }
+            screenPosition: { x: 1000.16, y: 465 }
           }
         ])
       })
@@ -482,12 +482,12 @@ describe('Indicators store', () => {
           {
             id: `${card4.id}.stack-size`,
             size: 3,
-            screenPosition: { x: 1024, y: 464.99 }
+            screenPosition: { x: 1024, y: 464.81 }
           },
           {
             id: `${card5.id}.stack-size`,
             size: 2,
-            screenPosition: { x: 1024, y: 360.69 }
+            screenPosition: { x: 1024, y: 360.58 }
           }
         ]
 

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -1454,31 +1454,79 @@ describe('Game interaction model', () => {
     })
 
     it('moves mesh on left click drag', () => {
-      const [, mesh] = meshes
-      const position = mesh.absolutePosition.clone()
+      const [box1, box2] = meshes
+      selectionManager.select([box1])
+      const position = box2.absolutePosition.clone()
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
         event: { pointerType: 'mouse', x: 50, y: 50 },
-        mesh,
+        mesh: box2,
         button: 0,
         timestamp: Date.now()
       })
+      expect(selectionManager.meshes.has(box1)).toBe(false)
+      expect(selectionManager.meshes.has(box2)).toBe(true)
       inputManager.onDragObservable.notifyObservers({
         type: 'drag',
         event: { pointerType: 'mouse', x: 100, y: 50 },
-        mesh,
+        mesh: box2,
+        button: 0,
+        timestamp: Date.now()
+      })
+      expect(selectionManager.meshes.has(box1)).toBe(false)
+      expect(selectionManager.meshes.has(box2)).toBe(true)
+      inputManager.onDragObservable.notifyObservers({
+        type: 'dragStop',
+        event: { pointerType: 'mouse', x: 200, y: 50 },
+        mesh: box2,
+        button: 0,
+        timestamp: Date.now()
+      })
+
+      expect(selectionManager.meshes.has(box1)).toBe(false)
+      expect(selectionManager.meshes.has(box2)).toBe(false)
+      expect(position.asArray()).not.toEqual(box2.absolutePosition.asArray())
+      expect(cameraManager.pan).not.toHaveBeenCalled()
+      expect(cameraManager.rotate).not.toHaveBeenCalled()
+      expect(drawSelectionBox).not.toHaveBeenCalled()
+      expect(selectWithinBox).not.toHaveBeenCalled()
+    })
+
+    it('moves selected meshes on left click drag', () => {
+      const [, , box3, , box5, box6, box7] = meshes
+      selectionManager.select([box3, box7])
+      const position = box5.absolutePosition.clone()
+      inputManager.onDragObservable.notifyObservers({
+        type: 'dragStart',
+        event: { pointerType: 'mouse', x: 50, y: 50 },
+        mesh: box5,
+        button: 0,
+        timestamp: Date.now()
+      })
+      expect(selectionManager.meshes.has(box3)).toBe(true)
+      expect(selectionManager.meshes.has(box5)).toBe(true)
+      expect(selectionManager.meshes.has(box6)).toBe(true)
+      expect(selectionManager.meshes.has(box7)).toBe(true)
+      inputManager.onDragObservable.notifyObservers({
+        type: 'drag',
+        event: { pointerType: 'mouse', x: 100, y: 50 },
+        mesh: box5,
         button: 0,
         timestamp: Date.now()
       })
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStop',
         event: { pointerType: 'mouse', x: 200, y: 50 },
-        mesh,
+        mesh: box5,
         button: 0,
         timestamp: Date.now()
       })
 
-      expect(position.asArray()).not.toEqual(mesh.absolutePosition.asArray())
+      expect(selectionManager.meshes.has(box3)).toBe(true)
+      expect(selectionManager.meshes.has(box5)).toBe(true)
+      expect(selectionManager.meshes.has(box6)).toBe(true)
+      expect(selectionManager.meshes.has(box7)).toBe(true)
+      expect(position.asArray()).not.toEqual(box5.absolutePosition.asArray())
       expect(cameraManager.pan).not.toHaveBeenCalled()
       expect(cameraManager.rotate).not.toHaveBeenCalled()
       expect(drawSelectionBox).not.toHaveBeenCalled()

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -314,7 +314,7 @@ describe('Game interaction model', () => {
 
     it('can trigger all actions for a selected quantifiable', async () => {
       const [, , mesh3, , mesh5, mesh6, mesh7] = meshes
-      selectionManager.select([mesh5, mesh7, mesh6])
+      selectionManager.select([mesh3, mesh5, mesh6, mesh7])
       const menuProps = computeMenuProps(mesh7)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -397,7 +397,7 @@ describe('Game interaction model', () => {
       mesh3.metadata.canPush.mockReturnValue(true)
       mesh5.metadata.canPush.mockReturnValue(true)
       mesh6.metadata.canPush.mockReturnValue(true)
-      selectionManager.select([mesh2, mesh3, mesh4, mesh5, mesh6])
+      selectionManager.select([mesh2, mesh4, mesh3, mesh5, mesh6])
       const menuProps = computeMenuProps(mesh2)
       expect(menuProps).toHaveProperty('items')
       expect(menuProps).toHaveProperty('open', true)
@@ -1081,7 +1081,7 @@ describe('Game interaction model', () => {
       it('does not alter selection when pushing an unselected mesh', () => {
         const [mesh1, mesh2, mesh3] = meshes
         selectionManager.clear()
-        selectionManager.select([mesh1])
+        selectionManager.select(mesh1)
         controlManager.onActionObservable.notifyObservers({
           meshId: mesh3.id,
           fn: 'push',
@@ -1095,7 +1095,7 @@ describe('Game interaction model', () => {
       it('selects the entire stack when pushing a selected mesh', () => {
         const [mesh1, mesh2, mesh3, , mesh5, mesh6] = meshes
         selectionManager.clear()
-        selectionManager.select([mesh1, mesh2])
+        selectionManager.select([mesh1, mesh2, ...mesh3.metadata.stack])
         mesh3.metadata.stack.push(mesh2)
         mesh2.metadata.stack = [...mesh3.metadata.stack]
         controlManager.onActionObservable.notifyObservers({
@@ -1225,7 +1225,7 @@ describe('Game interaction model', () => {
     })
 
     it('pans camera on right click drag', () => {
-      selectionManager.select([meshes[0]])
+      selectionManager.select(meshes[0])
       cameraManager.pan.mockResolvedValue()
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
@@ -1291,7 +1291,7 @@ describe('Game interaction model', () => {
         button: 0
       }
     ])('rotates camera on $title drag', ({ event, button }) => {
-      selectionManager.select([meshes[0]])
+      selectionManager.select(meshes[0])
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
         event,
@@ -1455,7 +1455,7 @@ describe('Game interaction model', () => {
 
     it('moves mesh on left click drag', () => {
       const [box1, box2] = meshes
-      selectionManager.select([box1])
+      selectionManager.select(box1)
       const position = box2.absolutePosition.clone()
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',
@@ -1494,7 +1494,7 @@ describe('Game interaction model', () => {
 
     it('moves selected meshes on left click drag', () => {
       const [, , box3, , box5, box6, box7] = meshes
-      selectionManager.select([box3, box7])
+      selectionManager.select([box3, box5, box6, box7])
       const position = box5.absolutePosition.clone()
       inputManager.onDragObservable.notifyObservers({
         type: 'dragStart',

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -1059,7 +1059,23 @@ describe('Game interaction model', () => {
         expectMeshActions(mesh)
       })
 
-      it('does not reset selection when tapping with 2 fingers on a selected mesh', async () => {
+      it('does not clear selection on a right click', async () => {
+        const [mesh1, , mesh3, , mesh5, mesh6] = meshes
+        inputManager.onTapObservable.notifyObservers({
+          type: 'tap',
+          event: { pointerType: 'mouse' },
+          button: 2,
+          timestamp: Date.now()
+        })
+        await sleep(doubleTapDelay * 1.1)
+        expect(selectionManager.meshes.size).toEqual(4)
+        expectMeshActions(mesh1)
+        expectMeshActions(mesh3)
+        expectMeshActions(mesh5)
+        expectMeshActions(mesh6)
+      })
+
+      it('does not clear selection when tapping with 2 fingers on a selected mesh', async () => {
         const [mesh1, , mesh3, , mesh5, mesh6] = meshes
         inputManager.onTapObservable.notifyObservers({
           type: 'tap',


### PR DESCRIPTION
### :book: What's in there?

In a multiplayer game, it is not possible to interact with someone else's active selection. Notably when moving meshes around.
However, moving a single mesh was not protected, since the moved mesh was not selected.

This PR brings many small but handy improvements to the active selection, including automatically (un)selecting a single mesh when moving it, or automatically (un)selecting anchored meshes.

Are included here:

- fix(chess): board should not be movable
- fix(draughts): board should not be movable
- fix(web): selected hand mesh is deselected when moving to main
- feat(web): automatically (un)selects descendant anchored meshes
- feat(web): selects single mesh while dragging, and deselects them
- refactor(web)!: does not automatically select a mesh's stack
- chore(web): when changing scene, returns final mesh on `stopDrag` event
- chore(web): removes `selectionManager.selectById()`
- chore(web): allows calling `selectionManager.select()` and `selectionManager.unselect()` with single meshes
- chore(web): restores drawable opacity animation now that Babylon fixed it

### :test_tube: How to test?

Unfortunately, it's impossible to test the main fix alone!
However, you can test other changes on a Klondike game:

1. drag a single card here and there:
   > it is selected while being handled, then deselected on operation end.
1. select a card, then stack it onto another card
   > the entire stack is selected
1. select a card with snapped ones, then stack it onto another card
   > the entire stack is selected
1. drag a "column" of cards:
   > all the snapped cards are selected along with their "base" card.

On a 32 cards game:

1. drag card to hand, then from hand to main:
   > it is selected even when moved to main scene.
1. right click a card in your hand, and play into main scene:
   > in addition to the descending animation, it also fades in.



<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
