### PR TITLE
fix(web): timezone used during server side rendering is wrong

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,8 @@
 ## Server
 
 - bug: lobby to parametrized game: handle concurrent parameters (playground)
-- bug: timezone used for Serverside rendering is wrong
+- bug: lobby to limited-seat game: rejected lobby owner creates an owner-less game
+- handle rejected players when promoting lobby to a limited-seats game
 - allows a single connection per player (discards other JWTs)
 - better coTURN integration (password management and rotation)
 

--- a/apps/web/src/common.js
+++ b/apps/web/src/common.js
@@ -5,6 +5,20 @@ import { getBrowserLocale, locale, options, translations } from 'svelte-intl'
 
 import fr from './locales/fr.yaml'
 
-translations.update({ fr, en: {} })
-locale.set(getBrowserLocale('fr'))
-options.update({ formats: fr.formats })
+export function initLocale(timeZone) {
+  translations.update({ fr, en: {} })
+  locale.set(getBrowserLocale('fr'))
+  options.update({
+    formats: {
+      ...fr.formats,
+      date: {
+        ...Object.fromEntries(
+          Object.entries(fr.formats.date).map(([name, definition]) => [
+            name,
+            { ...definition, timeZone }
+          ])
+        )
+      }
+    }
+  })
+}

--- a/apps/web/src/hooks.server.js
+++ b/apps/web/src/hooks.server.js
@@ -18,6 +18,8 @@ export async function handle({ event, resolve }) {
     locals.session = await recoverSession(fetch, locals.bearer)
   }
 
+  locals.timeZone = request.headers.get('x-vercel-ip-timezone') || undefined
+
   // session may be (un)set by endpoints
   return setCookie(await resolve(event), locals.session?.token)
 }

--- a/apps/web/src/routes/+layout.server.js
+++ b/apps/web/src/routes/+layout.server.js
@@ -4,7 +4,7 @@ const termsUrl = '/accept-terms'
 
 /** @type {import('./$types').LayoutServerLoad} */
 export function load({ url, locals }) {
-  const { bearer = null, session = null } = locals
+  const { bearer = null, session = null, timeZone } = locals
   if (session && !session.player?.termsAccepted && url.pathname !== termsUrl) {
     const location =
       url.pathname === '/'
@@ -12,5 +12,5 @@ export function load({ url, locals }) {
         : encodeURIComponent(url.href.replace(url.origin, ''))
     throw redirect(307, `${termsUrl}${location ? `?redirect=${location}` : ''}`)
   }
-  return { bearer, session }
+  return { bearer, session, timeZone }
 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,8 +1,13 @@
 <script>
-  import '../common'
-
   import { Toaster } from '@src/components'
   import { lastToast } from '@src/stores'
+  
+  import { initLocale } from '../common'
+
+  /** @type {import('./$types').LayoutData} */
+  export let data
+
+  initLocale(data.timeZone)
 </script>
 
 <slot />

--- a/apps/web/tests/atelier/setup.js
+++ b/apps/web/tests/atelier/setup.js
@@ -1,7 +1,9 @@
-import '../../src/common'
 import './styles.postcss'
 
 import * as kitClient from '../../node_modules/@sveltejs/kit/src/runtime/client/singletons'
+import { initLocale } from '../../src/common'
+
+initLocale()
 
 kitClient.init({
   client: {

--- a/apps/web/tests/setup.js
+++ b/apps/web/tests/setup.js
@@ -157,4 +157,5 @@ if (typeof window !== 'undefined') {
 }
 
 // common initialization, once locale is set
-await import('../src/common')
+const { initLocale } = await import('../src/common')
+initLocale()


### PR DESCRIPTION
### :book: What's in there?

Because the server hosting Tabulous is UTC, dates displayed on the home page (links to current games) are initially displayed as UTC and then swapped to user locale when the page hydrates.

To fix this, we can leverage [Vercel-specific request headers](https://vercel.com/docs/concepts/edge-network/headers#x-vercel-ip-timezone) to know the incoming request time zone, and adjust rendered dates.

Are included here:

- fix(web): timezone used during server side rendering is wrong

### :test_tube: How to test?

1. You'll need to use a VPN or live in a country that is not UTC 😁 .
2. Assuming you have current games, log in
3. Refresh the home page
   > Dates should not be swapped and should appear in your configured timeZone.