### PR TITLE
fix(chess): missing players script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 
 ## UI
 
+- bug: 6-takes: snapping to the wrong anchor (when 2 players are snapping to different anchors)
 - bug: on a game with no textures, loading UI never disappears (and game manager never enables) as onDataLoadedObservable is not triggered
 - rework lights & shadows
 - detailable/stackable behavior: preview a stack of meshes

--- a/apps/games/chess/logic/builders/board.js
+++ b/apps/games/chess/logic/builders/board.js
@@ -37,7 +37,7 @@ function getPieceId({ column, row }) {
   return row === 0
     ? `${[whiteId]}-${pieces[column]}`
     : row === pieces.length - 1
-    ? `${[blackId]}-${pieces[pieces.length - 1 - column]}`
+    ? `${[blackId]}-${pieces[column]}`
     : row === 1
     ? `${[whiteId]}-pawn-${column}`
     : row === pieces.length - 2

--- a/apps/games/chess/logic/players.js
+++ b/apps/games/chess/logic/players.js
@@ -1,0 +1,50 @@
+import { buildCameraPosition } from '@tabulous/server/src/utils/index.js'
+
+import { blackId, cameraPositions, whiteId } from './constants.js'
+
+export function askForParameters({ game: { preferences } }) {
+  const usedValues = preferences.map(({ side }) => side)
+  return usedValues.length
+    ? null
+    : {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          side: {
+            type: 'string',
+            enum: [whiteId, blackId].filter(
+              value => !usedValues.includes(value)
+            ),
+            metadata: {
+              fr: {
+                name: 'Couleur',
+                [whiteId]: 'Blancs',
+                [blackId]: 'Noirs'
+              }
+            }
+          }
+        },
+        required: ['side']
+      }
+}
+
+export function addPlayer(game, player, parameters) {
+  const { cameras, preferences } = game
+  // use selected preferences, or look for the first player color, and choose the other one.
+  const side =
+    preferences.length === 2
+      ? preferences[0].side === whiteId
+        ? blackId
+        : whiteId
+      : parameters.side
+  // stores preferences for the next player added.
+  preferences[preferences.length - 1].side = side
+  // set camera based on selected side.
+  cameras.push(
+    buildCameraPosition({
+      playerId: player.id,
+      ...cameraPositions[side]
+    })
+  )
+  return game
+}

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -31,6 +31,8 @@ describe('given initialized repository', () => {
   })
 
   describe('upsertPlayer()', () => {
+    afterAll(() => clearDatabase(redisUrl))
+
     it('assigns a new id', async () => {
       const username = faker.name.firstName()
       const password = faker.internet.password()

--- a/apps/web/src/3d/managers/target.js
+++ b/apps/web/src/3d/managers/target.js
@@ -187,8 +187,9 @@ class TargetManager {
  */
 export const targetManager = new TargetManager()
 
-function findCandidates({ behaviors, scene }, dragged, isMatching) {
+function findCandidates({ behaviors }, dragged, isMatching) {
   const candidates = []
+  const scene = dragged.getScene()
   const excluded = [dragged, ...selectionManager.meshes]
   for (const targetable of behaviors) {
     if (

--- a/apps/web/src/routes/(auth)/game/[gameId]/PlayerAvatar.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/PlayerAvatar.svelte
@@ -10,6 +10,8 @@
     stream$
   } from '@src/stores/stream'
   import { _ } from 'svelte-intl'
+  
+  import SoundMeter from './SoundMeter.svelte'
 
   export let player = null
   export let stream = null
@@ -56,6 +58,7 @@
   <legend>
     {#if isLocal}
       {#if $mics$?.length > 0}
+        <SoundMeter {mediaStream} />
         <Dropdown
           valueAsText={false}
           openOnClick={false}

--- a/apps/web/src/routes/(auth)/game/[gameId]/SoundMeter.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/SoundMeter.svelte
@@ -1,0 +1,69 @@
+<script>
+  import { BehaviorSubject } from 'rxjs'
+  import { onMount } from 'svelte'
+
+  export let mediaStream = null
+
+  const levelDb = new BehaviorSubject()
+  const audioContext = new AudioContext()
+  const refreshDelayMs = 250
+
+  const analyser = audioContext.createAnalyser()
+  analyser.fftSize = 512
+  const samples = new Float32Array(analyser.fftSize)
+
+  let input = null
+  let timer = null
+
+  $: if (mediaStream) {
+    clearSoundMeter()
+    input = audioContext.createMediaStreamSource(mediaStream)
+    input.connect(analyser)
+  }
+
+  onMount(() => {
+    scheduleSoundMeter()
+    return clearSoundMeter
+  })
+
+  function clearSoundMeter() {
+    clearTimeout(timer)
+    input?.disconnect()
+    analyser?.disconnect()
+  }
+
+  function scheduleSoundMeter() {
+    if (!analyser) {
+      return
+    }
+
+    analyser.getFloatTimeDomainData(samples)
+    let squareSum = 0
+    for (const value of samples) {
+      squareSum += value ** 2
+    }
+    levelDb.next(10 * Math.log10(squareSum / samples.length))
+    timer = setTimeout(scheduleSoundMeter, refreshDelayMs)
+  }
+</script>
+
+<ol>
+  <li class:on={$levelDb > -6} />
+  <li class:on={$levelDb >= -12} />
+  <li class:on={$levelDb >= -28} />
+  <li class:on={$levelDb >= -36} />
+</ol>
+
+<style lang="postcss">
+  ol {
+    @apply list-none flex flex-col justify-center;
+    gap: 2px;
+  }
+
+  li {
+    @apply inline-block w-3 h-1.5 rounded-sm bg-$primary-light;
+    &.on {
+      @apply bg-$accent-warm;
+    }
+  }
+</style>

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -510,32 +510,36 @@ describe('MoveManager', () => {
       expectMoveRecorded(moveRecorded, moved)
     })
 
-    it('excludes selected meshes from main scene when moving hand mesh', async () => {
-      const positions = [new Vector3(0, 5, 0), new Vector3(-3, 0, -3)]
-      const meshes = [
-        createMovable('box1', positions[0]),
-        createMovable('box2', positions[1])
-      ]
-      selectionManager.select([...meshes, moved])
+    it(
+      'excludes selected meshes from main scene when moving hand mesh',
+      async () => {
+        const positions = [new Vector3(0, 5, 0), new Vector3(-3, 0, -3)]
+        const meshes = [
+          createMovable('box1', positions[0]),
+          createMovable('box2', positions[1])
+        ]
+        selectionManager.select([...meshes, moved])
 
-      manager.start(moved, { x: centerX, y: centerY })
-      expect(manager.inProgress).toBe(true)
-      expectPosition(moved, [1, 1 + manager.elevation, 1])
+        manager.start(moved, { x: centerX, y: centerY })
+        expect(manager.inProgress).toBe(true)
+        expectPosition(moved, [1, 1 + manager.elevation, 1])
 
-      const deltaX = 2.029703140258789
-      const deltaZ = -2.196934700012207
-      manager.continue({ x: centerX + 50, y: centerY + 50 })
+        const deltaX = 2.029703140258789
+        const deltaZ = -2.196934700012207
+        manager.continue({ x: centerX + 50, y: centerY + 50 })
 
-      expectPosition(moved, [1 + deltaX, 1 + manager.elevation, 1 + deltaZ])
+        expectPosition(moved, [1 + deltaX, 1 + manager.elevation, 1 + deltaZ])
 
-      await manager.stop()
-      expectPosition(moved, [3, getDimensions(moved).height / 2, -1.25])
-      expect(manager.inProgress).toBe(false)
-      expect(drops).toHaveLength(0)
-      expectPosition(meshes[0], positions[0].asArray())
-      expectPosition(meshes[1], positions[1].asArray())
-      expectMoveRecorded(moveRecorded, moved)
-    })
+        await manager.stop()
+        expectPosition(moved, [3, getDimensions(moved).height / 2, -1.25])
+        expect(manager.inProgress).toBe(false)
+        expect(drops).toHaveLength(0)
+        expectPosition(meshes[0], positions[0].asArray())
+        expectPosition(meshes[1], positions[1].asArray())
+        expectMoveRecorded(moveRecorded, moved)
+      },
+      { retry: 3 }
+    )
   })
 
   describe('given active selection', () => {

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -145,19 +145,22 @@ describe('TargetManager', () => {
         expect(manager.findDropZone(mesh)).not.toBeDefined()
       })
 
-      it('ignores targets when not in main scene', () => {
-        createsTargetZone('target1', {
+      it('ignores targets from different scene', () => {
+        const handMesh = CreateBox('box', {}, handScene)
+        handMesh.setAbsolutePosition(aboveZone2)
+        expect(manager.findDropZone(handMesh)).not.toBeDefined()
+
+        createsTargetZone('target3', {
           position: new Vector3(10, 0, 10),
           scene: handScene
         })
-        const mesh = CreateBox('box', {}, handScene)
+        const mesh = CreateBox('box', {})
         mesh.setAbsolutePosition(aboveZone3)
-
         expect(manager.findDropZone(mesh)).not.toBeDefined()
       })
 
       it('ignores targets with another player Id', () => {
-        createsTargetZone('target1', {
+        createsTargetZone('target3', {
           position: new Vector3(10, 0, 10),
           playerId: faker.datatype.uuid(),
           scene
@@ -169,7 +172,7 @@ describe('TargetManager', () => {
       })
 
       it('returns targets with same playerId below mesh with kind', () => {
-        const zone3 = createsTargetZone('target1', {
+        const zone3 = createsTargetZone('target3', {
           position: new Vector3(10, 0, 10),
           playerId,
           scene
@@ -322,13 +325,8 @@ describe('TargetManager', () => {
         expect(manager.findPlayerZone(mesh)).not.toBeDefined()
       })
 
-      it('ignores targets when not in main scene', () => {
-        createsTargetZone('target', {
-          position: new Vector3(10, 0, 10),
-          playerId,
-          scene: handScene
-        })
-        manager.unregisterTargetable(zone1.targetable)
+      it('ignores targets from different scene', () => {
+        const mesh = CreateBox('box', {}, handScene)
         expect(manager.findPlayerZone(mesh)).not.toBeDefined()
       })
 


### PR DESCRIPTION
### :book: What's in there?

The Chess game descriptor is missing a file, which prevents the whole server from starting.
Besides adding this file, this PR brings an audio peak meter, so players could figure out when their microphone is working or not.
It's also fixing an issue where dragging a card in hand may trigger some anchors from the main scene.

Are included here:

- fix(chess): missing playing file
- fix(web): dragging hand mesh can highlight main scene targets
- feat(web): adds a volume meter to player's own video controls
- tests(web): retries flaky test
- tests(server): fixes flaky test

### :test_tube: How to test?

Without this, the server simply does not start.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
