### PR TITLE
feat(web): supports selecting player color

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Road to beta
 
 - replace material icon font with https://github.com/marella/material-design-icons/tree/main/svg#readme
-- select player color in games
 - interface in English
 - server logging (warning on invalid descriptors) + log file rotation
 - automerge.js
@@ -280,3 +279,11 @@ How to export from blender to Babylon?
 - do not export materials
 
 Pnpm has a super nice feature: interactive dependency update: `pnpm update -i --latest -r`
+
+For choosing game colors:
+
+1. use https://coolors.co/ and stick color hex codes (no '#' prefix) separated with '-'.
+2. make sure player colors have good contrast with white text.
+3. make sure player colors have sufficient contrast with table texture/color.
+4. try as much as possible to have player colors with enough distance, to avoid confusion.
+5. black is a great player color! Transparent colors work as well.

--- a/apps/games/chess/index.js
+++ b/apps/games/chess/index.js
@@ -25,8 +25,10 @@ export const tableSpec = {
 
 export const zoomSpec = { min: 20 }
 
+// https://coolors.co/dda15e-606c38-fefae0-bd5d2c-6d938e
 export const colors = {
   base: '#dda15e',
   primary: '#606c38',
-  secondary: '#fefae0'
+  secondary: '#fefae0',
+  players: ['#dda15e', '#606c38']
 }

--- a/apps/games/chess/logic/players.js
+++ b/apps/games/chess/logic/players.js
@@ -1,27 +1,22 @@
-import { buildCameraPosition } from '@tabulous/server/src/utils/index.js'
+import {
+  buildCameraPosition,
+  findAvailableValues
+} from '@tabulous/server/src/utils/index.js'
 
 import { blackId, cameraPositions, whiteId } from './constants.js'
 
 export function askForParameters({ game: { preferences } }) {
-  const usedValues = preferences.map(({ side }) => side)
-  return usedValues.length
+  const sides = findAvailableValues(preferences, 'side', [whiteId, blackId])
+  return sides.length <= 1
     ? null
     : {
         type: 'object',
         additionalProperties: false,
         properties: {
           side: {
-            type: 'string',
-            enum: [whiteId, blackId].filter(
-              value => !usedValues.includes(value)
-            ),
-            metadata: {
-              fr: {
-                name: 'Couleur',
-                [whiteId]: 'Blancs',
-                [blackId]: 'Noirs'
-              }
-            }
+            description: 'color',
+            enum: sides,
+            metadata: { fr: { name: 'Couleur' } }
           }
         },
         required: ['side']
@@ -39,6 +34,8 @@ export function addPlayer(game, player, parameters) {
       : parameters.side
   // stores preferences for the next player added.
   preferences[preferences.length - 1].side = side
+  preferences[preferences.length - 1].color =
+    game.colors.players[side === whiteId ? 1 : 0]
   // set camera based on selected side.
   cameras.push(
     buildCameraPosition({

--- a/apps/games/draughts/index.js
+++ b/apps/games/draughts/index.js
@@ -25,8 +25,10 @@ export const tableSpec = {
 
 export const zoomSpec = { min: 20 }
 
+// https://coolors.co/ebd8c3-fbe0e0-ffeeee-bd5d2c-6d938e
 export const colors = {
   base: '#ebd8c3',
   primary: '#fbe0e0',
-  secondary: '#ffeeee'
+  secondary: '#ffeeee',
+  players: ['#bd5d2c', '#6d938e']
 }

--- a/apps/games/draughts/logic/players.js
+++ b/apps/games/draughts/logic/players.js
@@ -1,27 +1,22 @@
-import { buildCameraPosition } from '@tabulous/server/src/utils/index.js'
+import {
+  buildCameraPosition,
+  findAvailableValues
+} from '@tabulous/server/src/utils/index.js'
 
 import { blackId, cameraPositions, whiteId } from './constants.js'
 
 export function askForParameters({ game: { preferences } }) {
-  const usedValues = preferences.map(({ side }) => side)
-  return usedValues.length
+  const sides = findAvailableValues(preferences, 'side', [whiteId, blackId])
+  return sides.length <= 1
     ? null
     : {
         type: 'object',
         additionalProperties: false,
         properties: {
           side: {
-            type: 'string',
-            enum: [whiteId, blackId].filter(
-              value => !usedValues.includes(value)
-            ),
-            metadata: {
-              fr: {
-                name: 'Couleur',
-                [whiteId]: 'Blancs',
-                [blackId]: 'Noirs'
-              }
-            }
+            description: 'color',
+            enum: sides,
+            metadata: { fr: { name: 'Couleur' } }
           }
         },
         required: ['side']
@@ -39,6 +34,8 @@ export function addPlayer(game, player, parameters) {
       : parameters.side
   // stores preferences for the next player added.
   preferences[preferences.length - 1].side = side
+  preferences[preferences.length - 1].color =
+    game.colors.players[side === whiteId ? 0 : 1]
   // set camera based on selected side.
   cameras.push(
     buildCameraPosition({

--- a/apps/games/mah-jong/index.js
+++ b/apps/games/mah-jong/index.js
@@ -1,4 +1,5 @@
 export * from './logic/build.js'
+export { colors } from './logic/constants.js'
 export * from './logic/player.js'
 
 export const locales = {
@@ -18,9 +19,3 @@ export const minTime = 60
 export const tableSpec = { texture: '#36823e' }
 
 export const zoomSpec = { hand: 35, min: 20, max: 90 }
-
-export const colors = {
-  base: '#B36B00',
-  primary: '#CB0A2A',
-  secondary: '#adc2ad'
-}

--- a/apps/games/mah-jong/logic/constants.js
+++ b/apps/games/mah-jong/logic/constants.js
@@ -1,3 +1,11 @@
+// https://coolors.co/b36b00-cb0a2a-adc2ad-1e152a-9c9c9c-eea93f-2274a5
+export const colors = {
+  base: '#b36b00',
+  primary: '#cb0a2a',
+  secondary: '#adc2ad',
+  players: ['#cb0a2a', '#1e152a', '#9c9c9c', '#eea93f', '#2274a5']
+}
+
 export const walls = {
   east: 'east',
   south: 'south',

--- a/apps/games/mah-jong/logic/player.js
+++ b/apps/games/mah-jong/logic/player.js
@@ -1,6 +1,24 @@
-import { buildCameraPosition } from '@tabulous/server/src/utils/index.js'
+import {
+  buildCameraPosition,
+  findAvailableValues
+} from '@tabulous/server/src/utils/index.js'
 
 import { buildSticks } from './builders/index.js'
+import { colors } from './constants.js'
+
+export function askForParameters({ game: { preferences } }) {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      color: {
+        description: 'color',
+        enum: findAvailableValues(preferences, 'color', colors.players),
+        metadata: { fr: { name: 'Couleur' } }
+      }
+    }
+  }
+}
 
 /**
  * Set player angle and camera position based on their rank:

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -419,10 +419,12 @@ async function enrichWithPlayer({ descriptor, game, guest, parameters }) {
   if (descriptor) {
     game.preferences.push({
       playerId: guest.id,
-      color: pickRandom(
-        colors,
-        game.preferences.map(({ color }) => color)
-      )
+      color:
+        parameters?.color ??
+        pickRandom(
+          game.colors?.players ?? colors,
+          game.preferences.map(({ color }) => color)
+        )
     })
   }
   if (!descriptor?.addPlayer) {

--- a/apps/server/src/utils/games.js
+++ b/apps/server/src/utils/games.js
@@ -466,3 +466,18 @@ export async function getParameterSchema({ descriptor, game, player }) {
   }
   return schema ? { ...game, schema } : null
 }
+
+/**
+ * Returns all possible values of a preference that were not picked by other players.
+ * For example: `findAvailableValues(preferences, 'color', colors.players)` returns available colors.
+ *
+ * @param {object[]} preferences - list of player preferences objects.
+ * @param {string} name - name of the preference considered.
+ * @param {any[]} possibleValues - list of possible values.
+ * @returns {any[]} filtered possible values (could be empty).
+ */
+export function findAvailableValues(preferences, name, possibleValues) {
+  return possibleValues.filter(value =>
+    preferences.every(pref => value !== pref[name])
+  )
+}

--- a/apps/server/tests/fixtures/games/belote/index.js
+++ b/apps/server/tests/fixtures/games/belote/index.js
@@ -18,3 +18,7 @@ export function addPlayer(game, player) {
 }
 
 export const zoomSpec = { min: 5, max: 50 }
+
+export const colors = {
+  players: ['red', 'green', 'blue']
+}

--- a/apps/server/tests/fixtures/games/draughts/index.js
+++ b/apps/server/tests/fixtures/games/draughts/index.js
@@ -12,15 +12,21 @@ export function askForParameters({ game: { preferences } }) {
     type: 'object',
     additionalProperties: false,
     properties: {
+      color: {
+        enum: ['red', 'green', 'blue'],
+        description: 'color',
+        metadata: {
+          fr: { name: 'Couleur', red: 'rouge', blue: 'bleu', green: 'vert' }
+        }
+      },
       side: {
-        type: 'string',
         enum: ['white', 'black'].filter(value => !usedValues.includes(value)),
         metadata: {
-          fr: { name: 'Couleur', white: 'Blancs', black: 'Noirs' }
+          fr: { name: 'Coté', white: 'Blancs', black: 'Noirs' }
         }
       }
     },
-    required: ['side']
+    required: ['side', 'color']
   }
 }
 

--- a/apps/server/tests/repositories/catalog-items.test.js
+++ b/apps/server/tests/repositories/catalog-items.test.js
@@ -17,7 +17,8 @@ describe('Catalog Items repository', () => {
       name: 'belote',
       build: expect.any(Function),
       addPlayer: expect.any(Function),
-      zoomSpec: { min: 5, max: 50 }
+      zoomSpec: { min: 5, max: 50 },
+      colors: { players: ['red', 'green', 'blue'] }
     },
     {
       name: 'draughts',

--- a/apps/server/tests/services/catalog.test.js
+++ b/apps/server/tests/services/catalog.test.js
@@ -48,7 +48,8 @@ describe('Catalog service', () => {
       name: 'belote',
       build: expect.any(Function),
       addPlayer: expect.any(Function),
-      zoomSpec: { min: 5, max: 50 }
+      zoomSpec: { min: 5, max: 50 },
+      colors: { players: ['red', 'green', 'blue'] }
     },
     {
       name: 'draughts',

--- a/apps/server/tests/utils/games.test.js
+++ b/apps/server/tests/utils/games.test.js
@@ -10,6 +10,7 @@ import {
   drawInHand,
   enrichAssets,
   findAnchor,
+  findAvailableValues,
   findMesh,
   findOrCreateHand,
   getParameterSchema,
@@ -1086,6 +1087,54 @@ describe('getParameterSchema()', () => {
       clubs: `/clubs.png`,
       spades: `#spades.png`
     })
+  })
+})
+
+describe('findAvailableValues()', () => {
+  const colors = ['red', 'green', 'blue']
+
+  it('returns all possible values when there are no preferences', () => {
+    expect(findAvailableValues([], 'color', colors)).toEqual(colors)
+  })
+
+  it('returns nothing when all possible values were used', () => {
+    expect(
+      findAvailableValues(
+        colors.map(color => ({ color })),
+        'color',
+        colors
+      )
+    ).toEqual([])
+  })
+
+  it('returns available values', () => {
+    expect(
+      findAvailableValues(
+        [
+          { color: 'red' },
+          { color: 'lime' },
+          { color: 'azure' },
+          { color: 'blue' }
+        ],
+        'color',
+        colors
+      )
+    ).toEqual(['green'])
+  })
+
+  it('ignores unknown preference name', () => {
+    expect(
+      findAvailableValues(
+        [
+          { color: 'red' },
+          { color: 'lime' },
+          { color: 'azure' },
+          { color: 'blue' }
+        ],
+        'unknown',
+        colors
+      )
+    ).toEqual(colors)
   })
 })
 

--- a/apps/web/src/components/Button.svelte
+++ b/apps/web/src/components/Button.svelte
@@ -11,7 +11,7 @@
   {...$$restProps}
   class:primary
   class:transparent
-  class:has-text={Boolean(text)}
+  class:has-text={Boolean(text) || $$slots.text}
   bind:this={ref}
   on:click
   on:keyup
@@ -21,7 +21,9 @@
   ><div>
     {#if icon}<span class="material-icons">{icon}</span
       >{:else if $$slots.icon}<span class="icon"><slot name="icon" /></span
-      >{/if}{#if text}<span class="text">{text}</span>{/if}<slot />
+      >{/if}{#if text}<span class="text">{text}</span
+      >{:else if $$slots.text}<span class="text"><slot name="text" /></span
+      >{/if}<slot />
   </div>
   {#if badge != undefined}
     <span class="badge">{badge > 999 ? `+999` : badge}</span>

--- a/apps/web/src/components/Button.svelte
+++ b/apps/web/src/components/Button.svelte
@@ -11,7 +11,7 @@
   {...$$restProps}
   class:primary
   class:transparent
-  class:has-text={Boolean(text) || $$slots.text}
+  class:has-text={Boolean(text)}
   bind:this={ref}
   on:click
   on:keyup
@@ -21,9 +21,8 @@
   ><div>
     {#if icon}<span class="material-icons">{icon}</span
       >{:else if $$slots.icon}<span class="icon"><slot name="icon" /></span
-      >{/if}{#if text}<span class="text">{text}</span
-      >{:else if $$slots.text}<span class="text"><slot name="text" /></span
-      >{/if}<slot />
+      >{/if}{#if $$slots.text}<span class="text"><slot name="text" /></span
+      >{:else if text}<span class="text">{text}</span>{/if}<slot />
   </div>
   {#if badge != undefined}
     <span class="badge">{badge > 999 ? `+999` : badge}</span>
@@ -81,6 +80,10 @@
     @apply rounded-full;
     &::before {
       @apply rounded-full;
+    }
+
+    .text {
+      @apply m-0;
     }
   }
 

--- a/apps/web/src/components/Dropdown.svelte
+++ b/apps/web/src/components/Dropdown.svelte
@@ -18,10 +18,11 @@
 
   $: iconOnly = !valueAsText && !text
   $: if (valueAsText) {
-    text =
-      value && !value.color && options?.includes(value)
-        ? value.label || value
-        : null
+    text = value?.color
+      ? ' '
+      : value && options?.includes(value)
+      ? value.label || value
+      : null
   }
 
   function handleClick() {
@@ -50,6 +51,7 @@
 <span class="wrapper" bind:this={anchor}>
   <Button
     {...$$restProps}
+    {text}
     role="combobox"
     aria-haspopup="menu"
     aria-expanded={open}
@@ -94,7 +96,7 @@
   }
 
   .color {
-    @apply inline-block w-6 h-6 p-1;
+    @apply inline-block w-6 h-[1.35rem];
     background-color: var(--color);
   }
 

--- a/apps/web/src/components/Dropdown.svelte
+++ b/apps/web/src/components/Dropdown.svelte
@@ -18,7 +18,10 @@
 
   $: iconOnly = !valueAsText && !text
   $: if (valueAsText) {
-    text = value && options?.includes(value) ? value.label || value : null
+    text =
+      value && !value.color && options?.includes(value)
+        ? value.label || value
+        : null
   }
 
   function handleClick() {
@@ -47,13 +50,17 @@
 <span class="wrapper" bind:this={anchor}>
   <Button
     {...$$restProps}
-    {text}
     role="combobox"
     aria-haspopup="menu"
     aria-expanded={open}
     on:click={handleClick}
   >
     <slot name="icon" />
+    <span
+      slot="text"
+      style:--color={value?.color}
+      class:color={Boolean(value?.color)}>{text || ''}</span
+    >
     {#if withArrow && options.length > 1}
       <i
         role="button"
@@ -84,6 +91,11 @@
 <style lang="postcss">
   .wrapper {
     @apply relative inline-block h-min;
+  }
+
+  .color {
+    @apply inline-block w-6 h-6 p-1;
+    background-color: var(--color);
   }
 
   .arrow {

--- a/apps/web/src/components/Menu.svelte
+++ b/apps/web/src/components/Menu.svelte
@@ -204,7 +204,10 @@
           />
         {:else}
           {#if option.icon}<i class="material-icons">{option.icon}</i>{/if}
-          {option.label || option}
+          {#if option.color}<span
+              class="color"
+              style:--color={option.color}
+            />{:else}{option.label || option}{/if}
         {/if}
       </li>
     {/each}
@@ -238,8 +241,13 @@
       }
     }
 
-    & > i {
+    > i {
       @apply mr-2 text-base;
+    }
+
+    > .color {
+      @apply inline-block w-full h-6 p-1;
+      background-color: var(--color);
     }
   }
 </style>

--- a/apps/web/src/components/Menu.svelte
+++ b/apps/web/src/components/Menu.svelte
@@ -246,7 +246,7 @@
     }
 
     > .color {
-      @apply inline-block w-full h-6 p-1;
+      @apply inline-block w-full h-6;
       background-color: var(--color);
     }
   }

--- a/apps/web/src/routes/(auth)/game/[gameId]/Parameters/Choice.svelte
+++ b/apps/web/src/routes/(auth)/game/[gameId]/Parameters/Choice.svelte
@@ -12,6 +12,7 @@
   // only build options for valid candidates
   $: options = findCandidates(property, name, values).map(value => ({
     value,
+    color: property.description === 'color' ? value : undefined,
     label: translate(value),
     image: findImage(property, value)
   }))
@@ -49,7 +50,13 @@
 <label for={name}>{translate('name') + $_('labels.colon')}</label>
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <span on:click|preventDefault on:keyup|preventDefault>
-  <Dropdown id={name} {options} {value} on:select={handleSelection} />
+  <Dropdown
+    id={name}
+    icon={property.description === 'color' ? 'color_lens' : undefined}
+    {options}
+    {value}
+    on:select={handleSelection}
+  />
   {#if value?.image}
     <img src="{gameAssetsUrl}{value.image}" alt="" />
   {/if}

--- a/apps/web/tests/components/Dropdown.tools.svelte
+++ b/apps/web/tests/components/Dropdown.tools.svelte
@@ -33,6 +33,13 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
     { icon: 'fast_rewind', label: 'previous' },
     { icon: 'fast_forward', label: 'next' }
   ]
+  const colorOptions = [
+    { color: '#CB0A2A', label: 'Fire engine red' },
+    { color: '#B36B00', label: "Tiger's eye" },
+    { color: '#ADC2AD', label: 'Ash gray' },
+    { color: '#6DBEC6', label: 'Verdigris' },
+    { color: '#BA69B0', label: 'Sky magenta' }
+  ]
 </script>
 
 <ToolBox
@@ -77,11 +84,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
     </div>
   </Tool>
   <Tool
-    name="Icon only"
+    name="With colors"
     props={{
-      text: null,
-      icon: 'headset_mic',
-      options: objectOptions
+      icon: 'colorize',
+      options: colorOptions,
+      value: colorOptions[2],
+      valueAsText: true
     }}
     let:props
     let:handleEvent
@@ -145,7 +153,6 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
   <Tool
     name="Split clicks"
     props={{
-      text: null,
       icon: 'headset_mic',
       openOnClick: false,
       options: [

--- a/apps/web/tests/components/Dropdown.tools.svelte
+++ b/apps/web/tests/components/Dropdown.tools.svelte
@@ -53,7 +53,7 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
     icon: 'emoji_people',
     options: [
       'Hello! (this is in English)',
-      `Salut ! (c'est en français)`,
+      "Salut ! (c'est en français)",
       'Hallo ! (das ist im Deutsch)'
     ]
   }}
@@ -72,7 +72,7 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
     </div>
   </Tool>
   <Tool name="Right aligned" let:props let:handleEvent>
-    <div class="text-right p-8">
+    <div class="p-8" style="text-align: right;">
       <div>{headerText}</div>
       <Dropdown
         {...props}
@@ -90,6 +90,27 @@ lacus vestibulum sed arcu non odio euismod lacinia.`
       options: colorOptions,
       value: colorOptions[2],
       valueAsText: true
+    }}
+    let:props
+    let:handleEvent
+  >
+    <div>
+      <div>{headerText}</div>
+      <Dropdown
+        {...props}
+        on:click={handleEvent}
+        on:select={handleEvent}
+        on:close={handleEvent}
+      />
+      <div>{footerText}</div>
+    </div>
+  </Tool>
+  <Tool
+    name="Icon only"
+    props={{
+      text: null,
+      icon: 'headset_mic',
+      options: objectOptions
     }}
     let:props
     let:handleEvent

--- a/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
@@ -1,76 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Icon only 1`] = `
-<div>
-  <div>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
-nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
-enim eu turpis egestas. Integer malesuada nunc vel risus commodo viverra
-maecenas accumsan lacus. Risus viverra adipiscing at in tellus integer
-feugiat scelerisque. Ultrices in iaculis nunc sed augue lacus viverra.
-Scelerisque in dictum non consectetur a erat nam at lectus. Egestas erat
-imperdiet sed euismod nisi porta. Ut faucibus pulvinar elementum integer
-enim neque. Proin sed libero enim sed faucibus turpis in eu. A iaculis at
-erat pellentesque adipiscing commodo elit at imperdiet.
-  </div>
-   
-  <span
-    class="wrapper s-rGIwyFRHo8D9"
-  >
-    <button
-      aria-expanded="false"
-      aria-haspopup="menu"
-      class="s-NMyTiX1zi6rz"
-      role="combobox"
-    >
-      <div
-        class="s-NMyTiX1zi6rz"
-      >
-        <span
-          class="material-icons s-NMyTiX1zi6rz"
-        >
-          headset_mic
-        </span>
-        
-        
-         
-        <i
-          class="material-icons arrow s-rGIwyFRHo8D9 iconOnly"
-          role="button"
-          tabindex="-1"
-        >
-          arrow_drop_down
-        </i>
-        
-      </div>
-       
-    </button>
-    <!--&lt;Button&gt;-->
-     
-    
-    <!--&lt;Menu&gt;-->
-  </span>
-  <!--&lt;Dropdown&gt;-->
-   
-  <div>
-    Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
-vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
-diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
-amet dictum sit amet justo donec. Metus aliquam eleifend mi in nulla
-posuere sollicitudin aliquam ultrices. Augue neque gravida in fermentum et
-sollicitudin ac orci phasellus. Vel quam elementum pulvinar etiam non quam
-lacus. Risus commodo viverra maecenas accumsan lacus vel facilisis
-volutpat est. Adipiscing vitae proin sagittis nisl rhoncus mattis.
-Vulputate eu scelerisque felis imperdiet proin fermentum. Suspendisse
-potenti nullam ac tortor vitae. Sem nulla pharetra diam sit amet. Egestas
-pretium aenean pharetra magna ac placerat vestibulum lectus. Ut porttitor
-leo a diam sollicitudin tempor id. Eget nullam non nisi est. Ullamcorper a
-lacus vestibulum sed arcu non odio euismod lacinia.
-  </div>
-</div>
-`;
-
 exports[`Invalid value 1`] = `
 <div>
   <div>
@@ -92,7 +21,7 @@ erat pellentesque adipiscing commodo elit at imperdiet.
     <button
       aria-expanded="false"
       aria-haspopup="menu"
-      class="s-NMyTiX1zi6rz"
+      class="has-text s-NMyTiX1zi6rz"
       role="combobox"
     >
       <div
@@ -104,6 +33,16 @@ erat pellentesque adipiscing commodo elit at imperdiet.
           headset_mic
         </span>
         
+        <span
+          class="text s-NMyTiX1zi6rz"
+        >
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            
+          </span>
+        </span>
         
          
         <i
@@ -180,7 +119,12 @@ erat pellentesque adipiscing commodo elit at imperdiet.
         <span
           class="text s-NMyTiX1zi6rz"
         >
-          Greet
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            Greet
+          </span>
         </span>
         
          
@@ -258,7 +202,12 @@ erat pellentesque adipiscing commodo elit at imperdiet.
         <span
           class="text s-NMyTiX1zi6rz"
         >
-          Greet
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            Greet
+          </span>
         </span>
         
          
@@ -319,7 +268,7 @@ erat pellentesque adipiscing commodo elit at imperdiet.
     <button
       aria-expanded="false"
       aria-haspopup="menu"
-      class="s-NMyTiX1zi6rz"
+      class="has-text s-NMyTiX1zi6rz"
       role="combobox"
     >
       <div
@@ -331,10 +280,20 @@ erat pellentesque adipiscing commodo elit at imperdiet.
           headset_mic
         </span>
         
+        <span
+          class="text s-NMyTiX1zi6rz"
+        >
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            Greet
+          </span>
+        </span>
         
          
         <i
-          class="material-icons arrow s-rGIwyFRHo8D9 iconOnly split"
+          class="material-icons arrow s-rGIwyFRHo8D9 split"
           role="button"
           tabindex="0"
         >
@@ -405,7 +364,94 @@ erat pellentesque adipiscing commodo elit at imperdiet.
         <span
           class="text s-NMyTiX1zi6rz"
         >
-          previous
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            previous
+          </span>
+        </span>
+        
+         
+        <i
+          class="material-icons arrow s-rGIwyFRHo8D9"
+          role="button"
+          tabindex="-1"
+        >
+          arrow_drop_down
+        </i>
+        
+      </div>
+       
+    </button>
+    <!--&lt;Button&gt;-->
+     
+    
+    <!--&lt;Menu&gt;-->
+  </span>
+  <!--&lt;Dropdown&gt;-->
+   
+  <div>
+    Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
+vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
+diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
+amet dictum sit amet justo donec. Metus aliquam eleifend mi in nulla
+posuere sollicitudin aliquam ultrices. Augue neque gravida in fermentum et
+sollicitudin ac orci phasellus. Vel quam elementum pulvinar etiam non quam
+lacus. Risus commodo viverra maecenas accumsan lacus vel facilisis
+volutpat est. Adipiscing vitae proin sagittis nisl rhoncus mattis.
+Vulputate eu scelerisque felis imperdiet proin fermentum. Suspendisse
+potenti nullam ac tortor vitae. Sem nulla pharetra diam sit amet. Egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus. Ut porttitor
+leo a diam sollicitudin tempor id. Eget nullam non nisi est. Ullamcorper a
+lacus vestibulum sed arcu non odio euismod lacinia.
+  </div>
+</div>
+`;
+
+exports[`With colors 1`] = `
+<div>
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
+nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
+enim eu turpis egestas. Integer malesuada nunc vel risus commodo viverra
+maecenas accumsan lacus. Risus viverra adipiscing at in tellus integer
+feugiat scelerisque. Ultrices in iaculis nunc sed augue lacus viverra.
+Scelerisque in dictum non consectetur a erat nam at lectus. Egestas erat
+imperdiet sed euismod nisi porta. Ut faucibus pulvinar elementum integer
+enim neque. Proin sed libero enim sed faucibus turpis in eu. A iaculis at
+erat pellentesque adipiscing commodo elit at imperdiet.
+  </div>
+   
+  <span
+    class="wrapper s-rGIwyFRHo8D9"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="menu"
+      class="has-text s-NMyTiX1zi6rz"
+      role="combobox"
+    >
+      <div
+        class="s-NMyTiX1zi6rz"
+      >
+        <span
+          class="material-icons s-NMyTiX1zi6rz"
+        >
+          colorize
+        </span>
+        
+        <span
+          class="text s-NMyTiX1zi6rz"
+        >
+          <span
+            class="s-rGIwyFRHo8D9 color"
+            slot="text"
+            style="--color: #ADC2AD;"
+          >
+            
+          </span>
         </span>
         
          

--- a/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Icon only 1`] = `
+<div>
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
+nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
+enim eu turpis egestas. Integer malesuada nunc vel risus commodo viverra
+maecenas accumsan lacus. Risus viverra adipiscing at in tellus integer
+feugiat scelerisque. Ultrices in iaculis nunc sed augue lacus viverra.
+Scelerisque in dictum non consectetur a erat nam at lectus. Egestas erat
+imperdiet sed euismod nisi porta. Ut faucibus pulvinar elementum integer
+enim neque. Proin sed libero enim sed faucibus turpis in eu. A iaculis at
+erat pellentesque adipiscing commodo elit at imperdiet.
+  </div>
+   
+  <span
+    class="wrapper s-rGIwyFRHo8D9"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="menu"
+      class="s-NMyTiX1zi6rz"
+      role="combobox"
+    >
+      <div
+        class="s-NMyTiX1zi6rz"
+      >
+        <span
+          class="material-icons s-NMyTiX1zi6rz"
+        >
+          headset_mic
+        </span>
+        
+        <span
+          class="text s-NMyTiX1zi6rz"
+        >
+          <span
+            class="s-rGIwyFRHo8D9"
+            slot="text"
+          >
+            
+          </span>
+        </span>
+        
+         
+        <i
+          class="material-icons arrow s-rGIwyFRHo8D9 iconOnly"
+          role="button"
+          tabindex="-1"
+        >
+          arrow_drop_down
+        </i>
+        
+      </div>
+       
+    </button>
+    <!--&lt;Button&gt;-->
+     
+    
+    <!--&lt;Menu&gt;-->
+  </span>
+  <!--&lt;Dropdown&gt;-->
+   
+  <div>
+    Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
+vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
+diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
+amet dictum sit amet justo donec. Metus aliquam eleifend mi in nulla
+posuere sollicitudin aliquam ultrices. Augue neque gravida in fermentum et
+sollicitudin ac orci phasellus. Vel quam elementum pulvinar etiam non quam
+lacus. Risus commodo viverra maecenas accumsan lacus vel facilisis
+volutpat est. Adipiscing vitae proin sagittis nisl rhoncus mattis.
+Vulputate eu scelerisque felis imperdiet proin fermentum. Suspendisse
+potenti nullam ac tortor vitae. Sem nulla pharetra diam sit amet. Egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus. Ut porttitor
+leo a diam sollicitudin tempor id. Eget nullam non nisi est. Ullamcorper a
+lacus vestibulum sed arcu non odio euismod lacinia.
+  </div>
+</div>
+`;
+
 exports[`Invalid value 1`] = `
 <div>
   <div>
@@ -21,7 +102,7 @@ erat pellentesque adipiscing commodo elit at imperdiet.
     <button
       aria-expanded="false"
       aria-haspopup="menu"
-      class="has-text s-NMyTiX1zi6rz"
+      class="s-NMyTiX1zi6rz"
       role="combobox"
     >
       <div
@@ -166,7 +247,8 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 
 exports[`Right aligned 1`] = `
 <div
-  class="text-right p-8"
+  class="p-8"
+  style="text-align: right;"
 >
   <div>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -450,7 +532,7 @@ erat pellentesque adipiscing commodo elit at imperdiet.
             slot="text"
             style="--color: #ADC2AD;"
           >
-            
+             
           </span>
         </span>
         

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
@@ -58,7 +58,7 @@ exports[`Manual account 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent has-text s-NMyTiX1zi6rz"
+            class="transparent s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div
@@ -324,7 +324,7 @@ exports[`OAuth account 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent has-text s-NMyTiX1zi6rz"
+            class="transparent s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div

--- a/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/(auth)/account/__snapshots__/+page.tools.shot
@@ -58,13 +58,23 @@ exports[`Manual account 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent s-NMyTiX1zi6rz"
+            class="transparent has-text s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div
               class="s-NMyTiX1zi6rz"
             >
               
+              <span
+                class="text s-NMyTiX1zi6rz"
+              >
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  
+                </span>
+              </span>
               
               <figure
                 class="s-engCJu8q-fNe"
@@ -314,13 +324,23 @@ exports[`OAuth account 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent s-NMyTiX1zi6rz"
+            class="transparent has-text s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div
               class="s-NMyTiX1zi6rz"
             >
               
+              <span
+                class="text s-NMyTiX1zi6rz"
+              >
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  
+                </span>
+              </span>
               
               <figure
                 class="s-engCJu8q-fNe"

--- a/apps/web/tests/routes/(auth)/game/[gameid]/Parameters.tools.svelte
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/Parameters.tools.svelte
@@ -16,6 +16,7 @@
         properties: {
           side: {
             enum: ['black', 'white'],
+            description: 'color',
             metadata: {
               fr: {
                 name: 'Couleur',
@@ -53,9 +54,9 @@
                 hearts: 'Coeur'
               },
               images: {
-                clubs: '/french-suited-card/images/clubs-1.svg',
-                spades: '/french-suited-card/images/spades-1.svg',
-                hearts: '/french-suited-card/images/hearts-1.svg'
+                clubs: '/assets/images/clubs-1.1.svg',
+                spades: '/assets/images/spades-1.1.svg',
+                hearts: '/assets/images/hearts-1.1.svg'
               }
             }
           }

--- a/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
@@ -35,7 +35,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="has-text s-NMyTiX1zi6rz"
+            class="s-NMyTiX1zi6rz has-text"
             id="side"
             role="combobox"
           >
@@ -92,7 +92,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="has-text s-NMyTiX1zi6rz"
+            class="s-NMyTiX1zi6rz has-text"
             id="position"
             role="combobox"
           >
@@ -202,7 +202,7 @@ exports[`Single choice 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="has-text s-NMyTiX1zi6rz"
+            class="s-NMyTiX1zi6rz has-text"
             id="side"
             role="combobox"
           >
@@ -223,7 +223,7 @@ exports[`Single choice 1`] = `
                   slot="text"
                   style="--color: black;"
                 >
-                  
+                   
                 </span>
               </span>
               

--- a/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
+++ b/apps/web/tests/routes/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
@@ -35,7 +35,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="side"
             role="combobox"
           >
@@ -46,7 +46,12 @@ exports[`Multiple choices 1`] = `
               <span
                 class="text s-NMyTiX1zi6rz"
               >
-                black
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  black
+                </span>
               </span>
               
                
@@ -87,7 +92,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="position"
             role="combobox"
           >
@@ -98,7 +103,12 @@ exports[`Multiple choices 1`] = `
               <span
                 class="text s-NMyTiX1zi6rz"
               >
-                Trèfle
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  Trèfle
+                </span>
               </span>
               
                
@@ -123,7 +133,7 @@ exports[`Multiple choices 1`] = `
         <img
           alt=""
           class="s-AFGyPIu2lLfy"
-          src="http://localhost:3001/games/french-suited-card/images/clubs-1.svg"
+          src="http://localhost:3001/games/assets/images/clubs-1.1.svg"
         />
       </span>
       <!--&lt;Choice&gt;-->
@@ -192,18 +202,29 @@ exports[`Single choice 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="side"
             role="combobox"
           >
             <div
               class="s-NMyTiX1zi6rz"
             >
+              <span
+                class="material-icons s-NMyTiX1zi6rz"
+              >
+                color_lens
+              </span>
               
               <span
                 class="text s-NMyTiX1zi6rz"
               >
-                Noirs
+                <span
+                  class="s-rGIwyFRHo8D9 color"
+                  slot="text"
+                  style="--color: black;"
+                >
+                  
+                </span>
               </span>
               
                

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -402,7 +402,7 @@ exports[`Authenticated 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent has-text s-NMyTiX1zi6rz"
+            class="transparent s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div

--- a/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/home/__snapshots__/+page.tools.shot
@@ -402,13 +402,23 @@ exports[`Authenticated 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent s-NMyTiX1zi6rz"
+            class="transparent has-text s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div
               class="s-NMyTiX1zi6rz"
             >
               
+              <span
+                class="text s-NMyTiX1zi6rz"
+              >
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  
+                </span>
+              </span>
               
               <figure
                 class="s-engCJu8q-fNe"

--- a/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
@@ -2391,7 +2391,7 @@ exports[`Connected 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent has-text s-NMyTiX1zi6rz"
+            class="transparent s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div

--- a/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/terms-of-service/__snapshots__/+page.tools.shot
@@ -2391,13 +2391,23 @@ exports[`Connected 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="transparent s-NMyTiX1zi6rz"
+            class="transparent has-text s-NMyTiX1zi6rz"
             role="combobox"
           >
             <div
               class="s-NMyTiX1zi6rz"
             >
               
+              <span
+                class="text s-NMyTiX1zi6rz"
+              >
+                <span
+                  class="s-rGIwyFRHo8D9"
+                  slot="text"
+                >
+                  
+                </span>
+              </span>
               
               <figure
                 class="s-engCJu8q-fNe"


### PR DESCRIPTION
### :book: What's in there?

In most games, player should pick a color when joining. The colors could be the color of their pawns (Chess, Draughts), or simply a different player color for their cursor and active selection (Mah-jong).

UI wise, the color picker should display the actual color, and not its name. It worth noting that we don't display a friendly name above the color: it would require adjusting the font color to the background color, and keep a readable ratio.

Are included here:

- feat(web): supports selecting color in game parameters
- feat(server): automatically assigns picked color or random game color when defined
- feat(mahjong): supports picking player color
- feat(draught): assigns player color based on picked side
- feat(chess): assigns player color based on picked side
- chore(server): introduces findAvailablePreference game utility

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
