### PR TITLE
feat(server): supports lobbies

### DIFF
--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -78,7 +78,7 @@ export default {
      * @param {object} obj - graphQL object.
      * @param {object} args - mutation arguments, including:
      * @param {string} args.gameId - game's id.
-     * @param {string} args.parameters - player's provided parameters
+     * @param {string} args.parameters - player's provided parameters.
      * @param {object} context - graphQL context.
      * @returns {Promise<Game|GameParameters|null>} joined game in case of success, new required parameters, or null.
      */
@@ -96,6 +96,21 @@ export default {
         }
         return services.joinGame(gameId, player, parameters)
       }
+    ),
+
+    /**
+     * Promote a lobby into a full game, setting its kind.
+     * May returns parameters if needed, or the actual game content.
+     * Requires valid authentication.
+     * @param {object} obj - graphQL object.
+     * @param {object} args - mutation arguments, including:
+     * @param {string} args.gameId - game's id.
+     * @param {string} args.kind - promoted game kind.
+     * @param {object} context - graphQL context.
+     * @returns {Promise<Game|GameParameters|null>} joined game in case of success, new required parameters, or null.
+     */
+    promoteGame: isAuthenticated((obj, { gameId, kind }, { player }) =>
+      services.promoteGame(gameId, kind, player)
     ),
 
     /**

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -1,13 +1,19 @@
 # import Player from "players.graphql"
 
 type Game {
+  """
+  lobby properties
+  """
   id: ID!
-  kind: String!
-  locales: ItemLocales!
   created: Float!
   players: [Player]!
-  meshes: [Mesh]!
   messages: [Message]
+  """
+  game properties
+  """
+  kind: String
+  locales: ItemLocales
+  meshes: [Mesh]
   cameras: [CameraPosition]
   hands: [Hand]
   preferences: [PlayerPreference]
@@ -329,8 +335,8 @@ type GameParameters {
   schemaString: String!
   error: String
   id: ID!
-  kind: String!
-  locales: ItemLocales!
+  kind: String
+  locales: ItemLocales
   players: [Player]!
   preferences: [PlayerPreference]
   rulesBookPageCount: Int
@@ -344,8 +350,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  createGame(kind: String!): Game
+  createGame(kind: String): Game
   joinGame(gameId: ID!, parameters: String): GameOrParameters
+  promoteGame(gameId: ID!, kind: String!): GameOrParameters
   saveGame(game: GameInput!): Game
   deleteGame(gameId: ID!): Game
   invite(gameId: ID!, playerId: ID!): Game

--- a/apps/server/src/graphql/index.js
+++ b/apps/server/src/graphql/index.js
@@ -4,9 +4,9 @@ import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
 import catalogResolvers from './catalog-resolver.js'
-import gameResolvers from './games-resolver.js'
-import playerResolvers from './players-resolver.js'
-import signalResolvers from './signals-resolver.js'
+import gamesResolvers from './games-resolver.js'
+import playersResolvers from './players-resolver.js'
+import signalsResolvers from './signals-resolver.js'
 
 const folder = dirname(fileURLToPath(import.meta.url))
 
@@ -20,9 +20,9 @@ const schema = [
 
 const { loaders, ...resolvers } = merge.all([
   catalogResolvers,
-  gameResolvers,
-  playerResolvers,
-  signalResolvers
+  gamesResolvers,
+  playersResolvers,
+  signalsResolvers
 ])
 
 export { loaders, resolvers, schema }

--- a/apps/server/src/repositories/games.js
+++ b/apps/server/src/repositories/games.js
@@ -71,10 +71,13 @@ class GameRepository extends AbstractRepository {
     const transaction = super._enrichSaveTransaction(context)
     for (const game of context.models) {
       for (const playerId of [
+        game?.ownerId,
         ...(game?.playerIds ?? []),
         ...(game?.guestIds ?? [])
       ]) {
-        transaction.sadd(this._buildPlayerKey(playerId), game.id)
+        if (playerId && game) {
+          transaction.sadd(this._buildPlayerKey(playerId), game.id)
+        }
       }
     }
     return transaction
@@ -90,10 +93,13 @@ class GameRepository extends AbstractRepository {
     const transaction = super._enrichDeleteTransaction(context)
     for (const game of context.models) {
       for (const playerId of [
+        game?.ownerId,
         ...(game?.playerIds ?? []),
         ...(game?.guestIds ?? [])
       ]) {
-        transaction.srem(this._buildPlayerKey(playerId), game.id)
+        if (playerId && game) {
+          transaction.srem(this._buildPlayerKey(playerId), game.id)
+        }
       }
     }
     return transaction

--- a/apps/web/tests/components/__snapshots__/PageFooter.tools.shot
+++ b/apps/web/tests/components/__snapshots__/PageFooter.tools.shot
@@ -8,7 +8,7 @@ exports[`Components/Page Footer 1`] = `
     class="s-_Wq18H0k1xjH"
   >
     © 
-    2022
+    2023
      
     Tabulous.fr. Tous droits réservés.
   </section>


### PR DESCRIPTION
### :book: What's in there?

This is preparation work for the next big feature: lobbies, or waiting rooms, before starting a game.

Are included here:

- feat(server): supports lobbies: games with no kind.
- feat(server): adds a mutation to promote a lobby to full game.

### :test_tube: How to test?

For now, no manual testing. The UI part will come next, and unlock testing.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
