### PR TITLE
fix(web): login errors are displayed as 500

### DIFF
--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -1,7 +1,6 @@
 // all BabylonJS imports must be from individual files to allow tree shaking.
 // more [here](https://doc.babylonjs.com/divingDeeper/developWithBjs/treeShaking)
 // mandatory side effects
-// import '@babylonjs/core/Debug/debugLayer'
 import '@babylonjs/core/Animations/animatable'
 import '@babylonjs/core/Materials/Textures/Loaders/ktxTextureLoader'
 import '@babylonjs/core/Rendering/edgesRenderer'
@@ -201,6 +200,7 @@ export function createEngine({
   /* c8 ignore start */
   if (typeof window !== 'undefined') {
     window.toggleDebugger = async (main = true, hand = false) => {
+      await import('@babylonjs/core/Debug/debugLayer')
       await import('@babylonjs/inspector')
       if (main) {
         if (!scene.debugLayer.isVisible()) {

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -147,7 +147,11 @@ function buildMaterial(materialByUrl, baseUrl, url, scene) {
     material.alpha = material.diffuseColor.a
   } else {
     material.transparencyMode = PBRBaseMaterial.PBRMATERIAL_ALPHATEST
-    material.diffuseTexture = new Texture(adaptTextureUrl(baseUrl, url), scene)
+    material.diffuseTexture = new Texture(
+      adaptTextureUrl(baseUrl, url),
+      scene,
+      { invertY: false }
+    )
     material.diffuseTexture.hasAlpha = true
     // new ColorizeMaterialPlugin(material)
     attachMaterialError(material)

--- a/apps/web/src/routes/login/+page.server.js
+++ b/apps/web/src/routes/login/+page.server.js
@@ -3,6 +3,14 @@ import { logIn } from '@src/stores/players'
 import { graphQlUrl } from '@src/utils/env'
 import { fail, redirect } from '@sveltejs/kit'
 
+/** @type {import('./$types').ServerLoad} */
+export function load({ locals }) {
+  const { session = null } = locals
+  if (session && session.player) {
+    throw redirect(303, '/home')
+  }
+}
+
 export const actions = {
   /** @type {import('./$types').Action} */
   default: async ({ request, locals, fetch }) => {
@@ -23,8 +31,8 @@ export const actions = {
     try {
       initGraphQlClient({ graphQlUrl, fetch, subscriptionSupport: false })
       locals.session = await logIn(id, password)
-    } catch (err) {
-      return fail(401, err)
+    } catch (error) {
+      return fail(401, { message: error.message })
     }
     throw redirect(303, location || '/home')
   }

--- a/apps/web/src/routes/login/Form.svelte
+++ b/apps/web/src/routes/login/Form.svelte
@@ -18,7 +18,7 @@
     !id || id.trim().length === 0 || !password || password.trim().length <= 3
 
   let details
-  let isPasswordOpen = false
+  let isPasswordOpen = !!error
 
   function resetError() {
     error = null
@@ -33,6 +33,9 @@
 
   function handleTogglePassword() {
     isPasswordOpen = details.open
+    if (!isPasswordOpen) {
+      resetError()
+    }
   }
 </script>
 
@@ -54,7 +57,7 @@
     {/if}
     <details
       bind:this={details}
-      open={!hasProviders || !!error || isPasswordOpen}
+      open={!hasProviders || isPasswordOpen}
       on:toggle={handleTogglePassword}
     >
       <summary class:hidden={!hasProviders} title="password-toggle">

--- a/apps/web/src/stores/configuration.js
+++ b/apps/web/src/stores/configuration.js
@@ -6,8 +6,8 @@ import { BehaviorSubject } from 'rxjs'
  * @property {boolean} useGoogleProvider enables "Connect with Google" button.
  */
 const flags$ = new BehaviorSubject({
-  useGithubProvider: import.meta.env.WEB_USE_GITHUB_PROVIDER,
-  useGoogleProvider: import.meta.env.WEB_USE_GOOGLE_PROVIDER
+  useGithubProvider: Boolean(import.meta.env.WEB_USE_GITHUB_PROVIDER),
+  useGoogleProvider: Boolean(import.meta.env.WEB_USE_GOOGLE_PROVIDER)
 })
 
 /**

--- a/apps/web/tests/routes/login/+page.server.test.js
+++ b/apps/web/tests/routes/login/+page.server.test.js
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { actions } from '@src/routes/login/+page.server'
+import { actions, load } from '@src/routes/login/+page.server'
 import { runMutation } from '@src/stores/graphql-client'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -7,6 +7,21 @@ vi.mock('@src/stores/graphql-client', () => ({
   initGraphQlClient: vi.fn(),
   runMutation: vi.fn()
 }))
+
+describe('/login route loader', () => {
+  it('redirects to home connected users', async () => {
+    await expect(async () =>
+      load({ locals: { session: { player: { name: 'dude' } } } })
+    ).rejects.toEqual({
+      status: 303,
+      location: '/home'
+    })
+  })
+
+  it('does nothing on anonymous access', () => {
+    expect(load({ locals: {} })).toBeUndefined()
+  })
+})
 
 describe('POST /login route action', () => {
   it('redirects to home and set session on success', async () => {
@@ -82,7 +97,7 @@ describe('POST /login route action', () => {
 
     expect(await actions.default({ request, locals, fetch })).toEqual({
       status: 401,
-      data: error
+      data: { message: error.message }
     })
     expect(locals.session).toBeUndefined()
   })

--- a/apps/web/tests/routes/login/+page.test.js
+++ b/apps/web/tests/routes/login/+page.test.js
@@ -19,9 +19,9 @@ describe('/login route', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('expands login panel and show all options', async () => {
+  it('expands login panel on error', async () => {
     const { container } = render(
-      html`<${LoginPage} form=${'wrong password'} />`
+      html`<${LoginPage} form=${{ message: 'wrong password' }} />`
     )
     expect(container).toMatchSnapshot()
   })

--- a/apps/web/tests/routes/login/__snapshots__/+page.test.js.snap
+++ b/apps/web/tests/routes/login/__snapshots__/+page.test.js.snap
@@ -295,7 +295,7 @@ exports[`/login route > displays all options 1`] = `
 </body>
 `;
 
-exports[`/login route > expands login panel and show all options 1`] = `
+exports[`/login route > expands login panel on error 1`] = `
 <body>
   <div>
      
@@ -388,67 +388,7 @@ exports[`/login route > expands login panel and show all options 1`] = `
             <div
               class="container s-OEREYjlWzGh2"
             >
-              <button
-                class="has-text s-NMyTiX1zi6rz"
-              >
-                <span
-                  class="icon s-NMyTiX1zi6rz"
-                >
-                  <svg
-                    height="20"
-                    slot="icon"
-                    viewBox="0 0 14 14"
-                    width="20"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M7 .175c-3.872 0-7 3.128-7 7 0 3.084 2.013 5.71 4.79 6.65.35.066.482-.153.482-.328v-1.181c-1.947.415-2.363-.941-2.363-.941-.328-.81-.787-1.028-.787-1.028-.634-.438.044-.416.044-.416.7.044 1.071.722 1.071.722.635 1.072 1.641.766 2.035.59.066-.459.24-.765.437-.94-1.553-.175-3.193-.787-3.193-3.456 0-.766.262-1.378.721-1.881-.065-.175-.306-.897.066-1.86 0 0 .59-.197 1.925.722a6.754 6.754 0 0 1 1.75-.24c.59 0 1.203.087 1.75.24 1.335-.897 1.925-.722 1.925-.722.372.963.131 1.685.066 1.86.46.48.722 1.115.722 1.88 0 2.691-1.641 3.282-3.194 3.457.24.219.481.634.481 1.29v1.926c0 .197.131.415.481.328C11.988 12.884 14 10.259 14 7.175c0-3.872-3.128-7-7-7z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <!--&lt;Github-logo.svg.rollup-plugin&gt;-->
-                </span>
-                
-                <span
-                  class="text s-NMyTiX1zi6rz"
-                >
-                  Continuer avec Github
-                </span>
-                
-                
-              </button>
-              <!--&lt;Button&gt;-->
                
-              <button
-                class="has-text s-NMyTiX1zi6rz"
-              >
-                <span
-                  class="icon s-NMyTiX1zi6rz"
-                >
-                  <svg
-                    height="18"
-                    slot="icon"
-                    width="17.64"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M8.991 10.71V7.362h8.424c.126.567.225 1.098.225 1.845C17.64 14.346 14.193 18 9 18c-4.968 0-9-4.032-9-9s4.032-9 9-9c2.43 0 4.464.891 6.021 2.349l-2.556 2.484C11.817 4.221 10.683 3.501 9 3.501c-2.979 0-5.409 2.475-5.409 5.508S6.021 14.517 9 14.517c3.447 0 4.716-2.385 4.95-3.798H8.991Z"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                  <!--&lt;Google-logo.svg.rollup-plugin&gt;-->
-                </span>
-                
-                <span
-                  class="text s-NMyTiX1zi6rz"
-                >
-                  Continuer avec Google
-                </span>
-                
-                
-              </button>
-              <!--&lt;Button&gt;-->
                
               <details
                 class="s-OEREYjlWzGh2"
@@ -461,9 +401,9 @@ exports[`/login route > expands login panel and show all options 1`] = `
                   <span
                     class="material-icons s-OEREYjlWzGh2"
                   >
-                    arrow_forward
+                    arrow_back
                   </span>
-                  Continuer avec un mot de passe
+                  Autres options
                 </summary>
                  
                 <form


### PR DESCRIPTION
### :book: What's in there?

With recent update of Sveltekit, unsuccessful login attempts end with a 500 error instead of a nice error message on UI.

<img width="50%" alt="image" src="https://github.com/feugy/tabulous/assets/186268/a6cc6639-f003-487f-9120-953708b5c762">

On Mac browsers (tested with Chrome & Firefox), texture are inverted on the Y axis
<img width="50%" alt="image" src="https://github.com/feugy/tabulous/assets/186268/8661b0b9-cca6-4f37-a97d-a5f23edd3e5e">


Are included here:

- fix(web): login errors are displayed as 500
- fix(web): 3D textures are Y-inverted on Mac
- feat(web): automatically redirects to /home when accessing /login while connected
- chore(web): loads Babylon debug layer on demand

### :test_tube: How to test?

The login error:
1. go to login page
2. enter any dummy credentials (at least 3-character password)
3. hit enter 
   > you should see the error message

The new login redirection:
1. log in with valid credentials
   > you should land on the home page
2. change the url to `/login`
   > you should be redirected to the home page

The Y-inverted issue
1. on a mac, with any browser, load any game
   > texture should appear properly.

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
