### PR TITLE
feat(web): reworks and improves lights and shadows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 - skin(s)
 - interface in English
 - always go fullscreen when entering game
-- allow spliting aside in a different window
-- rework lights & shadows
 - server logging (warning on invalid descriptors) + log file rotation
 - fix obvious bugs bellow
 

--- a/apps/web/src/3d/behaviors/quantifiable.js
+++ b/apps/web/src/3d/behaviors/quantifiable.js
@@ -82,10 +82,9 @@ export class QuantityBehavior extends TargetBehavior {
     })
 
     this.preMoveObserver = moveManager.onPreMoveObservable.add(moved => {
-      const index = moved.findIndex(({ id }) => id === this.mesh?.id)
       if (
         !selectionManager.meshes.has(this.mesh) &&
-        index !== -1 &&
+        moved.some(({ id }) => id === this.mesh?.id) &&
         this.state.quantity > 1
       ) {
         moveManager.exclude(this.mesh)

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -3,7 +3,6 @@
 // mandatory side effects
 // import '@babylonjs/core/Debug/debugLayer'
 // import '@babylonjs/inspector'
-// import { AxesViewer } from '@babylonjs/core/Debug/axesViewer'
 import '@babylonjs/core/Animations/animatable'
 import '@babylonjs/core/Materials/Textures/Loaders/ktxTextureLoader'
 import '@babylonjs/core/Rendering/edgesRenderer'
@@ -33,9 +32,6 @@ import {
   removeNulls,
   serializeMeshes
 } from './utils'
-
-const debug = false
-const debugHand = false
 
 /**
  * Enhanced Babylon' Engine
@@ -191,9 +187,27 @@ export function createEngine({
   function handleLeave(event) {
     inputManager.stopAll(event)
   }
-  debug && scene.debugLayer.show({ embedMode: true, enablePopup: true })
-  debugHand && handScene.debugLayer.show({ embedMode: true, enablePopup: true })
-  // new AxesViewer(scene)
+
+  /* c8 ignore start */
+  if (typeof window !== 'undefined') {
+    window.toggleDebugger = (main = true, hand = false) => {
+      if (main) {
+        if (!scene.debugLayer.isVisible()) {
+          scene.debugLayer.show({ embedMode: true, enablePopup: true })
+        } else {
+          scene.debugLayer.hide()
+        }
+      }
+      if (hand) {
+        if (!handScene.debugLayer.isVisible()) {
+          handScene.debugLayer.show({ embedMode: true, enablePopup: true })
+        } else {
+          handScene.debugLayer.hide()
+        }
+      }
+    }
+  }
+  /* c8 ignore stop */
 
   const dispose = engine.dispose
   engine.dispose = function (...args) {

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -2,9 +2,10 @@
 import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent.js'
 
 import { Engine } from '@babylonjs/core/Engines/engine.js'
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial.js'
+import { PBRBaseMaterial } from '@babylonjs/core/Materials/PBR/pbrBaseMaterial.js'
+import { PBRSpecularGlossinessMaterial } from '@babylonjs/core/Materials/PBR/pbrSpecularGlossinessMaterial.js'
 import { Texture } from '@babylonjs/core/Materials/Textures/texture.js'
-import { Color4 } from '@babylonjs/core/Maths/math.color.js'
+import { Color3, Color4 } from '@babylonjs/core/Maths/math.color.js'
 
 import { makeLogger } from '../../utils/logger'
 
@@ -139,11 +140,13 @@ function buildMaterials(manager, url, usedScene) {
 }
 
 function buildMaterial(materialByUrl, baseUrl, url, scene) {
-  const material = new StandardMaterial(url, scene)
+  const material = new PBRSpecularGlossinessMaterial(url, scene)
   if (url?.startsWith('#')) {
-    material.diffuseColor = Color4.FromHexString(url)
+    material.transparencyMode = PBRBaseMaterial.PBRMATERIAL_ALPHABLEND
+    material.diffuseColor = Color4.FromHexString(url).toLinearSpace()
     material.alpha = material.diffuseColor.a
   } else {
+    material.transparencyMode = PBRBaseMaterial.PBRMATERIAL_ALPHATEST
     material.diffuseTexture = new Texture(adaptTextureUrl(baseUrl, url), scene)
     material.diffuseTexture.hasAlpha = true
     // new ColorizeMaterialPlugin(material)
@@ -152,6 +155,7 @@ function buildMaterial(materialByUrl, baseUrl, url, scene) {
   // material.freeze()
   materialByUrl.set(url, material)
   material.onDisposeObservable.addOnce(() => materialByUrl.delete(url))
+  material.specularColor = Color3.Black()
   return material
 }
 

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -278,6 +278,10 @@ class SelectionManager {
     }
   }
 
+  /**
+   * @param {Mesh} mesh - tested mesh.
+   * @returns {boolean} whether this mesh is selected by another player or not.
+   */
   isSelectedByPeer(mesh) {
     for (const selection of this.selectionByPeerId.values()) {
       if (selection.has(mesh)) {

--- a/apps/web/src/3d/utils/lights.js
+++ b/apps/web/src/3d/utils/lights.js
@@ -4,7 +4,6 @@ import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent.js'
 import { DirectionalLight } from '@babylonjs/core/Lights/directionalLight.js'
 import { HemisphericLight } from '@babylonjs/core/Lights/hemisphericLight.js'
 import { ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator.js'
-import { Color3 } from '@babylonjs/core/Maths/math.color.js'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 
 /**
@@ -30,6 +29,8 @@ export function createLights({ scene, handScene } = {}) {
 
   const shadowGenerator = new ShadowGenerator(1024, light)
   shadowGenerator.usePercentageCloserFiltering = true
+  // https://forum.babylonjs.com/t/shadow-darkness-darker-than-0/22837
+  shadowGenerator._darkness = -1.5
 
   const handLight = makeAmbientLight(handScene)
   handLight.intensity = 1
@@ -42,15 +43,13 @@ export function createLights({ scene, handScene } = {}) {
 
 function makeDirectionalLight(scene) {
   const light = new DirectionalLight('sun', new Vector3(0, -1, 0), scene)
-  light.position = new Vector3(0, 100, 0)
-  light.intensity = 0.5
-  light.specular = Color3.Black()
+  light.position = new Vector3(0, 20, 0)
+  light.intensity = 1
   return light
 }
 
 function makeAmbientLight(scene) {
-  const light = new HemisphericLight('ambient', new Vector3(0, -1, 0), scene)
-  light.intensity = 0.7
-  light.groundColor = Color3.White()
+  const light = new HemisphericLight('ambient', new Vector3(0, 1, 0), scene)
+  light.intensity = 0.8
   return light
 }

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -78,7 +78,6 @@ export function attachInputs({
   let panPosition
   let rotatePosition
   let isPanInProgress = false
-  let shouldDeselect = false
 
   const taps$ = new Subject()
   const drags$ = new Subject()
@@ -200,11 +199,9 @@ export function attachInputs({
               if (kind === 'left') {
                 if (!selectionManager.meshes.has(mesh)) {
                   selectionManager.clear()
-                  shouldDeselect = true
-                  selectionManager.select(mesh)
                 }
                 logger.info(
-                  { mesh, button, long, pointers, event, shouldDeselect },
+                  { mesh, button, long, pointers, event },
                   `start moving mesh ${mesh.id}`
                 )
                 moveManager.start(mesh, event)
@@ -268,14 +265,10 @@ export function attachInputs({
               selectionManager.selectWithinBox()
             } else if (mesh) {
               logger.info(
-                { mesh, button, long, pointers, event, shouldDeselect },
+                { mesh, button, long, pointers, event },
                 `stop moving mesh ${mesh.id}`
               )
               moveManager.stop()
-              if (shouldDeselect) {
-                shouldDeselect = false
-                selectionManager.unselect(mesh)
-              }
             }
             selectionPosition = null
             rotatePosition = null
@@ -452,7 +445,6 @@ export function attachInputs({
         }
         if (
           fn === 'push' &&
-          !shouldDeselect &&
           [...selectionManager.meshes].some(({ id }) => args[0] === id)
         ) {
           const mesh = engine.scenes.reduce(

--- a/apps/web/tests/3d/managers/material.test.js
+++ b/apps/web/tests/3d/managers/material.test.js
@@ -1,6 +1,6 @@
 import { DirectionalLight } from '@babylonjs/core/Lights/directionalLight'
 import { ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator'
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial'
+import { PBRSpecularGlossinessMaterial } from '@babylonjs/core/Materials/PBR/pbrSpecularGlossinessMaterial'
 import { Texture } from '@babylonjs/core/Materials/Textures/texture'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
@@ -148,8 +148,10 @@ describe('MaterialManager', () => {
     describe('configure()', () => {
       it('creates a material with a color', () => {
         manager.configure(box, '#0066ff66')
-        expect(box.material).toBeInstanceOf(StandardMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([0, 0.4, 1, 0.4])
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(box.material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1, 0.4
+        ])
         expect(box.material.alpha).toEqual(0.4)
         expect(box.material.diffuseTexture).toBeNull()
       })
@@ -157,40 +159,42 @@ describe('MaterialManager', () => {
       it('creates a material with a texture', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
       })
 
       it('reuses existing color material on the same scene', () => {
         const color = '#0066ff66'
         manager.configure(box, color)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([0, 0.4, 1, 0.4])
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(box.material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1, 0.4
+        ])
         expect(box.material.diffuseTexture).toBeNull()
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, color)
-        expect(box2.material).toBeInstanceOf(StandardMaterial)
+        expect(box2.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box2.material === box.material).toBe(true)
 
         manager.configure(handBox, color)
-        expect(handBox.material).toBeInstanceOf(StandardMaterial)
+        expect(handBox.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(handBox.material === box.material).toBe(false)
       })
 
       it('reuses existing texture material on the same scene', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, texture)
-        expect(box2.material).toBeInstanceOf(StandardMaterial)
+        expect(box2.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box2.material === box.material).toBe(true)
 
         manager.configure(handBox, texture)
-        expect(handBox.material).toBeInstanceOf(StandardMaterial)
+        expect(handBox.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(handBox.material === box.material).toBe(false)
         expect(handBox.material.diffuseTexture.url).toEqual(
           box.material.diffuseTexture.url
@@ -286,8 +290,10 @@ describe('MaterialManager', () => {
         const texture = `${faker.internet.color()}ff`.toUpperCase()
         expect(manager.isManaging(texture)).toBe(false)
         const material = manager.buildOnDemand(texture, scene)
-        expect(material).toBeInstanceOf(StandardMaterial)
-        expect(material.diffuseColor?.toHexString()).toEqual(texture)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseColor?.toGammaSpace().toHexString()).toEqual(
+          texture
+        )
         expect(material.diffuseTexture).toBeNull()
         expect(manager.isManaging(texture)).toBe(true)
       })
@@ -296,7 +302,7 @@ describe('MaterialManager', () => {
         const texture = faker.internet.url()
         expect(manager.isManaging(texture)).toBe(false)
         const material = manager.buildOnDemand(texture, scene)
-        expect(material).toBeInstanceOf(StandardMaterial)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(material.diffuseTexture).toBeInstanceOf(Texture)
         expect(manager.isManaging(texture)).toBe(true)
       })
@@ -305,7 +311,7 @@ describe('MaterialManager', () => {
         const texture = `${faker.internet.color()}ff`.toUpperCase()
         expect(manager.isManaging(texture)).toBe(false)
         const material = manager.buildOnDemand(texture, scene)
-        expect(material).toBeInstanceOf(StandardMaterial)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
 
         expect(manager.isManaging(texture)).toBe(true)
         expect(manager.buildOnDemand(texture, scene)).toBe(material)
@@ -315,7 +321,7 @@ describe('MaterialManager', () => {
         const texture = faker.internet.url()
         expect(manager.isManaging(texture)).toBe(false)
         const material = manager.buildOnDemand(texture, scene)
-        expect(material).toBeInstanceOf(StandardMaterial)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
 
         expect(manager.isManaging(texture)).toBe(true)
         expect(manager.buildOnDemand(texture, scene)).toBe(material)
@@ -376,8 +382,10 @@ describe('MaterialManager', () => {
     describe('configure()', () => {
       it('creates a material with a color', () => {
         manager.configure(box, '#0066ff66')
-        expect(box.material).toBeInstanceOf(StandardMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([0, 0.4, 1, 0.4])
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(box.material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1, 0.4
+        ])
         expect(box.material.alpha).toEqual(0.4)
         expect(box.material.diffuseTexture).toBeNull()
       })
@@ -385,32 +393,34 @@ describe('MaterialManager', () => {
       it('creates a material with a texture', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
       })
 
       it('reuses existing color material', () => {
         const color = '#0066ff66'
         manager.configure(box, color)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([0, 0.4, 1, 0.4])
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(box.material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1, 0.4
+        ])
         expect(box.material.diffuseTexture).toBeNull()
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, color)
-        expect(box2.material).toBeInstanceOf(StandardMaterial)
+        expect(box2.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box2.material === box.material).toBe(true)
       })
 
       it('reuses existing texture material', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(StandardMaterial)
+        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, texture)
-        expect(box2.material).toBeInstanceOf(StandardMaterial)
+        expect(box2.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(box2.material === box.material).toBe(true)
       })
     })

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -223,6 +223,7 @@ describe('MoveManager', () => {
 
       it('can change moved mesh', () => {
         const moved2 = createMovable('box2')
+        expect(selectionManager.meshes.has(moved2)).toBe(false)
         manager.onPreMoveObservable.addOnce(meshes => {
           meshes.splice(0, meshes.length, moved2)
         })
@@ -230,6 +231,7 @@ describe('MoveManager', () => {
         expect(manager.inProgress).toBe(true)
         expect(manager.isMoving(moved)).toBe(false)
         expect(manager.isMoving(moved2)).toBe(true)
+        expect(selectionManager.meshes.has(moved2)).toBe(true)
         expectPosition(moved, [1, 1, 1])
         expectPosition(moved2, [1, 1 + manager.elevation, 1])
         expect(actionRecorded).toHaveBeenCalledWith(
@@ -254,6 +256,7 @@ describe('MoveManager', () => {
         manager.start(moved, { x: centerX, y: centerY })
         actionRecorded.mockReset()
         moveRecorded.mockReset()
+        expect(selectionManager.meshes.has(moved)).toBe(true)
       })
 
       it('updates moved mesh position', () => {
@@ -330,6 +333,7 @@ describe('MoveManager', () => {
         expect(manager.getActiveZones()).toHaveLength(0)
         expect(manager.inProgress).toBe(false)
         expectMoveRecorded(moveRecorded)
+        expect(selectionManager.meshes.has(moved)).toBe(false)
       })
     })
 
@@ -338,6 +342,7 @@ describe('MoveManager', () => {
         manager.start(moved, { x: centerX, y: centerY })
         actionRecorded.mockReset()
         moveRecorded.mockReset()
+        expect(selectionManager.meshes.has(moved)).toBe(true)
       })
 
       it('descends moved mesh', async () => {
@@ -357,6 +362,7 @@ describe('MoveManager', () => {
         expect(manager.inProgress).toBe(false)
         expect(drops).toHaveLength(0)
         expectMoveRecorded(moveRecorded)
+        expect(selectionManager.meshes.has(moved)).toBe(false)
       })
 
       it('drops moved mesh to active target', async () => {
@@ -387,6 +393,7 @@ describe('MoveManager', () => {
         expect(drops).toHaveLength(1)
         expectDroppedEvent(0, targets[0], [moved])
         expectMoveRecorded(moveRecorded)
+        expect(selectionManager.meshes.has(moved)).toBe(false)
       })
 
       it('disables other operations', async () => {
@@ -573,6 +580,9 @@ describe('MoveManager', () => {
         expect(manager.isMoving(moved[0])).toBe(true)
         expect(manager.isMoving(moved[1])).toBe(true)
         expect(manager.isMoving(moved[2])).toBe(true)
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(true)
+        expect(selectionManager.meshes.has(moved[2])).toBe(true)
         expectPosition(moved[0], [1, 1 + manager.elevation, 1])
         expectPosition(moved[1], [0, 5 + manager.elevation, 0])
         expectPosition(moved[2], [-3, 0.5 + manager.elevation, -3])
@@ -791,6 +801,9 @@ describe('MoveManager', () => {
         )
         expect(actionRecorded).toHaveBeenCalledTimes(1)
         expect(manager.getActiveZones()).toHaveLength(0)
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(true)
+        expect(selectionManager.meshes.has(moved[2])).toBe(true)
       })
 
       it('ignores unknow meshes', () => {
@@ -842,12 +855,18 @@ describe('MoveManager', () => {
         expect(manager.isMoving(moved[0])).toBe(true)
         expect(manager.isMoving(moved[1])).toBe(false)
         expect(manager.isMoving(moved[2])).toBe(false)
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(false)
+        expect(selectionManager.meshes.has(moved[2])).toBe(false)
         actionRecorded.mockReset()
 
         manager.include(moved[1], moved[2])
         expect(manager.isMoving(moved[0])).toBe(true)
         expect(manager.isMoving(moved[1])).toBe(true)
         expect(manager.isMoving(moved[2])).toBe(true)
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(true)
+        expect(selectionManager.meshes.has(moved[2])).toBe(true)
 
         const deltaX = 2.029703140258789
         const deltaZ = -2.196934700012207
@@ -971,6 +990,9 @@ describe('MoveManager', () => {
         manager.start(moved[0], { x: centerX, y: centerY })
         actionRecorded.mockReset()
         moveRecorded.mockReset()
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(true)
+        expect(selectionManager.meshes.has(moved[2])).toBe(true)
       })
 
       it('drops relevant meshes on their target and move others', async () => {
@@ -1002,6 +1024,9 @@ describe('MoveManager', () => {
         expectDroppedEvent(0, targets[1], [moved[2]])
         expectDroppedEvent(1, targets[0], [moved[0]])
         expectMoveRecorded(moveRecorded)
+        expect(selectionManager.meshes.has(moved[0])).toBe(true)
+        expect(selectionManager.meshes.has(moved[1])).toBe(true)
+        expect(selectionManager.meshes.has(moved[2])).toBe(true)
       })
     })
   })

--- a/apps/web/tests/3d/meshes/box.test.js
+++ b/apps/web/tests/3d/meshes/box.test.js
@@ -34,7 +34,9 @@ describe('createBox()', () => {
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [1, 1, 1])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a box with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/card.test.js
+++ b/apps/web/tests/3d/meshes/card.test.js
@@ -35,7 +35,9 @@ describe('createCard()', () => {
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [3, 0.01, 4.25])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a card with initial position, dimension, images and behaviors', async () => {

--- a/apps/web/tests/3d/meshes/custom.test.js
+++ b/apps/web/tests/3d/meshes/custom.test.js
@@ -74,7 +74,9 @@ describe('createCustom()', () => {
     const mesh = await createCustom({ file, texture: color })
     expect(mesh.name).toEqual('custom')
     expectDimension(mesh, pawnDimensions)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a mesh with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/die.test.js
+++ b/apps/web/tests/3d/meshes/die.test.js
@@ -106,7 +106,9 @@ describe('createDie()', () => {
     expectDimension(mesh, [2.94, 2.5, 2.6])
     expect(mesh.isPickable).toBe(false)
     expectPosition(mesh, [0, 0.7, 0])
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
     expect(mesh.metadata).toEqual({
       face,
       maxFace: 4,

--- a/apps/web/tests/3d/meshes/prism.test.js
+++ b/apps/web/tests/3d/meshes/prism.test.js
@@ -35,7 +35,9 @@ describe('createPrism()', () => {
     expect(boundingBox.extendSize.x * 2).toEqual(3)
     expect(boundingBox.extendSize.y * 2).toEqual(1)
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a prism with initial position, edges number, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/round-token.test.js
+++ b/apps/web/tests/3d/meshes/round-token.test.js
@@ -35,7 +35,9 @@ describe('createRoundToken()', () => {
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [2, 0.1, 2])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a token with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/meshes/rounded-tiles.test.js
+++ b/apps/web/tests/3d/meshes/rounded-tiles.test.js
@@ -34,7 +34,9 @@ describe('createRoundedTile()', () => {
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [3, 0.05, 3])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(Color4.FromHexString(color))
+    expect(mesh.material.diffuseColor).toEqual(
+      Color4.FromHexString(color).toLinearSpace()
+    )
   })
 
   describe('given a tile with initial position, dimension, images and behaviors', () => {

--- a/apps/web/tests/3d/utils/lights.test.js
+++ b/apps/web/tests/3d/utils/lights.test.js
@@ -18,18 +18,18 @@ describe('createLights() 3D utility', () => {
       handScene
     })
     expect(light.name).toEqual('sun')
-    expect(light.intensity).toEqual(0.5)
-    expect(light.specular.asArray()).toEqual([0, 0, 0])
+    expect(light.intensity).toEqual(1)
+    expect(light.specular.asArray()).toEqual([1, 1, 1])
     expect(light.direction.x).toEqual(0)
     expect(light.direction.y).toEqual(-1)
     expect(light.direction.z).toEqual(0)
 
     expect(ambientLight.name).toEqual('ambient')
-    expect(ambientLight.intensity).toEqual(0.7)
+    expect(ambientLight.intensity).toEqual(0.8)
     expect(ambientLight.specular.asArray()).toEqual([1, 1, 1])
-    expect(ambientLight.groundColor.asArray()).toEqual([1, 1, 1])
+    expect(ambientLight.groundColor.asArray()).toEqual([0, 0, 0])
     expect(ambientLight.direction.x).toEqual(0)
-    expect(ambientLight.direction.y).toEqual(-1)
+    expect(ambientLight.direction.y).toEqual(1)
     expect(ambientLight.direction.z).toEqual(0)
 
     expect(shadowGenerator.mapSize).toEqual(1024)

--- a/apps/web/tests/3d/utils/table.test.js
+++ b/apps/web/tests/3d/utils/table.test.js
@@ -35,7 +35,9 @@ describe('createTable() 3D utility', () => {
   it('creates a table mesh with a color', () => {
     const texture = `${faker.internet.color().toUpperCase()}FF`
     const table = createTable({ texture })
-    expect(table.material.diffuseColor?.toHexString()).toEqual(texture)
+    expect(table.material.diffuseColor?.toGammaSpace().toHexString()).toEqual(
+      texture
+    )
     expect(table.material.diffuseTexture).toBeNull()
   })
 

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -1778,7 +1778,7 @@ describe('Game interaction model', () => {
       expect(cameraManager.zoom).not.toHaveBeenCalled()
     })
 
-    it('moves mesh on left click drag', () => {
+    it('moves mesh on left click drag, and automatically selects it', () => {
       const [box1, box2] = meshes
       selectionManager.select(box1)
       const position = box2.absolutePosition.clone()


### PR DESCRIPTION
### :book: What's in there?

Simply by using Physics-Based-Rendered materials (PBR), we could considerably improve the quality of lights rendering:
| Old | New |
|--- | --- |
| ![image](https://github.com/feugy/tabulous/assets/186268/c7dd02b8-b92f-4404-941a-d11841464c03) | ![image](https://github.com/feugy/tabulous/assets/186268/c0a72ce3-c72b-4f44-a3e2-7199451276ca) |
| ![image](https://github.com/feugy/tabulous/assets/186268/b9d79868-6a64-42b2-afdc-78054a9e7cf6) | ![image](https://github.com/feugy/tabulous/assets/186268/0b4c9799-7d37-4c49-9e71-2b29596429f6) |

This give a much more realistic feeling.

I also discovered and fixed a regression on quantifiable behavior, due to auto-selecting meshes when moving them.

Are included here:

- fix(web): can not decrement a quantifiable by dragging it
- feat(web): reworks and improves lights and shadows


<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
