### PR TITLE
fix(web): last notification stays with no opacity in DOM, and prevents searching for friends

### DIFF
--- a/apps/web/src/components/Toaster/Container.svelte
+++ b/apps/web/src/components/Toaster/Container.svelte
@@ -22,7 +22,7 @@
   function removeMessage(id) {
     const index = messages.findIndex(candidate => candidate.id === id)
     if (index >= 0) {
-      messages.splice(index, 1)
+      messages = [...messages.slice(0, index), ...messages.slice(index + 1)]
     }
   }
 </script>
@@ -35,6 +35,6 @@
 
 <style lang="postcss">
   div {
-    @apply flex flex-col items-end fixed z-20 top-12 right-8;
+    @apply relative flex flex-col items-end fixed z-20 top-12 right-8;
   }
 </style>

--- a/apps/web/tests/components/__snapshots__/Toaster.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Toaster.tools.shot
@@ -23,7 +23,7 @@ exports[`Text only 1`] = `
   
   <div
     class="s-qGWxPda9kJl2"
-    style="--bg-color: #fcfcfc; --duration: 4s; --close-duration: 0.4s;"
+    style="--top: 0px; --bg-color: #fcfcfc; --duration: 4s; --close-duration: 0.4s;"
   >
     <span
       class="material-icons s-qGWxPda9kJl2"
@@ -62,7 +62,7 @@ exports[`Text, color and icon 1`] = `
   
   <div
     class="s-qGWxPda9kJl2"
-    style="--bg-color: #41d26d; --duration: 4s; --close-duration: 0.4s;"
+    style="--top: 0px; --bg-color: #41d26d; --duration: 4s; --close-duration: 0.4s;"
   >
     <span
       class="material-icons s-qGWxPda9kJl2"


### PR DESCRIPTION
### :book: What's in there?

Notifications stays in the DOM until a new notification arrives.
It is preventing interaction with the right-top corner of the screen, where we have the friend search box.

- fix(web): last notification stays with no opacity in DOM, and prevents searching for friends

### :test_tube: How to reproduce?

1. open the friends pane
   > the search box is interactible
2. click the trash button of an existing game (or lobby) and confirm
   > the deletion notification appears, and goes away
3. try interacting with the friend search field
   > it is not interactive because the notification element is still in DOM, with an opacity of 0

[notification-bug.webm](https://user-images.githubusercontent.com/186268/217810931-7615af2f-0e79-44a5-b277-974e85fdb4de.webm)

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
