### PR TITLE
fix(web): flash of unstyled content on authenticated home page

### DIFF
--- a/apps/web/src/components/QuantityButton.svelte
+++ b/apps/web/src/components/QuantityButton.svelte
@@ -64,6 +64,7 @@
 <span
   role="slider"
   aria-valuenow={quantity}
+  tabindex={0}
   on:keyup|stopPropagation={handleKeys}
 >
   <Button

--- a/apps/web/src/routes/home/GameLink.svelte
+++ b/apps/web/src/routes/home/GameLink.svelte
@@ -35,43 +35,43 @@
   }
 </script>
 
-<button
+<article
   class:lobby={isALobby}
   class:isCurrent
-  tabindex={0}
-  style="--bg-url: url('{coverImage}')"
-  on:click={handleClick}
+  style:--bg-url="url('{coverImage}')"
 >
-  <span class="title">
-    <h3>{title}</h3>
-    <div class="buttons">
-      {#if isCurrent}<Button
-          secondary
-          icon="close"
-          on:click={handleClose}
-          on:keyup={event => event.stopPropagation()}
-        />{:else if owned}<Button
-          secondary
-          icon="delete"
-          on:click={handleDelete}
-          on:keyup={event => event.stopPropagation()}
-        />{/if}
-    </div>
-  </span>
-  <span class="created">{$_('{ created, date, short-date }', game)}</span>
-  {#if peerNames.length}
-    <span>{$_('labels.peer-players', { names: peerNames.join(', ') })}</span>
-  {/if}
-  {#if guestNames.length}
-    <span class="guests"
-      >{$_('labels.peer-guests', { names: guestNames.join(', ') })}</span
-    >
-  {/if}
-</button>
+  <button tabindex={0} on:click={handleClick}>
+    <span class="title">
+      <h3>{title}</h3>
+    </span>
+    <span class="created">{$_('{ created, date, short-date }', game)}</span>
+    {#if peerNames.length}
+      <span>{$_('labels.peer-players', { names: peerNames.join(', ') })}</span>
+    {/if}
+    {#if guestNames.length}
+      <span class="guests"
+        >{$_('labels.peer-guests', { names: guestNames.join(', ') })}</span
+      >
+    {/if}
+  </button>
+  <div class="actions">
+    {#if isCurrent}<Button
+        secondary
+        icon="close"
+        on:click={handleClose}
+        on:keyup={event => event.stopPropagation()}
+      />{:else if owned}<Button
+        secondary
+        icon="delete"
+        on:click={handleDelete}
+        on:keyup={event => event.stopPropagation()}
+      />{/if}
+  </div>
+</article>
 
 <style lang="postcss">
-  button {
-    @apply relative inline-flex flex-col p-4 m-2 cursor-pointer bg-$base-lighter text-left rounded;
+  article {
+    @apply relative inline-flex flex p-4 m-2 bg-$base-lighter rounded;
     transition: background-color var(--long), color var(--medium),
       transform var(--short);
 
@@ -83,7 +83,7 @@
       filter: grayscale(100%) opacity(15%);
     }
 
-    &:not(.isCurrent) .buttons {
+    &:not(.isCurrent) .actions {
       @apply invisible;
     }
 
@@ -92,10 +92,10 @@
 
       h3 {
         @apply text-$primary-lighter;
-        transition: color var(--long) var(--medium);
+        transition: color var(--long) var(--short);
       }
 
-      .buttons {
+      .actions {
         @apply visible;
       }
 
@@ -115,6 +115,10 @@
         @apply text-$primary-lighter;
       }
     }
+  }
+
+  button {
+    @apply flex flex-col flex-1 text-left;
   }
 
   .title {

--- a/apps/web/src/routes/home/GameLink.svelte
+++ b/apps/web/src/routes/home/GameLink.svelte
@@ -59,19 +59,17 @@
         secondary
         icon="close"
         on:click={handleClose}
-        on:keyup={event => event.stopPropagation()}
       />{:else if owned}<Button
         secondary
         icon="delete"
         on:click={handleDelete}
-        on:keyup={event => event.stopPropagation()}
       />{/if}
   </div>
 </article>
 
 <style lang="postcss">
   article {
-    @apply relative inline-flex flex p-4 m-2 bg-$base-lighter rounded;
+    @apply relative inline-flex m-2 flex bg-$base-lighter rounded;
     transition: background-color var(--long), color var(--medium),
       transform var(--short);
 
@@ -84,7 +82,7 @@
     }
 
     &:not(.isCurrent) .actions {
-      @apply invisible;
+      @apply hidden;
     }
 
     &:hover {
@@ -96,7 +94,7 @@
       }
 
       .actions {
-        @apply visible;
+        @apply block;
       }
 
       .guests {
@@ -118,7 +116,11 @@
   }
 
   button {
-    @apply flex flex-col flex-1 text-left;
+    @apply relative flex flex-col flex-1 p-4 text-left rounded;
+  }
+
+  .actions {
+    @apply m-2;
   }
 
   .title {

--- a/apps/web/tests/components/__snapshots__/QuantityButton.tools.shot
+++ b/apps/web/tests/components/__snapshots__/QuantityButton.tools.shot
@@ -5,6 +5,7 @@ exports[`Default 1`] = `
   aria-valuenow="1"
   class="s-6VEvz9s88k9v"
   role="slider"
+  tabindex="0"
 >
   <button
     class="s-NMyTiX1zi6rz"
@@ -69,6 +70,7 @@ exports[`Disabled 1`] = `
   aria-valuenow="1"
   class="s-6VEvz9s88k9v"
   role="slider"
+  tabindex="0"
 >
   <button
     class="s-NMyTiX1zi6rz"
@@ -136,6 +138,7 @@ exports[`Secondary 1`] = `
   aria-valuenow="1"
   class="s-6VEvz9s88k9v"
   role="slider"
+  tabindex="0"
 >
   <button
     class="s-NMyTiX1zi6rz"

--- a/apps/web/tests/integration/pages/home.js
+++ b/apps/web/tests/integration/pages/home.js
@@ -32,7 +32,7 @@ export const HomePage = mixin(
         name: translate('titles.your-games')
       })
       /** @type {Locator} */
-      this.games = page.locator('[aria-roledescription="games"] >> role=button')
+      this.games = page.locator('[aria-roledescription="games"] >> article')
       /** @type {Locator} */
       this.catalogHeading = page.getByRole('heading', {
         name: translate('titles.catalog')

--- a/apps/web/tests/integration/pages/mixins/aside.js
+++ b/apps/web/tests/integration/pages/mixins/aside.js
@@ -84,7 +84,7 @@ export class AsideMixin {
       this.friendsTab,
       'the friends tab is not available'
     ).toBeVisible()
-    if (!(await this.isTabActive(this.friendsTab))) {
+    while (!(await this.isTabActive(this.friendsTab))) {
       await this.friendsTab.click()
     }
     await this.friendItems.getByText(guestUsername).click()

--- a/apps/web/tests/routes/home/+page.test.js
+++ b/apps/web/tests/routes/home/+page.test.js
@@ -204,10 +204,14 @@ describe('/home route', () => {
 
   it('can cancels game deletion', async () => {
     await renderWithLoad()
-    const gameLink = screen.getByRole('heading', {
-      name: games[0].locales.fr.title
-    }).parentElement
-    await fireEvent.click(within(gameLink).getByRole('button'))
+    const gameLink = screen
+      .getByRole('heading', {
+        name: games[0].locales.fr.title
+      })
+      .closest('article')
+    await fireEvent.click(
+      within(gameLink).getByRole('button', { name: 'delete' })
+    )
 
     const confirmDialogue = screen.getByRole('dialog')
     expect(confirmDialogue).toBeInTheDocument()
@@ -220,10 +224,14 @@ describe('/home route', () => {
 
   it('displays a toaster on game deletion', async () => {
     await renderWithLoad()
-    const gameLink = screen.getByRole('heading', {
-      name: games[0].locales.fr.title
-    }).parentElement
-    await fireEvent.click(within(gameLink).getByRole('button'))
+    const gameLink = screen
+      .getByRole('heading', {
+        name: games[0].locales.fr.title
+      })
+      .closest('article')
+    await fireEvent.click(
+      within(gameLink).getByRole('button', { name: 'delete' })
+    )
 
     const confirmDialogue = screen.getByRole('dialog')
     expect(confirmDialogue).toBeInTheDocument()

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -495,7 +495,7 @@ exports[`Authenticated 1`] = `
               <span
                 class="created s-QQoQzhRq8NK6"
               >
-                02 août, 08:13
+                02 août, 09:13
               </span>
                
                
@@ -543,7 +543,7 @@ exports[`Authenticated 1`] = `
               <span
                 class="created s-QQoQzhRq8NK6"
               >
-                29 juil., 07:17
+                29 juil., 08:17
               </span>
                
               <span

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -474,87 +474,95 @@ exports[`Authenticated 1`] = `
           class="s-A-bC3Hke5zSn"
         >
           
-          <button
+          <article
             class="s-QQoQzhRq8NK6"
             style="--bg-url: url('http://localhost:3001/games/playground/catalog/cover.webp');"
-            tabindex="0"
           >
-            <span
-              class="title s-QQoQzhRq8NK6"
+            <button
+              class="s-QQoQzhRq8NK6"
+              tabindex="0"
             >
-              <h3
-                class="s-QQoQzhRq8NK6"
+              <span
+                class="title s-QQoQzhRq8NK6"
               >
-                Jeu de 32 cartes
-              </h3>
-               
-              <div
-                class="buttons s-QQoQzhRq8NK6"
-              >
-                <button
-                  class="s-NMyTiX1zi6rz"
-                  secondary="true"
+                <h3
+                  class="s-QQoQzhRq8NK6"
                 >
-                  <span
-                    class="material-icons s-NMyTiX1zi6rz"
-                  >
-                    delete
-                  </span>
-                  
-                  
-                  
-                </button>
-                <!--&lt;Button&gt;-->
-              </div>
-            </span>
+                  Jeu de 32 cartes
+                </h3>
+              </span>
+               
+              <span
+                class="created s-QQoQzhRq8NK6"
+              >
+                02 août, 08:13
+              </span>
+               
+               
+            </button>
              
-            <span
-              class="created s-QQoQzhRq8NK6"
+            <div
+              class="actions s-QQoQzhRq8NK6"
             >
-              02 août, 09:13
-            </span>
-             
-             
-          </button>
+              <button
+                class="s-NMyTiX1zi6rz"
+                secondary="true"
+              >
+                <span
+                  class="material-icons s-NMyTiX1zi6rz"
+                >
+                  delete
+                </span>
+                
+                
+                
+              </button>
+              <!--&lt;Button&gt;-->
+            </div>
+          </article>
           <!--&lt;GameLink&gt;-->
           
-          <button
+          <article
             class="s-QQoQzhRq8NK6"
             style="--bg-url: url('http://localhost:3001/games/6-takes/catalog/cover.webp');"
-            tabindex="0"
           >
-            <span
-              class="title s-QQoQzhRq8NK6"
+            <button
+              class="s-QQoQzhRq8NK6"
+              tabindex="0"
             >
-              <h3
+              <span
+                class="title s-QQoQzhRq8NK6"
+              >
+                <h3
+                  class="s-QQoQzhRq8NK6"
+                >
+                  6 qui prend !
+                </h3>
+              </span>
+               
+              <span
+                class="created s-QQoQzhRq8NK6"
+              >
+                29 juil., 07:17
+              </span>
+               
+              <span
                 class="s-QQoQzhRq8NK6"
               >
-                6 qui prend !
-              </h3>
+                avec Dams, Célia
+              </span>
                
-              <div
-                class="buttons s-QQoQzhRq8NK6"
-              />
-            </span>
+              <span
+                class="guests s-QQoQzhRq8NK6"
+              >
+                invités: Hugo
+              </span>
+            </button>
              
-            <span
-              class="created s-QQoQzhRq8NK6"
-            >
-              29 juil., 08:17
-            </span>
-             
-            <span
-              class="s-QQoQzhRq8NK6"
-            >
-              avec Dams, Célia
-            </span>
-             
-            <span
-              class="guests s-QQoQzhRq8NK6"
-            >
-              invités: Hugo
-            </span>
-          </button>
+            <div
+              class="actions s-QQoQzhRq8NK6"
+            />
+          </article>
           <!--&lt;GameLink&gt;-->
         </section>
          

--- a/apps/web/tests/routes/home/__snapshots__/GameLink.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/GameLink.tools.shot
@@ -1,251 +1,275 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Current lobby 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6 lobby isCurrent"
   style="--bg-url: url('http://localhost:3001/games/undefined/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
-      class="s-QQoQzhRq8NK6"
+    <span
+      class="title s-QQoQzhRq8NK6"
     >
-      Salon
-    </h3>
-     
-    <div
-      class="buttons s-QQoQzhRq8NK6"
-    >
-      <button
-        class="s-NMyTiX1zi6rz"
-        secondary="true"
+      <h3
+        class="s-QQoQzhRq8NK6"
       >
-        <span
-          class="material-icons s-NMyTiX1zi6rz"
-        >
-          close
-        </span>
-        
-        
-        
-      </button>
-      <!--&lt;Button&gt;-->
-    </div>
-  </span>
+        Salon
+      </h3>
+    </span>
+     
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+     
+  </button>
    
-  <span
-    class="created s-QQoQzhRq8NK6"
+  <div
+    class="actions s-QQoQzhRq8NK6"
   >
-    02 mai, 21:25
-  </span>
-   
-   
-</button>
+    <button
+      class="s-NMyTiX1zi6rz"
+      secondary="true"
+    >
+      <span
+        class="material-icons s-NMyTiX1zi6rz"
+      >
+        close
+      </span>
+      
+      
+      
+    </button>
+    <!--&lt;Button&gt;-->
+  </div>
+</article>
 `;
 
 exports[`Guests only 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6"
   style="--bg-url: url('http://localhost:3001/games/riichi/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
-      class="s-QQoQzhRq8NK6"
+    <span
+      class="title s-QQoQzhRq8NK6"
     >
-      Richii Mahjong
-    </h3>
+      <h3
+        class="s-QQoQzhRq8NK6"
+      >
+        Richii Mahjong
+      </h3>
+    </span>
      
-    <div
-      class="buttons s-QQoQzhRq8NK6"
-    />
-  </span>
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+     
+    <span
+      class="guests s-QQoQzhRq8NK6"
+    >
+      invités: John, Georges
+    </span>
+  </button>
    
-  <span
-    class="created s-QQoQzhRq8NK6"
-  >
-    02 mai, 21:25
-  </span>
-   
-   
-  <span
-    class="guests s-QQoQzhRq8NK6"
-  >
-    invités: John, Georges
-  </span>
-</button>
+  <div
+    class="actions s-QQoQzhRq8NK6"
+  />
+</article>
 `;
 
 exports[`Invited 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6"
   style="--bg-url: url('http://localhost:3001/games/riichi/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
+    <span
+      class="title s-QQoQzhRq8NK6"
+    >
+      <h3
+        class="s-QQoQzhRq8NK6"
+      >
+        Richii Mahjong
+      </h3>
+    </span>
+     
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+    <span
       class="s-QQoQzhRq8NK6"
     >
-      Richii Mahjong
-    </h3>
+      avec Chandra, Timothé
+    </span>
      
-    <div
-      class="buttons s-QQoQzhRq8NK6"
-    />
-  </span>
+    <span
+      class="guests s-QQoQzhRq8NK6"
+    >
+      invités: John, Georges
+    </span>
+  </button>
    
-  <span
-    class="created s-QQoQzhRq8NK6"
-  >
-    02 mai, 21:25
-  </span>
-   
-  <span
-    class="s-QQoQzhRq8NK6"
-  >
-    avec Chandra, Timothé
-  </span>
-   
-  <span
-    class="guests s-QQoQzhRq8NK6"
-  >
-    invités: John, Georges
-  </span>
-</button>
+  <div
+    class="actions s-QQoQzhRq8NK6"
+  />
+</article>
 `;
 
 exports[`Lobby 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6 lobby"
   style="--bg-url: url('http://localhost:3001/games/undefined/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
-      class="s-QQoQzhRq8NK6"
+    <span
+      class="title s-QQoQzhRq8NK6"
     >
-      Salon
-    </h3>
+      <h3
+        class="s-QQoQzhRq8NK6"
+      >
+        Salon
+      </h3>
+    </span>
      
-    <div
-      class="buttons s-QQoQzhRq8NK6"
-    />
-  </span>
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+     
+  </button>
    
-  <span
-    class="created s-QQoQzhRq8NK6"
-  >
-    02 mai, 21:25
-  </span>
-   
-   
-</button>
+  <div
+    class="actions s-QQoQzhRq8NK6"
+  />
+</article>
 `;
 
 exports[`Owned 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6"
   style="--bg-url: url('http://localhost:3001/games/riichi/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
+    <span
+      class="title s-QQoQzhRq8NK6"
+    >
+      <h3
+        class="s-QQoQzhRq8NK6"
+      >
+        Richii Mahjong
+      </h3>
+    </span>
+     
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+    <span
       class="s-QQoQzhRq8NK6"
     >
-      Richii Mahjong
-    </h3>
+      avec Sarah, Timothé
+    </span>
      
-    <div
-      class="buttons s-QQoQzhRq8NK6"
+    <span
+      class="guests s-QQoQzhRq8NK6"
     >
-      <button
-        class="s-NMyTiX1zi6rz"
-        secondary="true"
+      invités: John, Georges
+    </span>
+  </button>
+   
+  <div
+    class="actions s-QQoQzhRq8NK6"
+  >
+    <button
+      class="s-NMyTiX1zi6rz"
+      secondary="true"
+    >
+      <span
+        class="material-icons s-NMyTiX1zi6rz"
       >
-        <span
-          class="material-icons s-NMyTiX1zi6rz"
-        >
-          delete
-        </span>
-        
-        
-        
-      </button>
-      <!--&lt;Button&gt;-->
-    </div>
-  </span>
-   
-  <span
-    class="created s-QQoQzhRq8NK6"
-  >
-    02 mai, 21:25
-  </span>
-   
-  <span
-    class="s-QQoQzhRq8NK6"
-  >
-    avec Sarah, Timothé
-  </span>
-   
-  <span
-    class="guests s-QQoQzhRq8NK6"
-  >
-    invités: John, Georges
-  </span>
-</button>
+        delete
+      </span>
+      
+      
+      
+    </button>
+    <!--&lt;Button&gt;-->
+  </div>
+</article>
 `;
 
 exports[`Single owned 1`] = `
-<button
+<article
   class="s-QQoQzhRq8NK6"
   style="--bg-url: url('http://localhost:3001/games/riichi/catalog/cover.webp');"
-  tabindex="0"
 >
-  <span
-    class="title s-QQoQzhRq8NK6"
+  <button
+    class="s-QQoQzhRq8NK6"
+    tabindex="0"
   >
-    <h3
-      class="s-QQoQzhRq8NK6"
+    <span
+      class="title s-QQoQzhRq8NK6"
     >
-      Richii Mahjong
-    </h3>
-     
-    <div
-      class="buttons s-QQoQzhRq8NK6"
-    >
-      <button
-        class="s-NMyTiX1zi6rz"
-        secondary="true"
+      <h3
+        class="s-QQoQzhRq8NK6"
       >
-        <span
-          class="material-icons s-NMyTiX1zi6rz"
-        >
-          delete
-        </span>
-        
-        
-        
-      </button>
-      <!--&lt;Button&gt;-->
-    </div>
-  </span>
+        Richii Mahjong
+      </h3>
+    </span>
+     
+    <span
+      class="created s-QQoQzhRq8NK6"
+    >
+      02 mai, 20:25
+    </span>
+     
+     
+  </button>
    
-  <span
-    class="created s-QQoQzhRq8NK6"
+  <div
+    class="actions s-QQoQzhRq8NK6"
   >
-    02 mai, 21:25
-  </span>
-   
-   
-</button>
+    <button
+      class="s-NMyTiX1zi6rz"
+      secondary="true"
+    >
+      <span
+        class="material-icons s-NMyTiX1zi6rz"
+      >
+        delete
+      </span>
+      
+      
+      
+    </button>
+    <!--&lt;Button&gt;-->
+  </div>
+</article>
 `;

--- a/apps/web/tests/routes/home/__snapshots__/GameLink.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/GameLink.tools.shot
@@ -22,7 +22,7 @@ exports[`Current lobby 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
      
@@ -71,7 +71,7 @@ exports[`Guests only 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
      
@@ -110,7 +110,7 @@ exports[`Invited 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
     <span
@@ -154,7 +154,7 @@ exports[`Lobby 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
      
@@ -188,7 +188,7 @@ exports[`Owned 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
     <span
@@ -247,7 +247,7 @@ exports[`Single owned 1`] = `
     <span
       class="created s-QQoQzhRq8NK6"
     >
-      02 mai, 20:25
+      02 mai, 21:25
     </span>
      
      


### PR DESCRIPTION
### :book: What's in there?

When players have some current games, loading the their home page will suffer from a flash of unstyled content, due to nested buttons in the `GameLink` component.

Are included here:

- fix(web): FLOUC on home page
- test(web): fixes flaky integration test

### :test_tube: How to test?

1. make sure you have current game(s)
   > There should be a couple of GameLink component instances
2. reload your home page
   > There should not be FLOUC

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
