### PR TITLE
chore: suffers a lot hoping to get benefits from types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 apps/games/assets/
 apps/games/descriptors/
+apps/web/.svelte-kit/
 coverage/
 dist/
 dist-atelier/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,25 +1,27 @@
 module.exports = {
-  extends: ['eslint:recommended'],
+  root: true,
+  extends: ['eslint:recommended', 'plugin:svelte/recommended', 'prettier'],
   env: {
     browser: true,
     es2022: true,
     node: true
   },
-  plugins: ['svelte3', 'simple-import-sort', 'vitest'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['simple-import-sort', 'vitest', '@typescript-eslint'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2022,
+    extraFileExtensions: ['.svelte']
+  },
   overrides: [
     {
       files: ['*.svelte'],
-      processor: 'svelte3/svelte3'
-    },
-    {
-      files: ['*.js'],
-      extends: ['prettier']
+      parser: 'svelte-eslint-parser',
+      parserOptions: {
+        parser: '@typescript-eslint/parser'
+      }
     }
   ],
-  parserOptions: {
-    sourceType: 'module',
-    ecmaVersion: 2022
-  },
   rules: {
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',

--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,9 @@
 # TODO
 
-- manual testing: anchors on flip all/reorder
-- manual testing: lock/unlock
-- manual testing: decrement/increment by dragging
-- manual testing: updates shared in multiplayer
-- manual testing: texture caching: make a difference between hand & main
-- manual testing: texture color with alpha
-- manual testing: intersect geometries
-- manual testing: game parameters
-- manual/integration testing: kick
-- move server graphql types in a d.ts file
-- create type for migration files
-
 ## Road to beta
 
+- move server graphql types in a d.ts file
+- create type for migration files
 - ts-check game files
 - replace windicss with a successor (tailwind or UnoCSS)
 - automerge.js
@@ -31,6 +21,7 @@
 
 ## UI
 
+- bug: a game with no available seats and no other player should not display the friend list tab
 - bug: game shortcuts ignore active selection to only apply to hover mesh
 - bug: 6-takes: snapping to the wrong anchor (when 2 players are snapping to different anchors)
 - chore: a couple TODOs in the code

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,18 @@
 # TODO
 
+- move server graphql types in a d.ts file
+- create type for migration files
+
 ## Road to beta
 
+- ts-check game files
+- replace windicss with a successor (tailwind or UnoCSS)
 - automerge.js
 
 ## Refactor
 
-- add tests for web/src/utils/peer-connection
-- ts-check all the things!
 - graphQL + mesh: replace prismRotation with initialRotation
+- add tests for web/src/utils/peer-connection
 - group candidate target per kind for performance
 - keep anchor ids
 - create Animation objects as part of runAnimation() (constant frameRate of 60)
@@ -20,6 +24,8 @@
 
 - bug: game shortcuts ignore active selection to only apply to hover mesh
 - bug: 6-takes: snapping to the wrong anchor (when 2 players are snapping to different anchors)
+- chore: a couple TODOs in the code
+- chore: Placing %sveltekit.body% directly inside <body> is not recommended
 - score card (Mah-jong, Belote)
 - command to reset some mesh state and restart a game (Mah-jong, Belote)
 - check headings ordering

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,14 @@
 # TODO
 
+- manual testing: anchors on flip all/reorder
+- manual testing: lock/unlock
+- manual testing: decrement/increment by dragging
+- manual testing: updates shared in multiplayer
+- manual testing: texture caching: make a difference between hand & main
+- manual testing: texture color with alpha
+- manual testing: intersect geometries
+- manual testing: game parameters
+- manual/integration testing: kick
 - move server graphql types in a d.ts file
 - create type for migration files
 

--- a/apps/cli/src/commands/add-player.js
+++ b/apps/cli/src/commands/add-player.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').Player} Player */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 import kebabCase from 'lodash.kebabcase'
@@ -16,7 +18,7 @@ import { commonOptions } from './help.js'
 
 /**
  * @typedef {object} AddPlayerResult player addition command result
- * @property {import('../util/formaters.js').Player} player - added player.
+ * @property {Player} player - added player.
  */
 
 const addPlayerMutation = gql`

--- a/apps/cli/src/commands/catalog.js
+++ b/apps/cli/src/commands/catalog.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').CatalogItem} CatalogItem */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -13,8 +15,6 @@ import {
   signToken
 } from '../util/index.js'
 import { commonOptions } from './help.js'
-
-/** @typedef {import('@tabulous/server/src/services/catalog.js').GameDescriptor} GameDescriptor */
 
 /**
  * @typedef {object} CatalogResult game catalog command result
@@ -75,7 +75,7 @@ export default async function catalogCommand(argv) {
  */
 export async function catalog({ username }) {
   const { id } = await findUser(username)
-  /** @type {{ listCatalog: GameDescriptor[] }} */
+  /** @type {{ listCatalog: CatalogItem[] }} */
   const { listCatalog: catalog } = await getGraphQLClient().query(
     listCatalogQuery,
     signToken(id)
@@ -95,7 +95,7 @@ export async function catalog({ username }) {
 }
 
 /**
- * @param {GameDescriptor} descriptor
+ * @param {CatalogItem} descriptor
  * @returns {string} the descriptor localized name.
  */
 function getLocaleName({ name, locales }) {

--- a/apps/cli/src/commands/configure-loggers.js
+++ b/apps/cli/src/commands/configure-loggers.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').LoggerLevel} LoggerLevel */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -11,8 +13,6 @@ import {
   signToken
 } from '../util/index.js'
 import { commonOptions } from './help.js'
-
-/** @typedef {import('@tabulous/server/src/graphql/logger-resolver.js').LoggerLevel} LoggerLevel */
 
 const configureLoggersMutation = gql`
   mutation configureLoggerLevels($levels: [InputLoggerLevel!]!) {

--- a/apps/cli/src/commands/delete-game.js
+++ b/apps/cli/src/commands/delete-game.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').Game} Game */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -15,7 +17,7 @@ import { commonOptions } from './help.js'
 
 /**
  * @typedef {object} DeleteGameResult game deletion command result
- * @property {import('@tabulous/server/src/repositories/games.js').Game} game - deleted game.
+ * @property {Game} game - deleted game.
  */
 
 const deleteGameMutation = gql`

--- a/apps/cli/src/commands/delete-player.js
+++ b/apps/cli/src/commands/delete-player.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').Player} Player */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -15,7 +17,7 @@ import { commonOptions } from './help.js'
 
 /**
  * @typedef {object} DeletePlayerResult player deletion command result
- * @property {import('../util/formaters.js').Player} player - deleted player.
+ * @property {Player} player - deleted player.
  */
 
 const deletePlayerMutation = gql`

--- a/apps/cli/src/commands/list-players.js
+++ b/apps/cli/src/commands/list-players.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').Player} Player */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -12,8 +14,6 @@ import {
   signToken
 } from '../util/index.js'
 import { commonOptions } from './help.js'
-
-/** @typedef {import('../util/formaters.js').Player} Player */
 
 /**
  * Triggers player list command.

--- a/apps/cli/src/commands/show-player.js
+++ b/apps/cli/src/commands/show-player.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('@tabulous/server/src/graphql/types').Game} Game
+ * @typedef {import('@tabulous/server/src/graphql/types').Player} Player
+ */
+
 import { gql } from '@urql/core'
 import chalkTemplate from 'chalk-template'
 
@@ -14,11 +19,6 @@ import {
   signToken
 } from '../util/index.js'
 import { commonOptions } from './help.js'
-
-/** @typedef {import('../util/formaters.js').Player} Player */
-/** @typedef {import('@tabulous/server/src/services/games.js').Game} _Game */
-/** @typedef {(_Game & { players: Player[] })} Game */
-/** @typedef {Player & { games: Game[] }} PlayerDetails */
 
 const listGamesQuery = gql`
   query listGamesQuery {
@@ -37,7 +37,7 @@ const listGamesQuery = gql`
 /**
  * Triggers show player command.
  * @param {string[]} argv - array of parsed arguments (without executable and current file).
- * @returns {Promise<PlayerDetails | string>} whether the operation succeeded.
+ * @returns {Promise<Player | string>} whether the operation succeeded.
  */
 export default async function showPlayerCommand(argv) {
   const args = parseArgv(argv, {
@@ -59,10 +59,10 @@ export default async function showPlayerCommand(argv) {
 /**
  * Show a player's details.
  * @param {ShowPlayerArgs} args - username.
- * @returns {Promise<PlayerDetails>} found player details.
+ * @returns {Promise<Player>} found player details.
  */
 export async function showPlayer({ username }) {
-  const player = attachFormater(await findUser(username), formatPlayerDetails)
+  const player = attachFormater(await findUser(username), formatPlayer)
   const { listGames: games } = await getGraphQLClient().query(
     listGamesQuery,
     signToken(player.id)
@@ -80,7 +80,7 @@ export async function showPlayer({ username }) {
  * @param {Player} result
  * @returns {string} formatted results
  */
-function formatPlayerDetails({
+function formatPlayer({
   id,
   isAdmin,
   username,
@@ -100,13 +100,13 @@ function formatPlayerDetails({
 const spacing = '\n                '
 
 /**
- * @param {PlayerDetails} result
+ * @param {Player & {games: Game[]}} result
  * @returns {string} formatted results
  */
 function formatGames({ id: playerId, games }) {
   const { owned, invited } = games.reduce(
     (counts, game) => {
-      if (game.players.find(({ id, isOwner }) => isOwner && id === playerId)) {
+      if (game.players?.find(({ id, isOwner }) => isOwner && id === playerId)) {
         counts.owned.push(game)
       } else {
         counts.invited.push(game)

--- a/apps/cli/src/util/find-user.js
+++ b/apps/cli/src/util/find-user.js
@@ -1,4 +1,6 @@
 // @ts-check
+/** @typedef {import('@tabulous/server/src/graphql/types').Player} Player */
+
 import { gql } from '@urql/core'
 
 import { getGraphQLClient } from './graphql-client.js'
@@ -23,7 +25,7 @@ const findUserQuery = gql`
  * Finds user details from their username
  * @param {string} username - desired username.
  * @param {boolean} [failOnNull = true] - whether to throw an error when no player could be found.
- * @returns {Promise<import('@tabulous/server/src/services/players').Player>} corresponding player, or null.
+ * @returns {Promise<Player>} corresponding player, or null.
  * @throws {Error} when failOnNull is true, and no player could be found
  */
 export async function findUser(username, failOnNull = true) {

--- a/apps/cli/src/util/formaters.js
+++ b/apps/cli/src/util/formaters.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('@tabulous/server/src/graphql/types').Game} Game
+ * @typedef {import('@tabulous/server/src/graphql/types').Player} Player
+ */
+
 import chalkTemplate from 'chalk-template'
 
 const symbol = Symbol('formaters')
@@ -54,7 +59,7 @@ export function attachFormater(object, formater, first = false) {
 
 /**
  * Formater for game objects.
- * @param {import('@tabulous/server/src/services/games.js').Game} game - game to format.
+ * @param {Game} game - game to format.
  * @returns {string} formatted game.
  */
 export function formatGame({ id, created, kind }) {
@@ -62,9 +67,6 @@ export function formatGame({ id, created, kind }) {
     created
   )}} (${id})`
 }
-
-/** @typedef {import('@tabulous/server/src/services/players.js').Player} _Player */
-/** @typedef {_Player & { isOwner?: boolean }} Player */
 
 /**
  * Formater for player objects.

--- a/apps/cli/src/util/graphql-client.js
+++ b/apps/cli/src/util/graphql-client.js
@@ -1,11 +1,18 @@
 // @ts-check
+/**
+ * @typedef {import('@urql/core').Client} UrqlClient
+ * @typedef {import('@urql/core').ClientOptions} UrqlClientOptions
+ */
+
 import { cacheExchange, createClient, fetchExchange } from '@urql/core'
 import { Agent, fetch, setGlobalDispatcher } from 'undici'
 
 import { loadConfiguration } from './configuration.js'
 
-/** @typedef {Parameters<import('@urql/core').Client['query']>[0]} Query */
-/** @typedef {Parameters<import('@urql/core').Client['query']>[1]} Variables */
+/** @typedef {Parameters<UrqlClient['query']>[0]} Query */
+
+/** @typedef {Parameters<UrqlClient['query']>[1]} Variables */
+
 /** @typedef {<T>(query: Query, variablesOrJwt: Variables|string, jwt?: string) => Promise<T>} RequestSignature */
 
 /**
@@ -14,7 +21,7 @@ import { loadConfiguration } from './configuration.js'
  * @property {RequestSignature} mutation - runs a GraphQL query with pre-defined JWT, throwing received errors.
  */
 
-/** @typedef {Omit<import('@urql/core').Client, 'query'|'mutation'> & CustomClient} Client */
+/** @typedef {Omit<UrqlClient, 'query'|'mutation'> & CustomClient} Client */
 
 /** @type {?Client} */
 let client
@@ -40,7 +47,7 @@ export function getGraphQLClient() {
 }
 
 /**
- * @param {import('@urql/core').ClientOptions} options - GraphQL client options.
+ * @param {UrqlClientOptions} options - GraphQL client options.
  * @returns {Client} initialized client.
  */
 function initClient(options) {

--- a/apps/cli/src/util/index.js
+++ b/apps/cli/src/util/index.js
@@ -1,4 +1,3 @@
-// @ts-check
 export * from './args.js'
 export * from './configuration.js'
 export * from './find-user.js'

--- a/apps/cli/tests/commands/add-player.test.js
+++ b/apps/cli/tests/commands/add-player.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import kebabCase from 'lodash.kebabcase'
 import stripAnsi from 'strip-ansi'
@@ -12,8 +16,6 @@ const mockQuery = vi.fn()
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi.fn().mockReturnValue({ mutation: mockQuery })
 }))
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 describe('Player addition command', () => {
   /** @type {Command} */

--- a/apps/cli/tests/commands/catalog.test.js
+++ b/apps/cli/tests/commands/catalog.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,8 +11,6 @@ import { applyFormaters } from '../../src/util/formaters.js'
 import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi.fn().mockReturnValue({ query: mockQuery })

--- a/apps/cli/tests/commands/configure-loggers.test.js
+++ b/apps/cli/tests/commands/configure-loggers.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,8 +15,6 @@ const mockQuery = vi.fn()
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi.fn().mockReturnValue({ mutation: mockQuery })
 }))
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 describe('Logger configuration command', () => {
   /** @type {Command} */

--- a/apps/cli/tests/commands/delete-game.test.js
+++ b/apps/cli/tests/commands/delete-game.test.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ * @typedef {import('../../src/commands/show-player').Game} Game
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,9 +12,6 @@ import { applyFormaters, formatGame } from '../../src/util/formaters.js'
 import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
-
-/** @typedef {import('../../src/commands/show-player.js').Game} Game */
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi.fn().mockReturnValue({ mutation: mockQuery })

--- a/apps/cli/tests/commands/delete-player.test.js
+++ b/apps/cli/tests/commands/delete-player.test.js
@@ -1,4 +1,8 @@
-// @ts-check
+// @ts-checkcheck
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,8 +11,6 @@ import { applyFormaters } from '../../src/util/formaters.js'
 import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi.fn().mockReturnValue({ mutation: mockQuery })

--- a/apps/cli/tests/commands/delete-player.test.js
+++ b/apps/cli/tests/commands/delete-player.test.js
@@ -1,4 +1,4 @@
-// @ts-checkcheck
+// @ts-check
 /**
  * @typedef {import('../../src').Command} Command
  */

--- a/apps/cli/tests/commands/grant.test.js
+++ b/apps/cli/tests/commands/grant.test.js
@@ -1,4 +1,8 @@
-// @ts-check
+// @ts-checkcheck
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,8 +12,6 @@ import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
 const mockMutation = vi.fn()
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi

--- a/apps/cli/tests/commands/grant.test.js
+++ b/apps/cli/tests/commands/grant.test.js
@@ -1,4 +1,4 @@
-// @ts-checkcheck
+// @ts-check
 /**
  * @typedef {import('../../src').Command} Command
  */

--- a/apps/cli/tests/commands/list-players.test.js
+++ b/apps/cli/tests/commands/list-players.test.js
@@ -1,4 +1,4 @@
-// @ts-checkcheck
+// @ts-check
 /**
  * @typedef {import('../../src').Command} Command
  * @typedef {import('@tabulous/server/src/graphql/types').Player} Player

--- a/apps/cli/tests/commands/list-players.test.js
+++ b/apps/cli/tests/commands/list-players.test.js
@@ -1,4 +1,9 @@
-// @ts-check
+// @ts-checkcheck
+/**
+ * @typedef {import('../../src').Command} Command
+ * @typedef {import('@tabulous/server/src/graphql/types').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,9 +12,6 @@ import { applyFormaters, formatPlayer } from '../../src/util/formaters.js'
 
 const mockQuery = vi.fn()
 const mockMutation = vi.fn()
-
-/** @typedef {import('../../src/util/formaters.js').Player} Player */
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi

--- a/apps/cli/tests/commands/revoke.test.js
+++ b/apps/cli/tests/commands/revoke.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,8 +12,6 @@ import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
 const mockMutation = vi.fn()
-
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi

--- a/apps/cli/tests/commands/show-player.test.js
+++ b/apps/cli/tests/commands/show-player.test.js
@@ -1,4 +1,10 @@
 // @ts-check
+/**
+ * @typedef {import('../../src').Command} Command
+ * @typedef {import('../../src/commands/show-player').Game} Game
+ * @typedef {import('@tabulous/server/src/graphql/types').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import stripAnsi from 'strip-ansi'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,10 +14,6 @@ import { signToken } from '../../src/util/jwt.js'
 
 const mockQuery = vi.fn()
 const mockMutation = vi.fn()
-
-/** @typedef {import('../../src/commands/show-player.js').Game} Game */
-/** @typedef {import('../../src/util/formaters.js').Player} Player */
-/** @typedef {import('../../src/index.js').Command} Command */
 
 vi.mock('../../src/util/graphql-client.js', () => ({
   getGraphQLClient: vi
@@ -29,7 +31,6 @@ describe('Show player command', () => {
     id: faker.string.uuid(),
     username: faker.person.fullName(),
     email: faker.internet.email(),
-    isOwner: false,
     currentGameId: null
   }
   /** @type {Player} */
@@ -37,7 +38,6 @@ describe('Show player command', () => {
     id: faker.string.uuid(),
     username: faker.person.fullName(),
     email: faker.internet.email(),
-    isOwner: false,
     currentGameId: null
   }
 

--- a/apps/server/migrations/001-redis.js
+++ b/apps/server/migrations/001-redis.js
@@ -1,9 +1,15 @@
 // @ts-check
+/**
+ * @typedef {typeof import('@tabulous/server/src/repositories').default} Repositories
+ */
+/**
+ * @template {{id: string}} M
+ * @typedef {import('@tabulous/server/src/repositories/abstract-repository').AbstractRepository<M> } AbstractRepository
+ */
+
 import { access, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-/** @typedef {typeof import('../src/repositories/index.js').default} Repositories */
 
 /**
  * Applies the migration.
@@ -17,7 +23,7 @@ export async function apply(repositories) {
 
 /**
  * @template {{id: string}} M
- * @template {import('../src/repositories/abstract-repository.js').AbstractRepository<M>} R
+ * @template {AbstractRepository<M>} R
  * @param {R} repository
  * @returns {Promise<void>}
  */

--- a/apps/server/migrations/002-guests.js
+++ b/apps/server/migrations/002-guests.js
@@ -1,10 +1,13 @@
 // @ts-check
+/**
+ * @typedef {typeof import('@tabulous/server/src/repositories').default} Repositories
+ */
 
 import { iteratePage } from './utils.js'
 
 /**
  * Applies the migration.
- * @param {typeof import('../src/repositories/index.js').default} repositories - connected repositories.
+ * @param {Repositories} repositories - connected repositories.
  * @returns {Promise<void>}
  */
 export async function apply(repositories) {

--- a/apps/server/migrations/003-fix-players-index.js
+++ b/apps/server/migrations/003-fix-players-index.js
@@ -1,9 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('ioredis').Redis} Redis
+ * @typedef {typeof import('@tabulous/server/src/repositories').default} Repositories
+ */
 
 /**
  * Applies the migration.
- * @param {typeof import('../src/repositories/index.js').default} repositories - connected repositories.
- * @param {import('ioredis').Redis} redis - initialized Redis client.
+ * @param {Repositories} repositories - connected repositories.
+ * @param {Redis} redis - initialized Redis client.
  * @returns {Promise<void>}
  */
 export async function apply({ players }, redis) {

--- a/apps/server/migrations/004-drop-card-games.js
+++ b/apps/server/migrations/004-drop-card-games.js
@@ -1,9 +1,13 @@
 // @ts-check
+/**
+ * @typedef {typeof import('@tabulous/server/src/repositories').default} Repositories
+ */
+
 import { iteratePage } from './utils.js'
 
 /**
  * Applies the migration.
- * @param {typeof import('../src/repositories/index.js').default} repositories - connected repositories.
+ * @param {Repositories} repositories - connected repositories.
  * @returns {Promise<void>}
  */
 export async function apply({ games }) {

--- a/apps/server/migrations/005-drop-redis-search.js
+++ b/apps/server/migrations/005-drop-redis-search.js
@@ -1,10 +1,15 @@
 // @ts-check
+/**
+ * @typedef {import('ioredis').Redis} Redis
+ * @typedef {typeof import('@tabulous/server/src/repositories').default} Repositories
+ */
+
 import { iteratePage } from './utils.js'
 
 /**
  * Applies the migration.
- * @param {typeof import('../src/repositories/index.js').default} repositories - connected repositories.
- * @param {import('ioredis').Redis} redis - initialized Redis client.
+ * @param {Repositories} repositories - connected repositories.
+ * @param {Redis} redis - initialized Redis client.
  * @returns {Promise<void>}
  */
 export async function apply({ players }, redis) {

--- a/apps/server/migrations/utils.js
+++ b/apps/server/migrations/utils.js
@@ -1,9 +1,13 @@
 // @ts-check
+/**
+ * @template {{id: string}} M
+ * @typedef {import('@tabulous/server/src/repositories/abstract-repository').AbstractRepository<M> } AbstractRepository
+ */
 
 /**
  * Recursively fetches all model pages of a given repository, applying a function to each of them.
  * @template {{ id: string }} M
- * @param {import('../src/repositories/abstract-repository.js').AbstractRepository<M>} repository - repository of models.
+ * @param {AbstractRepository<M>} repository - repository of models.
  * @param {(obj: M) => Promise<void>} apply - function individually applied to each model.
  * @param {{ from: number }} [params = { from: 0 }] - fetch parameters, for internal use.
  */

--- a/apps/server/src/graphql/catalog-resolver.js
+++ b/apps/server/src/graphql/catalog-resolver.js
@@ -1,9 +1,11 @@
 // @ts-check
+/**
+ * @typedef {import('./utils').GraphQLAnonymousContext} GraphQLAnonymousContext
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ */
+
 import services from '../services/index.js'
 import { isAdmin } from './utils.js'
-
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLAnonymousContext */
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
 
 export default {
   Query: {
@@ -13,7 +15,7 @@ export default {
      * @param {unknown} obj - graphQL object.
      * @param {unknown} args - query arguments.
      * @param {GraphQLAnonymousContext} context - graphQL context.
-     * @returns {Promise<import('./types.js').CatalogItem[]>} list of catalog items.
+     * @returns {Promise<import('./types').CatalogItem[]>} list of catalog items.
      */
     listCatalog: (obj, args, { player }) => services.listCatalog(player)
   },
@@ -24,7 +26,7 @@ export default {
        * Grants another player access to a given catalog item.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').GrantAccessArgs} args - query arguments.
+       * @param {import('./types').GrantAccessArgs} args - query arguments.
        * @returns {Promise<boolean>} true if access was granted.
        */
       async (obj, { playerId, itemName }) => {
@@ -38,7 +40,7 @@ export default {
        * Requires authentication and elevated privileges.
        * @async
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').RevokeAccessArgs} args - query arguments.
+       * @param {import('./types').RevokeAccessArgs} args - query arguments.
        * @returns {Promise<boolean>} true if access was revoked.
        */
       async (obj, { playerId, itemName }) => {

--- a/apps/server/src/graphql/catalog-resolver.js
+++ b/apps/server/src/graphql/catalog-resolver.js
@@ -1,5 +1,8 @@
 // @ts-check
 /**
+ * @typedef {import('./types').CatalogItem} CatalogItem
+ * @typedef {import('./types').GrantAccessArgs} GrantAccessArgs
+ * @typedef {import('./types').RevokeAccessArgs} RevokeAccessArgs
  * @typedef {import('./utils').GraphQLAnonymousContext} GraphQLAnonymousContext
  * @typedef {import('./utils').GraphQLContext} GraphQLContext
  */
@@ -15,7 +18,7 @@ export default {
      * @param {unknown} obj - graphQL object.
      * @param {unknown} args - query arguments.
      * @param {GraphQLAnonymousContext} context - graphQL context.
-     * @returns {Promise<import('./types').CatalogItem[]>} list of catalog items.
+     * @returns {Promise<CatalogItem[]>} list of catalog items.
      */
     listCatalog: (obj, args, { player }) => services.listCatalog(player)
   },
@@ -26,7 +29,7 @@ export default {
        * Grants another player access to a given catalog item.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').GrantAccessArgs} args - query arguments.
+       * @param {GrantAccessArgs} args - query arguments.
        * @returns {Promise<boolean>} true if access was granted.
        */
       async (obj, { playerId, itemName }) => {
@@ -40,7 +43,7 @@ export default {
        * Requires authentication and elevated privileges.
        * @async
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').RevokeAccessArgs} args - query arguments.
+       * @param {RevokeAccessArgs} args - query arguments.
        * @returns {Promise<boolean>} true if access was revoked.
        */
       async (obj, { playerId, itemName }) => {

--- a/apps/server/src/graphql/catalog-resolver.js
+++ b/apps/server/src/graphql/catalog-resolver.js
@@ -7,51 +7,39 @@ import { isAdmin } from './utils.js'
 
 export default {
   Query: {
-    /** @typedef {ReturnType<typeof services.listCatalog>} ListCatalogResponse */
     /**
      * Returns catalog for current player.
      * Requires valid authentication.
      * @param {unknown} obj - graphQL object.
      * @param {unknown} args - query arguments.
      * @param {GraphQLAnonymousContext} context - graphQL context.
-     * @returns {ListCatalogResponse} list of catalog items.
+     * @returns {Promise<import('./types.js').CatalogItem[]>} list of catalog items.
      */
     listCatalog: (obj, args, { player }) => services.listCatalog(player)
   },
+
   Mutation: {
-    /**
-     * @typedef {object} GrantAccessArgs
-     * @property {string} playerId - player id being granted access.
-     * @property {string} itemName - granted catalog item name.
-     */
-    /** @typedef {Promise<boolean>} GrantAccessResponse */
     grantAccess: isAdmin(
       /**
        * Grants another player access to a given catalog item.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {GrantAccessArgs} args - query arguments.
-       * @returns {GrantAccessResponse} true if access was granted
+       * @param {import('./types.js').GrantAccessArgs} args - query arguments.
+       * @returns {Promise<boolean>} true if access was granted.
        */
       async (obj, { playerId, itemName }) => {
         return (await services.grantAccess(playerId, itemName)) !== null
       }
     ),
 
-    /**
-     * @typedef {object} RevokeAccessArgs
-     * @property {string} playerId - player id being granted access.
-     * @property {string} itemName - granted catalog item name.
-     */
-    /** @typedef {Promise<boolean>} RevokeAccessResponse */
     revokeAccess: isAdmin(
       /**
        * Revokes access to a given catalog item for another player.
        * Requires authentication and elevated privileges.
        * @async
        * @param {unknown} obj - graphQL object.
-       * @param {RevokeAccessArgs} args - query arguments.
-       * @returns {RevokeAccessResponse} true if access was granted
+       * @param {import('./types.js').RevokeAccessArgs} args - query arguments.
+       * @returns {Promise<boolean>} true if access was revoked.
        */
       async (obj, { playerId, itemName }) => {
         return (await services.revokeAccess(playerId, itemName)) !== null

--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -1,9 +1,18 @@
 // @ts-check
 /**
- * @typedef {import('./utils').GraphQLContext} GraphQLContext
- * @typedef {import('./types').GamePlayer} Player
+ * @typedef {import('./types').CreateGameArgs} CreateGameArgs
+ * @typedef {import('./types').DeleteGameArgs} DeleteGameArgs
  * @typedef {import('./types').Game} Game
  * @typedef {import('./types').GameParameters} GameParameters
+ * @typedef {import('./types').GamePlayer} Player
+ * @typedef {import('./types').InviteArgs} InviteArgs
+ * @typedef {import('./types').JoinGameArgs} JoinGameArgs
+ * @typedef {import('./types').KickArgs} KickArgs
+ * @typedef {import('./types').PromoteGameArgs} PromoteGameArgs
+ * @typedef {import('./types').ReceiveGameUpdatesArgs} ReceiveGameUpdatesArgs
+ * @typedef {import('./types').SaveGameArgs} SaveGameArgs
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./utils').PubSubQueue} PubSubQueue
  */
 
 import { filter } from 'rxjs/operators'
@@ -78,7 +87,7 @@ export default {
        * Instanciates a new game for the a current player (who becomes its owner).
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').CreateGameArgs} args - mutation arguments.
+       * @param {CreateGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Game>} created game details, or null.
        */
@@ -91,7 +100,7 @@ export default {
        * May returns other parameters if provided values disn't suffice, or the actual game content.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').JoinGameArgs} args - mutation arguments.
+       * @param {JoinGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game|GameParameters>} joined game in case of success, new required parameters, or null.
        */
@@ -118,7 +127,7 @@ export default {
        * May returns parameters if needed, or the actual game content.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').PromoteGameArgs} args - mutation arguments.
+       * @param {PromoteGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game|GameParameters>} joined game in case of success, new required parameters, or null.
        */
@@ -131,7 +140,7 @@ export default {
        * Saves a current player's existing game details.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').SaveGameArgs} args - mutation arguments.
+       * @param {SaveGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} created game details, or null.
        */
@@ -143,7 +152,7 @@ export default {
        * Deletes a current player's existing game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').DeleteGameArgs} args - mutation arguments.
+       * @param {DeleteGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} deleted game details, or null.
        */
@@ -155,7 +164,7 @@ export default {
        * Invites another player to a current player's game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').InviteArgs} args - mutation arguments.
+       * @param {InviteArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} saved game details, or null.
        */
@@ -168,7 +177,7 @@ export default {
        * Kick a player from a current player's game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').KickArgs} args - mutation arguments.
+       * @param {KickArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} saved game details, or null.
        */
@@ -218,10 +227,10 @@ export default {
          * Sends a given game updates from server.
          * Requires valid authentication, and users must have this game in their list.
          * @param {unknown} obj - graphQL object.
-         * @param {import('./types').ReceiveGameUpdatesArgs} args - subscription argument.
+         * @param {ReceiveGameUpdatesArgs} args - subscription argument.
          * @param {GraphQLContext} context - graphQL context.
          * @yields {Game}
-         * @returns {import('./utils').PubSubQueue}
+         * @returns {PubSubQueue}
          */
         async (obj, { gameId }, { player, pubsub }) => {
           const topic = `receiveGameUpdates-${player.id}-${gameId}`

--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -1,4 +1,11 @@
 // @ts-check
+/**
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./types').GamePlayer} Player
+ * @typedef {import('./types').Game} Game
+ * @typedef {import('./types').GameParameters} GameParameters
+ */
+
 import { filter } from 'rxjs/operators'
 
 import services from '../services/index.js'
@@ -6,11 +13,6 @@ import { makeLogger } from '../utils/index.js'
 import { isAuthenticated } from './utils.js'
 
 const logger = makeLogger('games-resolver')
-
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
-/** @typedef {import('./types.js').GamePlayer} Player */
-/** @typedef {import('./types.js').Game} Game */
-/** @typedef {import('./types.js').GameParameters} GameParameters */
 
 /**
  * Scafolds Mercurius loaders for specific properties of queried objects.
@@ -76,7 +78,7 @@ export default {
        * Instanciates a new game for the a current player (who becomes its owner).
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').CreateGameArgs} args - mutation arguments.
+       * @param {import('./types').CreateGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Game>} created game details, or null.
        */
@@ -89,7 +91,7 @@ export default {
        * May returns other parameters if provided values disn't suffice, or the actual game content.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').JoinGameArgs} args - mutation arguments.
+       * @param {import('./types').JoinGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game|GameParameters>} joined game in case of success, new required parameters, or null.
        */
@@ -116,7 +118,7 @@ export default {
        * May returns parameters if needed, or the actual game content.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').PromoteGameArgs} args - mutation arguments.
+       * @param {import('./types').PromoteGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game|GameParameters>} joined game in case of success, new required parameters, or null.
        */
@@ -129,7 +131,7 @@ export default {
        * Saves a current player's existing game details.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').SaveGameArgs} args - mutation arguments.
+       * @param {import('./types').SaveGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} created game details, or null.
        */
@@ -141,7 +143,7 @@ export default {
        * Deletes a current player's existing game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').DeleteGameArgs} args - mutation arguments.
+       * @param {import('./types').DeleteGameArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} deleted game details, or null.
        */
@@ -153,7 +155,7 @@ export default {
        * Invites another player to a current player's game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').InviteArgs} args - mutation arguments.
+       * @param {import('./types').InviteArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} saved game details, or null.
        */
@@ -166,7 +168,7 @@ export default {
        * Kick a player from a current player's game.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').KickArgs} args - mutation arguments.
+       * @param {import('./types').KickArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<?Game>} saved game details, or null.
        */
@@ -185,7 +187,7 @@ export default {
          * @param {unknown} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
          * @yields {Game[]}
-         * @returns {import('./utils.js').PubSubQueue}
+         * @returns {import('./utils').PubSubQueue}
          */
         async (obj, args, { player, pubsub }) => {
           const topic = `listGames-${player.id}`
@@ -216,10 +218,10 @@ export default {
          * Sends a given game updates from server.
          * Requires valid authentication, and users must have this game in their list.
          * @param {unknown} obj - graphQL object.
-         * @param {import('./types.js').ReceiveGameUpdatesArgs} args - subscription argument.
+         * @param {import('./types').ReceiveGameUpdatesArgs} args - subscription argument.
          * @param {GraphQLContext} context - graphQL context.
          * @yields {Game}
-         * @returns {import('./utils.js').PubSubQueue}
+         * @returns {import('./utils').PubSubQueue}
          */
         async (obj, { gameId }, { player, pubsub }) => {
           const topic = `receiveGameUpdates-${player.id}-${gameId}`
@@ -258,7 +260,7 @@ export default {
   GameParameters: {
     /**
      * Serializer for schema.
-     * @param {import('../services/games.js').GameParameters} obj - serialized game parameter schema
+     * @param {import('../services/games').GameParameters} obj - serialized game parameter schema
      * @returns {string}
      */
     schemaString: obj => JSON.stringify(obj.schema)

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -1,4 +1,9 @@
-# import Player from "players.graphql"
+type Player {
+  id: ID!
+  username: String!
+  isGuest: Boolean
+  isOwner: Boolean
+}
 
 type Game {
   """

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -1,6 +1,8 @@
-type Player {
+type GamePlayer {
   id: ID!
   username: String!
+  currentGameId: ID
+  avatar: String
   isGuest: Boolean
   isOwner: Boolean
 }
@@ -11,7 +13,7 @@ type Game {
   """
   id: ID!
   created: Float!
-  players: [Player]!
+  players: [GamePlayer]!
   messages: [Message]
   """
   game properties
@@ -441,7 +443,7 @@ type GameParameters {
   id: ID!
   kind: String
   locales: ItemLocales
-  players: [Player]!
+  players: [GamePlayer]!
   preferences: [PlayerPreference]
   rulesBookPageCount: Int
   availableSeats: Int

--- a/apps/server/src/graphql/logger-resolver.js
+++ b/apps/server/src/graphql/logger-resolver.js
@@ -1,9 +1,11 @@
 // @ts-check
+/**
+ * @typedef {import('./utils').GraphQLAnonymousContext} GraphQLAnonymousContext
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ */
+
 import { configureLoggers, currentLevels } from '../utils/logger.js'
 import { isAdmin } from './utils.js'
-
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLAnonymousContext */
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
 
 const comparator = new Intl.Collator('en', { numeric: true, usage: 'sort' })
 
@@ -22,7 +24,7 @@ export default {
   Mutation: {
     /**
      * @typedef {object} ConfigureLoggerLevelsArgs
-     * @property {import('./types.js').LoggerLevel[]} levels - new logger levels.
+     * @property {import('./types').LoggerLevel[]} levels - new logger levels.
      */
 
     configureLoggerLevels: isAdmin(
@@ -31,7 +33,7 @@ export default {
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
        * @param {ConfigureLoggerLevelsArgs} args - mutation arguments.
-       * @returns {import('./types.js').LoggerLevel[]} the ordered list of logger names and their respective levels.
+       * @returns {import('./types').LoggerLevel[]} the ordered list of logger names and their respective levels.
        */
       (obj, { levels }) => {
         configureLoggers(

--- a/apps/server/src/graphql/logger-resolver.js
+++ b/apps/server/src/graphql/logger-resolver.js
@@ -1,5 +1,6 @@
 // @ts-check
 /**
+ * @typedef {import('./types').LoggerLevel} LoggerLevel
  * @typedef {import('./utils').GraphQLAnonymousContext} GraphQLAnonymousContext
  * @typedef {import('./utils').GraphQLContext} GraphQLContext
  */
@@ -24,7 +25,7 @@ export default {
   Mutation: {
     /**
      * @typedef {object} ConfigureLoggerLevelsArgs
-     * @property {import('./types').LoggerLevel[]} levels - new logger levels.
+     * @property {LoggerLevel[]} levels - new logger levels.
      */
 
     configureLoggerLevels: isAdmin(
@@ -33,7 +34,7 @@ export default {
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
        * @param {ConfigureLoggerLevelsArgs} args - mutation arguments.
-       * @returns {import('./types').LoggerLevel[]} the ordered list of logger names and their respective levels.
+       * @returns {LoggerLevel[]} the ordered list of logger names and their respective levels.
        */
       (obj, { levels }) => {
         configureLoggers(

--- a/apps/server/src/graphql/logger-resolver.js
+++ b/apps/server/src/graphql/logger-resolver.js
@@ -7,12 +7,6 @@ import { isAdmin } from './utils.js'
 
 const comparator = new Intl.Collator('en', { numeric: true, usage: 'sort' })
 
-/**
- * @typedef {object} LoggerLevel
- * @property {string} name - logger name.
- * @property {import('../utils/logger.js').Level} level - current log level.
- */
-
 export default {
   Query: {
     getLoggerLevels: isAdmin(
@@ -28,7 +22,7 @@ export default {
   Mutation: {
     /**
      * @typedef {object} ConfigureLoggerLevelsArgs
-     * @property {LoggerLevel[]} levels - new logger levels.
+     * @property {import('./types.js').LoggerLevel[]} levels - new logger levels.
      */
 
     configureLoggerLevels: isAdmin(
@@ -37,7 +31,7 @@ export default {
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
        * @param {ConfigureLoggerLevelsArgs} args - mutation arguments.
-       * @returns {LoggerLevel[]} the ordered list of logger names and their respective levels.
+       * @returns {import('./types.js').LoggerLevel[]} the ordered list of logger names and their respective levels.
        */
       (obj, { levels }) => {
         configureLoggers(

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./types').Player} Player
+ */
+
 import { filter } from 'rxjs'
 
 import { makeToken } from '../plugins/utils.js'
@@ -8,9 +13,6 @@ import { hash, makeLogger } from '../utils/index.js'
 import { isAdmin, isAuthenticated } from './utils.js'
 
 const logger = makeLogger('players-resolver')
-
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
-/** @typedef {import('./types.js').Player} Player */
 
 /**
  * Scafolds Mercurius loaders for specific properties of queried objects.
@@ -63,7 +65,7 @@ export default {
        * @param {unknown} obj - graphQL object.
        * @param {unknown} args - query arguments:
        * @param {GraphQLContext} context - graphQL context.
-       * @returns {import('./types.js').PlayerWithTurnCredentials} current player with turn credentials.
+       * @returns {import('./types').PlayerWithTurnCredentials} current player with turn credentials.
        */
       (obj, args, { player, conf, token }) => {
         logger.trace(
@@ -82,7 +84,7 @@ export default {
        * Returns players (except the current one) which username contains searched text.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').SearchPlayersArgs} args - query arguments.
+       * @param {import('./types').SearchPlayersArgs} args - query arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Player[]>} list (potentially empty) of matching players.
        */
@@ -95,8 +97,8 @@ export default {
        * Returns a page or players.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').ListPlayersArgs} args - query arguments, including:
-       * @returns {Promise<import('../repositories/abstract-repository.js').Page<Player>>} extract of the player list.
+       * @param {import('./types').ListPlayersArgs} args - query arguments, including:
+       * @returns {Promise<import('../repositories/abstract-repository').Page<Player>>} extract of the player list.
        */
       (obj, args) => repositories.players.list(args)
     ),
@@ -108,7 +110,7 @@ export default {
        * @param {unknown} obj - graphQL object.
        * @param {unknown} args - query arguments.
        * @param {GraphQLContext} context - graphQL context.
-       * @returns {Promise<import('./types.js').Friendship[]>} list (potentially empty) of friend players.
+       * @returns {Promise<import('./types').Friendship[]>} list (potentially empty) of friend players.
        */
       (obj, args, { player }) =>
         // @ts-expect-error: player is enriched by loaders
@@ -123,7 +125,7 @@ export default {
        * The clear password provided is hashed before being stored.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').AddPlayerArgs} args - mutation arguments.
+       * @param {import('./types').AddPlayerArgs} args - mutation arguments.
        * @returns {Promise<Player>} the created player.
        */
       async (obj, { id, username, password }) =>
@@ -134,9 +136,9 @@ export default {
      * Authenticates an user from their user id.
      * Returns a token to allow browser issueing authenticated requests.
      * @param {unknown} obj - graphQL object.
-     * @param {import('./types.js').LogInArgs} args - mutation arguments.
+     * @param {import('./types').LogInArgs} args - mutation arguments.
      * @param {GraphQLContext} context - graphQL context.
-     * @returns {Promise<import('./types.js').PlayerWithTurnCredentials>} authentified player with turn credentials.
+     * @returns {Promise<import('./types').PlayerWithTurnCredentials>} authentified player with turn credentials.
      */
     logIn: async (obj, { id, password }, { conf }) => {
       logger.trace('authenticates manual player')
@@ -169,7 +171,7 @@ export default {
        * Updates current player's details.
        * Requires authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').UpdateCurrentPlayerArgs} args - mutation arguments.
+       * @param {import('./types').UpdateCurrentPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Player>} the updated player.
        */
@@ -209,7 +211,7 @@ export default {
        * Deletes an existing player account.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').TargetedPlayerArgs} args - mutation arguments.
+       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
        * @returns {Promise<?Player>} deleted player account, or null.
        */
       (obj, { id }) => repositories.players.deleteById(id)
@@ -220,7 +222,7 @@ export default {
        * Sends a friend request from one player to another one.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').TargetedPlayerArgs} args - mutation arguments.
+       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -232,7 +234,7 @@ export default {
        * Accepts a friend request from another player.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').TargetedPlayerArgs} args - mutation arguments.
+       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -244,7 +246,7 @@ export default {
        * Declines a friend request or ends existing friendship with another player.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types.js').TargetedPlayerArgs} args - mutation arguments.
+       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -261,8 +263,8 @@ export default {
          * @param {unknown} obj - graphQL object.
          * @param {object} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
-         * @yields {import('./types.js').FriendshipUpdate}
-         * @returns {import('./utils.js').PubSubQueue}
+         * @yields {import('./types').FriendshipUpdate}
+         * @returns {import('./utils').PubSubQueue}
          */
         async (obj, args, { player, pubsub }) => {
           const topic = `friendship-${player.id}`

--- a/apps/server/src/graphql/players-resolver.js
+++ b/apps/server/src/graphql/players-resolver.js
@@ -1,7 +1,17 @@
 // @ts-check
 /**
- * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./types').AddPlayerArgs} AddPlayerArgs
+ * @typedef {import('./types').Friendship} Friendship
+ * @typedef {import('./types').FriendshipUpdate} FriendshipUpdate
+ * @typedef {import('./types').ListPlayersArgs} ListPlayersArgs
+ * @typedef {import('./types').LogInArgs} LogInArgs
  * @typedef {import('./types').Player} Player
+ * @typedef {import('./types').PlayerWithTurnCredentials} PlayerWithTurnCredentials
+ * @typedef {import('./types').SearchPlayersArgs} SearchPlayersArgs
+ * @typedef {import('./types').TargetedPlayerArgs} TargetedPlayerArgs
+ * @typedef {import('./types').UpdateCurrentPlayerArgs} UpdateCurrentPlayerArgs
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./utils').PubSubQueue} PubSubQueue
  */
 
 import { filter } from 'rxjs'
@@ -65,7 +75,7 @@ export default {
        * @param {unknown} obj - graphQL object.
        * @param {unknown} args - query arguments:
        * @param {GraphQLContext} context - graphQL context.
-       * @returns {import('./types').PlayerWithTurnCredentials} current player with turn credentials.
+       * @returns {PlayerWithTurnCredentials} current player with turn credentials.
        */
       (obj, args, { player, conf, token }) => {
         logger.trace(
@@ -84,7 +94,7 @@ export default {
        * Returns players (except the current one) which username contains searched text.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').SearchPlayersArgs} args - query arguments.
+       * @param {SearchPlayersArgs} args - query arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Player[]>} list (potentially empty) of matching players.
        */
@@ -97,7 +107,7 @@ export default {
        * Returns a page or players.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').ListPlayersArgs} args - query arguments, including:
+       * @param {ListPlayersArgs} args - query arguments, including:
        * @returns {Promise<import('../repositories/abstract-repository').Page<Player>>} extract of the player list.
        */
       (obj, args) => repositories.players.list(args)
@@ -110,7 +120,7 @@ export default {
        * @param {unknown} obj - graphQL object.
        * @param {unknown} args - query arguments.
        * @param {GraphQLContext} context - graphQL context.
-       * @returns {Promise<import('./types').Friendship[]>} list (potentially empty) of friend players.
+       * @returns {Promise<Friendship[]>} list (potentially empty) of friend players.
        */
       (obj, args, { player }) =>
         // @ts-expect-error: player is enriched by loaders
@@ -125,7 +135,7 @@ export default {
        * The clear password provided is hashed before being stored.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').AddPlayerArgs} args - mutation arguments.
+       * @param {AddPlayerArgs} args - mutation arguments.
        * @returns {Promise<Player>} the created player.
        */
       async (obj, { id, username, password }) =>
@@ -136,9 +146,9 @@ export default {
      * Authenticates an user from their user id.
      * Returns a token to allow browser issueing authenticated requests.
      * @param {unknown} obj - graphQL object.
-     * @param {import('./types').LogInArgs} args - mutation arguments.
+     * @param {LogInArgs} args - mutation arguments.
      * @param {GraphQLContext} context - graphQL context.
-     * @returns {Promise<import('./types').PlayerWithTurnCredentials>} authentified player with turn credentials.
+     * @returns {Promise<PlayerWithTurnCredentials>} authentified player with turn credentials.
      */
     logIn: async (obj, { id, password }, { conf }) => {
       logger.trace('authenticates manual player')
@@ -171,7 +181,7 @@ export default {
        * Updates current player's details.
        * Requires authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').UpdateCurrentPlayerArgs} args - mutation arguments.
+       * @param {UpdateCurrentPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<Player>} the updated player.
        */
@@ -211,7 +221,7 @@ export default {
        * Deletes an existing player account.
        * Requires authentication and elevated privileges.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
+       * @param {TargetedPlayerArgs} args - mutation arguments.
        * @returns {Promise<?Player>} deleted player account, or null.
        */
       (obj, { id }) => repositories.players.deleteById(id)
@@ -222,7 +232,7 @@ export default {
        * Sends a friend request from one player to another one.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
+       * @param {TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -234,7 +244,7 @@ export default {
        * Accepts a friend request from another player.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
+       * @param {TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -246,7 +256,7 @@ export default {
        * Declines a friend request or ends existing friendship with another player.
        * Requires valid authentication.
        * @param {unknown} obj - graphQL object.
-       * @param {import('./types').TargetedPlayerArgs} args - mutation arguments.
+       * @param {TargetedPlayerArgs} args - mutation arguments.
        * @param {GraphQLContext} context - graphQL context.
        * @returns {Promise<boolean>} true if the operation succeeds.
        */
@@ -263,8 +273,8 @@ export default {
          * @param {unknown} obj - graphQL object.
          * @param {object} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
-         * @yields {import('./types').FriendshipUpdate}
-         * @returns {import('./utils').PubSubQueue}
+         * @yields {FriendshipUpdate}
+         * @returns {PubSubQueue}
          */
         async (obj, args, { player, pubsub }) => {
           const topic = `friendship-${player.id}`

--- a/apps/server/src/graphql/players.graphql
+++ b/apps/server/src/graphql/players.graphql
@@ -2,8 +2,6 @@ type Player {
   id: ID!
   username: String!
   currentGameId: ID
-  isGuest: Boolean
-  isOwner: Boolean
   avatar: String
   provider: String
   email: String

--- a/apps/server/src/graphql/signals-resolver.js
+++ b/apps/server/src/graphql/signals-resolver.js
@@ -8,12 +8,6 @@ const logger = makeLogger('signals-resolver')
 /** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
 
 /**
- * @typedef {object} Signal
- * @property {string} from - player id sending this signal
- * @property {string} data - the signal payload.
- */
-
-/**
  * The implemented protocol is:
  *   1. player A is already in game, with an open awaitSignal() subscription
  *   2. player B join game
@@ -30,19 +24,12 @@ const logger = makeLogger('signals-resolver')
 export default {
   Mutation: {
     /**
-     * @typedef {object} SendSignalArgs
-     * @property {object} signal - signal addressed to another player.
-     * @property {string} signal.to - player id to which the signal is sent.
-     * @property {string} signal.data - the signal payload.
-     */
-
-    /**
      * Emits signal addressed from current player onto the subscription of another player.
      * Requires valid authentication.
      * @param {unknown} obj - graphQL object.
-     * @param {SendSignalArgs} args - mutation arguments, including:
+     * @param {import('./types.js').SendSignalArgs} args - mutation arguments, including:
      * @param {GraphQLContext} context - graphQL context.
-     * @returns {Signal} signal addressed.
+     * @returns {import('./types.js').Signal} signal addressed.
      */
     sendSignal: isAuthenticated((obj, { signal }, { player, pubsub }) => {
       signal.from = player.id
@@ -57,19 +44,15 @@ export default {
   },
 
   Subscription: {
-    /**
-     * @typedef {object} AwaitSignalArgs
-     * @property {string} gameId - game's id.
-     */
     awaitSignal: {
       subscribe: isAuthenticated(
         /**
          * Emits signal addressed to the current player
          * Requires valid authentication.
          * @param {unknown} obj - graphQL object.
-         * @param {AwaitSignalArgs} args - subscription arguments.
+         * @param {import('./types.js').AwaitSignalArgs} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
-         * @yields {Signal}
+         * @yields {import('./types.js').Signal}
          * @returns {import('./utils.js').PubSubQueue}
          */
         async (obj, { gameId }, { player, pubsub }) => {

--- a/apps/server/src/graphql/signals-resolver.js
+++ b/apps/server/src/graphql/signals-resolver.js
@@ -1,11 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ */
+
 import services from '../services/index.js'
 import { makeLogger } from '../utils/index.js'
 import { isAuthenticated } from './utils.js'
 
 const logger = makeLogger('signals-resolver')
-
-/** @typedef {import('./utils.js').GraphQLContext} GraphQLContext */
 
 /**
  * The implemented protocol is:
@@ -27,9 +29,9 @@ export default {
      * Emits signal addressed from current player onto the subscription of another player.
      * Requires valid authentication.
      * @param {unknown} obj - graphQL object.
-     * @param {import('./types.js').SendSignalArgs} args - mutation arguments, including:
+     * @param {import('./types').SendSignalArgs} args - mutation arguments, including:
      * @param {GraphQLContext} context - graphQL context.
-     * @returns {import('./types.js').Signal} signal addressed.
+     * @returns {import('./types').Signal} signal addressed.
      */
     sendSignal: isAuthenticated((obj, { signal }, { player, pubsub }) => {
       signal.from = player.id
@@ -50,10 +52,10 @@ export default {
          * Emits signal addressed to the current player
          * Requires valid authentication.
          * @param {unknown} obj - graphQL object.
-         * @param {import('./types.js').AwaitSignalArgs} args - subscription arguments.
+         * @param {import('./types').AwaitSignalArgs} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
-         * @yields {import('./types.js').Signal}
-         * @returns {import('./utils.js').PubSubQueue}
+         * @yields {import('./types').Signal}
+         * @returns {import('./utils').PubSubQueue}
          */
         async (obj, { gameId }, { player, pubsub }) => {
           const queue = await pubsub.subscribe(`sendSignal-${player.id}`)

--- a/apps/server/src/graphql/signals-resolver.js
+++ b/apps/server/src/graphql/signals-resolver.js
@@ -1,6 +1,10 @@
 // @ts-check
 /**
+ * @typedef {import('./types').AwaitSignalArgs} AwaitSignalArgs
+ * @typedef {import('./types').SendSignalArgs} SendSignalArgs
+ * @typedef {import('./types').Signal} Signal
  * @typedef {import('./utils').GraphQLContext} GraphQLContext
+ * @typedef {import('./utils').PubSubQueue} PubSubQueue
  */
 
 import services from '../services/index.js'
@@ -29,9 +33,9 @@ export default {
      * Emits signal addressed from current player onto the subscription of another player.
      * Requires valid authentication.
      * @param {unknown} obj - graphQL object.
-     * @param {import('./types').SendSignalArgs} args - mutation arguments, including:
+     * @param {SendSignalArgs} args - mutation arguments, including:
      * @param {GraphQLContext} context - graphQL context.
-     * @returns {import('./types').Signal} signal addressed.
+     * @returns {Signal} signal addressed.
      */
     sendSignal: isAuthenticated((obj, { signal }, { player, pubsub }) => {
       signal.from = player.id
@@ -52,10 +56,10 @@ export default {
          * Emits signal addressed to the current player
          * Requires valid authentication.
          * @param {unknown} obj - graphQL object.
-         * @param {import('./types').AwaitSignalArgs} args - subscription arguments.
+         * @param {AwaitSignalArgs} args - subscription arguments.
          * @param {GraphQLContext} context - graphQL context.
-         * @yields {import('./types').Signal}
-         * @returns {import('./utils').PubSubQueue}
+         * @yields {Signal}
+         * @returns {PubSubQueue}
          */
         async (obj, { gameId }, { player, pubsub }) => {
           const queue = await pubsub.subscribe(`sendSignal-${player.id}`)

--- a/apps/server/src/graphql/types.js
+++ b/apps/server/src/graphql/types.js
@@ -1,0 +1,118 @@
+// @ts-check
+/** @typedef {import('../services/games.js').GameData} _Game */
+/** @typedef {import('../services/games.js').GameParameters} _GameParameters */
+
+/**
+ * Generated from catalog.graphql
+ * @typedef {Pick<import('../services/catalog.js').GameDescriptor, 'name'|'locales'> & Partial<Pick<import('../services/catalog.js').GameDescriptor, 'copyright'|'minSeats'|'maxSeats'|'maxAge'|'minTime'>>} CatalogItem
+ *
+ * @typedef {object} GrantAccessArgs
+ * @property {string} playerId - player id being granted access.
+ * @property {string} itemName - granted catalog item name.
+ *
+ * @typedef {object} RevokeAccessArgs
+ * @property {string} playerId - player id being granted access.
+ * @property {string} itemName - granted catalog item name.
+ */
+
+/**
+ * Generated from games.graphql
+ * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & { isGuest?: boolean, isOwner?: boolean }} GamePlayer
+ *
+ * @typedef {Pick<_Game, 'id'|'created'|'kind'|'rulesBookPageCount'|'zoomSpec'|'tableSpec'|'colors'|'actions'> & Partial<Pick<_Game, 'messages'|'locales'|'meshes'|'cameras'|'hands'|'preferences'|'availableSeats'>> & { players?: GamePlayer[]}} Game
+ *
+ * @typedef {Pick<_GameParameters, 'error'|'id'|'kind'> & Partial<Pick<_GameParameters, 'locales'|'preferences'|'rulesBookPageCount'|'availableSeats'|'colors'>> & { schemaString?: string, players?: GamePlayer[]}} GameParameters
+ *
+ * @typedef {object} CreateGameArgs
+ * @property {string} kind - created game kind.
+ *
+ * @typedef {object} JoinGameArgs
+ * @property {string} gameId - joined game's id.
+ * @property {string} parameters -player's provided parameters in a stringified object.
+ **
+ * @typedef {object} PromoteGameArgs
+ * @property {string} gameId - promoted game's id.
+ * @property {string} kind - promoted game kind.
+ *
+ * @typedef {object} SaveGameArgs
+ * @property {Pick<Game, 'id'|'meshes'|'messages'|'cameras'|'hands'>} game - saved game data
+ *
+ * @typedef {object} DeleteGameArgs
+ * @property {string} gameId - deleted game's id.
+ *
+ * @typedef {object} InviteArgs
+ * @property {string} gameId - game's id.
+ * @property {string[]} playerIds - invited player ids.
+ *
+ * @typedef {object} KickArgs
+ * @property {string} gameId - game's id.
+ * @property {string} playerId - kicked player id.
+ *
+ * @typedef {object} ReceiveGameUpdatesArgs
+ * @property {string} gameId - game's id.
+ */
+
+/**
+ * From logger.graphql LoggerLevel and InputLoggerLevel
+ * @typedef {object} LoggerLevel
+ * @property {string} name - logger name.
+ * @property {import('../utils/logger.js').Level} level - current log level.
+ */
+
+/**
+ * Generated from players.graphql
+ * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & Partial<Pick<import('../services/players.js').Player, 'currentGameId'|'avatar'|'provider'|'email'|'termsAccepted'|'isAdmin'|'usernameSearchable'>>} Player
+ *
+ * @typedef {{ player: Player } & Pick<import('../services/players.js').Friendship, 'isRequest'|'isProposal'> } Friendship
+ *
+ * @typedef {{ from: Player } & Pick<import('../services/players.js').FriendshipUpdate, 'requested'|'proposed'|'accepted'|'declined'> } FriendshipUpdate
+ *
+ * @typedef {import('../services/turn-credentials.js').TurnCredentials} TurnCredentials
+ *
+ * @typedef {object} PlayerWithTurnCredentials
+ * @property {string} token - authentication token.
+ * @property {Player} player - authenticated player.
+ * @property {TurnCredentials} turnCredentials - credentials for the TURN server.
+ *
+ * @typedef {object} SearchPlayersArgs
+ * @property {string} search - searched text.
+ * @property {boolean} [includeCurrent] - whether to include current player in results or not.
+ *
+ * @typedef {object} ListPlayersArgs
+ * @property {number} [from] - index of the first result returned.
+ * @property {number} [size] - number of return results.
+ *
+ * @typedef {object} AddPlayerArgs
+ * @property {string} id - created player id.
+ * @property {string} username - created player username.
+ * @property {string} password - created player password (clear value).
+ *
+ * @typedef {object} LogInArgs
+ * @property {string} id - user account id.
+ * @property {string} password - clear password.
+ *
+ * @typedef {object} UpdateCurrentPlayerArgs
+ * @property {string} [username] - new username value, if any.
+ * @property {string} [avatar] - new avatar value, if any.
+ * @property {boolean} [usernameSearchable] - new value for username searchability, if any.
+ *
+ * @typedef {object} TargetedPlayerArgs - for deletePlayer, sendFriendRequest, requestFriendship, acceptFriendship, endFriendship mutations
+ * @property {string} id - id of the targeted player.
+ */
+
+/**
+ * Generated from signal.graphql
+ *
+ * @typedef {object} Signal
+ * @property {string} from - player id sending this signal.
+ * @property {string} data - the signal payload.
+ *
+ * @typedef {object} SendSignalArgs
+ * @property {string} to - player id to which the signal is sent.
+ * @property {string} data - the signal payload.
+ *
+ * @typedef {object} AwaitSignalArgs
+ * @property {string} gameId - game's id.
+ */
+
+export default void 0

--- a/apps/server/src/graphql/types.js
+++ b/apps/server/src/graphql/types.js
@@ -6,6 +6,15 @@
  * Generated from catalog.graphql
  * @typedef {Pick<import('../services/catalog.js').GameDescriptor, 'name'|'locales'> & Partial<Pick<import('../services/catalog.js').GameDescriptor, 'copyright'|'minSeats'|'maxSeats'|'maxAge'|'minTime'>>} CatalogItem
  *
+ * @typedef {import('../services/catalog.js').Copyright} Copyright
+ * @typedef {import('../services/catalog.js').TableSpec} TableSpec
+ * @typedef {import('../services/catalog.js').ZoomSpec} ZoomSpec
+ * @typedef {import('../services/catalog.js').ColorSpec} ColorSpec
+ * @typedef {import('../services/catalog.js').ActionSpec} ActionSpec
+ * @typedef {import('../services/catalog.js').ActionName} ActionName
+ * @typedef {import('../services/catalog.js').ItemLocale} ItemLocale
+ * @typedef {import('../services/catalog.js').ItemLocales} ItemLocales
+ *
  * @typedef {object} GrantAccessArgs
  * @property {string} playerId - player id being granted access.
  * @property {string} itemName - granted catalog item name.
@@ -20,6 +29,28 @@
  * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & { isGuest?: boolean, isOwner?: boolean }} GamePlayer
  *
  * @typedef {Pick<_Game, 'id'|'created'|'kind'|'rulesBookPageCount'|'zoomSpec'|'tableSpec'|'colors'|'actions'> & Partial<Pick<_Game, 'messages'|'locales'|'meshes'|'cameras'|'hands'|'preferences'|'availableSeats'>> & { players?: GamePlayer[]}} Game
+ *
+ * @typedef {import('../services/games.js').Shape} Shape
+ * @typedef {import('../services/games.js').Mesh} Mesh
+ * @typedef {import('../services/games.js').InitialTransform} InitialTransform
+ * @typedef {import('../services/games.js').DetailableState} DetailableState
+ * @typedef {import('../services/games.js').FlippableState} FlippableState
+ * @typedef {import('../services/games.js').RotableState} RotableState
+ * @typedef {import('../services/games.js').MovableState} MovableState
+ * @typedef {import('../services/games.js').StackableState} StackableState
+ * @typedef {import('../services/games.js').AnchorableState} AnchorableState
+ * @typedef {import('../services/games.js').DrawableState} DrawableState
+ * @typedef {import('../services/games.js').LockableState} LockableState
+ * @typedef {import('../services/games.js').QuantifiableState} QuantifiableState
+ * @typedef {import('../services/games.js').RandomizableState} RandomizableState
+ * @typedef {import('../services/games.js').Anchor} Anchor
+ * @typedef {import('../services/games.js').Point} Point
+ * @typedef {import('../services/games.js').Dimension} Dimension
+ * @typedef {import('../services/games.js').Targetable} Targetable
+ * @typedef {import('../services/games.js').PlayerPreference} PlayerPreference
+ * @typedef {import('../services/games.js').Message} Message
+ * @typedef {import('../services/games.js').CameraPosition} CameraPosition
+ * @typedef {import('../services/games.js').Hand} Hand
  *
  * @typedef {Pick<_GameParameters, 'error'|'id'|'kind'> & Partial<Pick<_GameParameters, 'locales'|'preferences'|'rulesBookPageCount'|'availableSeats'|'colors'>> & { schemaString?: string, players?: GamePlayer[]}} GameParameters
  *

--- a/apps/server/src/graphql/types.js
+++ b/apps/server/src/graphql/types.js
@@ -1,19 +1,20 @@
 // @ts-check
-/** @typedef {import('../services/games.js').GameData} _Game */
-/** @typedef {import('../services/games.js').GameParameters} _GameParameters */
+/** @typedef {import('../services/games').GameData} _Game */
+/** @typedef {import('../services/games').GameParameters} _GameParameters */
 
 /**
  * Generated from catalog.graphql
- * @typedef {Pick<import('../services/catalog.js').GameDescriptor, 'name'|'locales'> & Partial<Pick<import('../services/catalog.js').GameDescriptor, 'copyright'|'minSeats'|'maxSeats'|'maxAge'|'minTime'>>} CatalogItem
+ * @typedef {Pick<import('../services/catalog.js').GameDescriptor, 'name'|'locales'> & Partial<Pick<import('../services/catalog').GameDescriptor, 'copyright'|'minSeats'|'maxSeats'|'minAge'|'maxAge'|'minTime'>>} CatalogItem
  *
- * @typedef {import('../services/catalog.js').Copyright} Copyright
- * @typedef {import('../services/catalog.js').TableSpec} TableSpec
- * @typedef {import('../services/catalog.js').ZoomSpec} ZoomSpec
- * @typedef {import('../services/catalog.js').ColorSpec} ColorSpec
- * @typedef {import('../services/catalog.js').ActionSpec} ActionSpec
- * @typedef {import('../services/catalog.js').ActionName} ActionName
- * @typedef {import('../services/catalog.js').ItemLocale} ItemLocale
- * @typedef {import('../services/catalog.js').ItemLocales} ItemLocales
+ * @typedef {import('../services/catalog').Copyright} Copyright
+ * @typedef {import('../services/catalog').TableSpec} TableSpec
+ * @typedef {import('../services/catalog').ZoomSpec} ZoomSpec
+ * @typedef {import('../services/catalog').ColorSpec} ColorSpec
+ * @typedef {import('../services/catalog').ActionSpec} ActionSpec
+ * @typedef {keyof ActionSpec} ButtonName
+ * @typedef {import('../services/catalog').ActionName} ActionName
+ * @typedef {import('../services/catalog').ItemLocale} ItemLocale
+ * @typedef {import('../services/catalog').ItemLocales} ItemLocales
  *
  * @typedef {object} GrantAccessArgs
  * @property {string} playerId - player id being granted access.
@@ -26,41 +27,41 @@
 
 /**
  * Generated from games.graphql
- * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & { isGuest?: boolean, isOwner?: boolean }} GamePlayer
+ * @typedef {import('../services/players').Player & { isGuest?: boolean, isOwner?: boolean }} GamePlayer
  *
  * @typedef {Pick<_Game, 'id'|'created'|'kind'|'rulesBookPageCount'|'zoomSpec'|'tableSpec'|'colors'|'actions'> & Partial<Pick<_Game, 'messages'|'locales'|'meshes'|'cameras'|'hands'|'preferences'|'availableSeats'>> & { players?: GamePlayer[]}} Game
  *
- * @typedef {import('../services/games.js').Shape} Shape
- * @typedef {import('../services/games.js').Mesh} Mesh
- * @typedef {import('../services/games.js').InitialTransform} InitialTransform
- * @typedef {import('../services/games.js').DetailableState} DetailableState
- * @typedef {import('../services/games.js').FlippableState} FlippableState
- * @typedef {import('../services/games.js').RotableState} RotableState
- * @typedef {import('../services/games.js').MovableState} MovableState
- * @typedef {import('../services/games.js').StackableState} StackableState
- * @typedef {import('../services/games.js').AnchorableState} AnchorableState
- * @typedef {import('../services/games.js').DrawableState} DrawableState
- * @typedef {import('../services/games.js').LockableState} LockableState
- * @typedef {import('../services/games.js').QuantifiableState} QuantifiableState
- * @typedef {import('../services/games.js').RandomizableState} RandomizableState
- * @typedef {import('../services/games.js').Anchor} Anchor
- * @typedef {import('../services/games.js').Point} Point
- * @typedef {import('../services/games.js').Dimension} Dimension
- * @typedef {import('../services/games.js').Targetable} Targetable
- * @typedef {import('../services/games.js').PlayerPreference} PlayerPreference
- * @typedef {import('../services/games.js').Message} Message
- * @typedef {import('../services/games.js').CameraPosition} CameraPosition
- * @typedef {import('../services/games.js').Hand} Hand
+ * @typedef {import('../services/games').Shape} Shape
+ * @typedef {import('../services/games').Mesh} Mesh
+ * @typedef {import('../services/games').InitialTransform} InitialTransform
+ * @typedef {import('../services/games').DetailableState} DetailableState
+ * @typedef {import('../services/games').FlippableState} FlippableState
+ * @typedef {import('../services/games').RotableState} RotableState
+ * @typedef {import('../services/games').MovableState} MovableState
+ * @typedef {import('../services/games').StackableState} StackableState
+ * @typedef {import('../services/games').AnchorableState} AnchorableState
+ * @typedef {import('../services/games').DrawableState} DrawableState
+ * @typedef {import('../services/games').LockableState} LockableState
+ * @typedef {import('../services/games').QuantifiableState} QuantifiableState
+ * @typedef {import('../services/games').RandomizableState} RandomizableState
+ * @typedef {import('../services/games').Anchor} Anchor
+ * @typedef {import('../services/games').Point} Point
+ * @typedef {import('../services/games').Dimension} Dimension
+ * @typedef {import('../services/games').Targetable} Targetable
+ * @typedef {import('../services/games').PlayerPreference} PlayerPreference
+ * @typedef {import('../services/games').Message} Message
+ * @typedef {import('../services/games').CameraPosition} CameraPosition
+ * @typedef {import('../services/games').Hand} Hand
  *
  * @typedef {Pick<_GameParameters, 'error'|'id'|'kind'> & Partial<Pick<_GameParameters, 'locales'|'preferences'|'rulesBookPageCount'|'availableSeats'|'colors'>> & { schemaString?: string, players?: GamePlayer[]}} GameParameters
  *
  * @typedef {object} CreateGameArgs
- * @property {string} kind - created game kind.
+ * @property {string} [kind] - created game kind (omit to create a lobby).
  *
  * @typedef {object} JoinGameArgs
  * @property {string} gameId - joined game's id.
- * @property {string} parameters -player's provided parameters in a stringified object.
- **
+ * @property {string} [parameters] -player's provided parameters in a stringified object.
+ *
  * @typedef {object} PromoteGameArgs
  * @property {string} gameId - promoted game's id.
  * @property {string} kind - promoted game kind.
@@ -87,18 +88,18 @@
  * From logger.graphql LoggerLevel and InputLoggerLevel
  * @typedef {object} LoggerLevel
  * @property {string} name - logger name.
- * @property {import('../utils/logger.js').Level} level - current log level.
+ * @property {import('../utils/logger').Level} level - current log level.
  */
 
 /**
  * Generated from players.graphql
- * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & Partial<Pick<import('../services/players.js').Player, 'currentGameId'|'avatar'|'provider'|'email'|'termsAccepted'|'isAdmin'|'usernameSearchable'>>} Player
+ * @typedef {Pick<import('../services/players.js').Player, 'id'|'username'> & Partial<Pick<import('../services/players').Player, 'currentGameId'|'avatar'|'provider'|'email'|'termsAccepted'|'isAdmin'|'usernameSearchable'>>} Player
  *
- * @typedef {{ player: Player } & Pick<import('../services/players.js').Friendship, 'isRequest'|'isProposal'> } Friendship
+ * @typedef {{ player: Player } & Pick<import('../services/players').Friendship, 'isRequest'|'isProposal'> } Friendship
  *
- * @typedef {{ from: Player } & Pick<import('../services/players.js').FriendshipUpdate, 'requested'|'proposed'|'accepted'|'declined'> } FriendshipUpdate
+ * @typedef {{ from: Player } & Pick<import('../services/players').FriendshipUpdate, 'requested'|'proposed'|'accepted'|'declined'> } FriendshipUpdate
  *
- * @typedef {import('../services/turn-credentials.js').TurnCredentials} TurnCredentials
+ * @typedef {import('../services/turn-credentials').TurnCredentials} TurnCredentials
  *
  * @typedef {object} PlayerWithTurnCredentials
  * @property {string} token - authentication token.
@@ -139,8 +140,7 @@
  * @property {string} data - the signal payload.
  *
  * @typedef {object} SendSignalArgs
- * @property {string} to - player id to which the signal is sent.
- * @property {string} data - the signal payload.
+ * @property {{ to: string, data: string }} signal - player id to which the signal is sent and the signal payload.
  *
  * @typedef {object} AwaitSignalArgs
  * @property {string} gameId - game's id.

--- a/apps/server/src/graphql/utils.js
+++ b/apps/server/src/graphql/utils.js
@@ -1,11 +1,15 @@
 // @ts-check
+/**
+ * @typedef {import('mercurius').PubSub} PubSub
+ * @typedef {import('../plugins/graphql').GraphQLContext} GraphQLAnonymousContext
+ */
+
 import mercurius from 'mercurius'
 
 const { ErrorWithProps } = mercurius
 
-/** @typedef {import('../plugins/graphql').GraphQLContext} GraphQLAnonymousContext*/
 /** @typedef {Omit<GraphQLAnonymousContext, 'player'> & { player: NonNullable<GraphQLAnonymousContext['player']> }} GraphQLContext*/
-/** @typedef {ReturnType<import('mercurius').PubSub['subscribe']>} PubSubQueue*/
+/** @typedef {ReturnType<PubSub['subscribe']>} PubSubQueue*/
 
 /**
  * @template Source, Context, Args

--- a/apps/server/src/plugins/auth.js
+++ b/apps/server/src/plugins/auth.js
@@ -1,24 +1,28 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('../services/auth/oauth2').ProviderInit} ProviderInit
+ * @typedef {import('./utils').SignerOptions} SignerOptions
+ */
+
 import services from '../services/index.js'
 import { addToLogContext, makeLogger } from '../utils/index.js'
 import { makeToken } from './utils.js'
-
-/** @typedef {Omit<import('../services/auth/oauth2').ProviderInit, 'redirect'>} ProviderInit */
 
 /**
  * @typedef {object} AuthOptions authentication plugin options, including:
  * @property {string} domain - public facing domain (full url) for authentication redirections.
  * @property {string} allowedOrigins - regular expression for allowed domains during authentication.
- * @property {import('./utils').SignerOptions} jwt - options used to encrypt JWT token: needs 'key' at least.
- * @property {ProviderInit} [github] - Github authentication provider options.
- * @property {ProviderInit} [google] - Google authentication provider options.
+ * @property {SignerOptions} jwt - options used to encrypt JWT token: needs 'key' at least.
+ * @property {Omit<ProviderInit, 'redirect'>} [github] - Github authentication provider options.
+ * @property {Omit<ProviderInit, 'redirect'>} [google] - Google authentication provider options.
  */
 
 const logger = makeLogger('auth-plugin')
 
 /**
  * Registers endpoint to handle player authentication with various authentication providers.
- * @param {import('fastify').FastifyInstance} app - a fastify application.
+ * @param {FastifyInstance} app - a fastify application.
  * @param {AuthOptions} options - plugin's options.
  * @returns {Promise<void>}
  */

--- a/apps/server/src/plugins/auth.js
+++ b/apps/server/src/plugins/auth.js
@@ -3,14 +3,13 @@ import services from '../services/index.js'
 import { addToLogContext, makeLogger } from '../utils/index.js'
 import { makeToken } from './utils.js'
 
-/** @typedef {import('./utils.js').SignerOptions} SignerOptions */
-/** @typedef {Omit<import('../services/auth/oauth2.js').ProviderInit, 'redirect'>} ProviderInit */
+/** @typedef {Omit<import('../services/auth/oauth2').ProviderInit, 'redirect'>} ProviderInit */
 
 /**
  * @typedef {object} AuthOptions authentication plugin options, including:
  * @property {string} domain - public facing domain (full url) for authentication redirections.
  * @property {string} allowedOrigins - regular expression for allowed domains during authentication.
- * @property {SignerOptions} jwt - options used to encrypt JWT token: needs 'key' at least.
+ * @property {import('./utils').SignerOptions} jwt - options used to encrypt JWT token: needs 'key' at least.
  * @property {ProviderInit} [github] - Github authentication provider options.
  * @property {ProviderInit} [google] - Google authentication provider options.
  */

--- a/apps/server/src/plugins/graphql.js
+++ b/apps/server/src/plugins/graphql.js
@@ -1,4 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('mercurius').MercuriusContext} MercuriusContext
+ * @typedef {import('mercurius').MercuriusOptions} MercuriusOptions
+ * @typedef {import('../server').Server} Server
+ * @typedef {import('../services/configuration').Configuration} Configuration
+ * @typedef {import('../services/players').Player} Player
+ */
+
 import mercurius from 'mercurius'
 import redis from 'mqemitter-redis'
 
@@ -16,15 +25,15 @@ const logger = makeLogger('graphql-plugin')
 
 /**
  * @typedef {object} Context Context passed to every GraphQL resolver.
- * @property {?import('../services/players').Player} player - authenticated player, if any.
+ * @property {?Player} player - authenticated player, if any.
  * @property {string} token - authentication token (could be empty).
- * @property {import('../services/configuration').Configuration} conf - application configuration.
+ * @property {Configuration} conf - application configuration.
  */
 
-/** @typedef {import('mercurius').MercuriusContext & Context} GraphQLContext */
+/** @typedef {MercuriusContext & Context} GraphQLContext */
 
 /**
- * @typedef {import('mercurius').MercuriusOptions & GraphQLCustomOptions} GraphQLOptions graphQL plugin options.
+ * @typedef {MercuriusOptions & GraphQLCustomOptions} GraphQLOptions graphQL plugin options.
  * You can use any of Mercurius options but `schema`, `resolvers`, `loaders` and `context` which are computed.
  */
 
@@ -37,7 +46,7 @@ const logger = makeLogger('graphql-plugin')
  * Request authentication expects a Bearer token ("Bearer " + a valid JWT).
  * In the case of GraphQL subscription, bearer is expected on the connection payload message.
  * In the case of GraphQL queries and mutations, bearer is expected in the Authorization header
- * @param {import('fastify').FastifyInstance} fastify - a fastify application.
+ * @param {FastifyInstance} fastify - a fastify application.
  * @param {GraphQLOptions} opts - plugin options.
  * @returns {Promise<void>}
  */
@@ -46,7 +55,7 @@ export default async function registerGraphQL(
   { allowedOrigins, pubsubUrl, ...opts }
 ) {
   const allowedOriginsRegExp = new RegExp(allowedOrigins)
-  const app = /** @type {import('../server').Server} */ (fastify)
+  const app = /** @type {Server} */ (fastify)
   await app.register(mercurius, {
     ...opts,
     schema,

--- a/apps/server/src/plugins/graphql.js
+++ b/apps/server/src/plugins/graphql.js
@@ -16,9 +16,9 @@ const logger = makeLogger('graphql-plugin')
 
 /**
  * @typedef {object} Context Context passed to every GraphQL resolver.
- * @property {?import('../services/players.js').Player} player - authenticated player, if any.
+ * @property {?import('../services/players').Player} player - authenticated player, if any.
  * @property {string} token - authentication token (could be empty).
- * @property {import('../services/configuration.js').Configuration} conf - application configuration.
+ * @property {import('../services/configuration').Configuration} conf - application configuration.
  */
 
 /** @typedef {import('mercurius').MercuriusContext & Context} GraphQLContext */
@@ -46,7 +46,7 @@ export default async function registerGraphQL(
   { allowedOrigins, pubsubUrl, ...opts }
 ) {
   const allowedOriginsRegExp = new RegExp(allowedOrigins)
-  const app = /** @type {import('../server.js').Server} */ (fastify)
+  const app = /** @type {import('../server').Server} */ (fastify)
   await app.register(mercurius, {
     ...opts,
     schema,

--- a/apps/server/src/plugins/utils.js
+++ b/apps/server/src/plugins/utils.js
@@ -1,12 +1,17 @@
 // @ts-check
+/**
+ * @typedef {import('../services/players').Player} Player
+ */
+
 import { createSigner, createVerifier } from 'fast-jwt'
 
 import services from '../services/index.js'
 import { makeLogger } from '../utils/logger.js'
 
-/** @typedef {import('../services/players.js').Player} Player */
 /** @typedef {Partial<import('fast-jwt').SignerOptions> & { key: string }} SignerOptions */
+
 /** @typedef {import('fast-jwt').SignerSync} Signer */
+
 /** @typedef {(jwt: string) => { id: string }} Verifier */
 
 /** @type {Map<string, Signer>} */

--- a/apps/server/src/plugins/utils.js
+++ b/apps/server/src/plugins/utils.js
@@ -1,5 +1,7 @@
 // @ts-check
 /**
+ * @typedef {import('fast-jwt').SignerOptions} FullSignerOptions
+ * @typedef {import('fast-jwt').SignerSync} Signer
  * @typedef {import('../services/players').Player} Player
  */
 
@@ -8,9 +10,7 @@ import { createSigner, createVerifier } from 'fast-jwt'
 import services from '../services/index.js'
 import { makeLogger } from '../utils/logger.js'
 
-/** @typedef {Partial<import('fast-jwt').SignerOptions> & { key: string }} SignerOptions */
-
-/** @typedef {import('fast-jwt').SignerSync} Signer */
+/** @typedef {Partial<FullSignerOptions> & { key: string }} SignerOptions */
 
 /** @typedef {(jwt: string) => { id: string }} Verifier */
 

--- a/apps/server/src/repositories/abstract-repository.js
+++ b/apps/server/src/repositories/abstract-repository.js
@@ -1,13 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('ioredis').ChainableCommander} Transaction
+ */
+
 import { randomUUID } from 'node:crypto'
 
 import Redis from 'ioredis'
 
 import { makeLogger } from '../utils/index.js'
-
-/**
- * @typedef {import('ioredis').ChainableCommander} Transaction
- */
 
 /**
  * @template {object} T

--- a/apps/server/src/repositories/catalog-items.js
+++ b/apps/server/src/repositories/catalog-items.js
@@ -1,10 +1,12 @@
 // @ts-check
+/**
+ * @typedef {import('../services/catalog').GameDescriptor} CatalogItem
+ */
+
 import { readdir } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 
 import { makeLogger } from '../utils/index.js'
-
-/** @typedef {import('../services/catalog.js').GameDescriptor} CatalogItem */
 
 class CatalogItemRepository {
   /**

--- a/apps/server/src/repositories/games.js
+++ b/apps/server/src/repositories/games.js
@@ -1,14 +1,16 @@
 // @ts-check
+/**
+ * @typedef {import('../services/games').GameData} Game
+ * @typedef {import('./abstract-repository').SaveTransactionContext<Game>} SaveTransactionContext
+ * @typedef {import('./abstract-repository').DeleteTransactionContext<Game>} DeleteTransactionContext
+ * @typedef {SaveTransactionContext['transaction']} Transaction
+ */
+
 import {
   AbstractRepository,
   deserializeArray,
   deserializeNumber
 } from './abstract-repository.js'
-
-/** @typedef {import('../services/games.js').GameData} Game */
-/** @typedef {import('./abstract-repository.js').SaveTransactionContext<Game>} SaveTransactionContext */
-/** @typedef {import('./abstract-repository.js').DeleteTransactionContext<Game>} DeleteTransactionContext */
-/** @typedef {SaveTransactionContext['transaction']} Transaction */
 
 /** @extends AbstractRepository<Game> */
 class GameRepository extends AbstractRepository {
@@ -45,7 +47,7 @@ class GameRepository extends AbstractRepository {
   /**
    * Saves player as Redis Hash.
    * @override
-   * @param {import('./abstract-repository.js').SaveModelContext<Game>} context - the save operation context.
+   * @param {import('./abstract-repository').SaveModelContext<Game>} context - the save operation context.
    */
   _saveModel({ transaction, model, key }) {
     const { id, created, playerIds, guestIds, ownerId, ...otherFields } = model

--- a/apps/server/src/repositories/players.js
+++ b/apps/server/src/repositories/players.js
@@ -1,4 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('ioredis').Redis} Redis
+ * @typedef {import('./abstract-repository').DeleteTransactionContext<Player>} DeleteTransactionContext
+ * @typedef {import('./abstract-repository').SaveTransactionContext<Player>} SaveTransactionContext
+ * @typedef {import('./abstract-repository').Transaction} Transaction
+ * @typedef {import('../services/players').Player} Player
+ * @typedef {import('../utils/logger').Logger} Logger
+ */
+
 import {
   count,
   create,
@@ -13,10 +22,6 @@ import {
   deserializeBoolean
 } from './abstract-repository.js'
 
-/** @typedef {import('../services/players.js').Player} Player */
-/** @typedef {import('./abstract-repository.js').SaveTransactionContext<Player>} SaveTransactionContext */
-/** @typedef {import('./abstract-repository.js').DeleteTransactionContext<Player>} DeleteTransactionContext */
-/** @typedef {import('ioredis').Redis} Redis */
 /** @typedef {?import('@orama/orama').Orama<{ Schema: { username: 'string', fullName: 'string', email: 'string' } }>} SearchIndex */
 
 /**
@@ -116,13 +121,12 @@ class PlayerRepository extends AbstractRepository {
    * When saving players, add their provider id references, and updates their username for autocompletion.
    * @override
    * @param {SaveTransactionContext} context - contextual information.
-   * @returns {Promise<import('./abstract-repository.js').Transaction>}
+   * @returns {Promise<Transaction>}
    */
   async _enrichSaveTransaction(context) {
-    const transaction =
-      /** @type {import('./abstract-repository.js').Transaction} */ (
-        super._enrichSaveTransaction(context)
-      )
+    const transaction = /** @type {Transaction} */ (
+      super._enrichSaveTransaction(context)
+    )
     const { models, existings } = context
     const references = /** @type {[string[]]} */ (
       models
@@ -148,7 +152,7 @@ class PlayerRepository extends AbstractRepository {
    */
   async _enrichDeleteTransaction(context) {
     const transaction =
-      /** @type {import('./abstract-repository.js').Transaction} */ (
+      /** @type {import('./abstract-repository').Transaction} */ (
         super._enrichDeleteTransaction(context)
       )
     const references = /** @type {string[]} */ (
@@ -375,7 +379,7 @@ export const players = new PlayerRepository()
 /**
  * @param {SearchIndex} searchIndex
  * @param {Player[]} models
- * @param {import('../utils/logger.js').Logger} logger
+ * @param {Logger} logger
  * @returns {Promise<void>}
  */
 async function insertIntoIndex(searchIndex, models, logger) {
@@ -390,7 +394,7 @@ async function insertIntoIndex(searchIndex, models, logger) {
 /**
  * @param {SearchIndex} searchIndex
  * @param {(?Player)[]} models
- * @param {import('../utils/logger.js').Logger} logger
+ * @param {Logger} logger
  * @returns {Promise<void>}
  */
 async function removeFromIndex(searchIndex, models, logger) {

--- a/apps/server/src/repositories/players.js
+++ b/apps/server/src/repositories/players.js
@@ -151,10 +151,9 @@ class PlayerRepository extends AbstractRepository {
    * @param {DeleteTransactionContext} context - contextual information.
    */
   async _enrichDeleteTransaction(context) {
-    const transaction =
-      /** @type {import('./abstract-repository').Transaction} */ (
-        super._enrichDeleteTransaction(context)
-      )
+    const transaction = /** @type {Transaction} */ (
+      super._enrichDeleteTransaction(context)
+    )
     const references = /** @type {string[]} */ (
       context.models
         .flatMap(player =>

--- a/apps/server/src/server.js
+++ b/apps/server/src/server.js
@@ -1,10 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('./services/configuration').Configuration} Configuration
+ */
+
 import fastify from 'fastify'
 
 import repositories from './repositories/index.js'
 import { createLogContext } from './utils/index.js'
 
-/** @typedef {import('./services/configuration.js').Configuration} Configuration */
 /** @typedef {import('fastify').FastifyInstance & { conf: Configuration }} Server */
 
 /**

--- a/apps/server/src/services/catalog.js
+++ b/apps/server/src/services/catalog.js
@@ -15,6 +15,7 @@ import { makeLogger } from '../utils/index.js'
  * @property {number} [maxSeats] - maximum seats allowed, when relevant.
  * @property {number} [minAge] - minimum age suggested.
  * @property {number} [maxAge] - maximum age suggested.
+ * @property {number} [minTime] - minimum time observed.
  * @property {Copyright} [copyright] - copyright data, meaning this item has restricted access.
  * @property {number} [rulesBookPageCount] - number of pages in the rules book, if any.
  * @property {ZoomSpec} [zoomSpec] - zoom specifications for main and hand scene.

--- a/apps/server/src/services/catalog.js
+++ b/apps/server/src/services/catalog.js
@@ -1,11 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('./players').Player} Player
+ * @typedef {import('./games').StartedGameData} GameData
+ * @typedef {import('./games').Schema} Schema
+ * @typedef {import('../utils/games').GameSetup} GameSetup
+ */
+
 import repositories from '../repositories/index.js'
 import { makeLogger } from '../utils/index.js'
-
-/** @typedef {import('./players.js').Player} Player */
-/** @typedef {import('./games.js').StartedGameData} GameData */
-/** @typedef {import('./games.js').Schema} Schema */
-/** @typedef {import('../utils/games.js').GameSetup} GameSetup */
 
 /**
  * @typedef {object} GameDescriptor a catalog item
@@ -28,9 +30,11 @@ import { makeLogger } from '../utils/index.js'
  */
 
 /**
- * @typedef {object} ItemLocales All the localized data for this catalog item.
+ * @typedef {object} _ItemLocales
  * @property {ItemLocale} [fr] - French locale
  * @property {ItemLocale} [en] - English locale
+ *
+ * @typedef {Record<string, ?> & _ItemLocales} ItemLocales All the localized data for a catalog item.
  */
 
 /**
@@ -46,7 +50,7 @@ import { makeLogger } from '../utils/index.js'
 /**
  * @typedef {object} Copyright game copyright data
  * @property {PersonOrCompany[]} authors - game authors.
- * @property {PersonOrCompany[]} [designer] - game designers.
+ * @property {PersonOrCompany[]} [designers] - game designers.
  * @property {PersonOrCompany[]} [publishers] - game publishers.
  */
 

--- a/apps/server/src/services/configuration.js
+++ b/apps/server/src/services/configuration.js
@@ -1,14 +1,18 @@
 // @ts-check
+/**
+ * @typedef {import('../plugins/auth').AuthOptions} AuthOptions
+ * @typedef {import('../plugins/graphql').GraphQLOptions} GraphQLOptions
+ * @typedef {import('../plugins/static').StaticOptions} StaticOptions
+ * @typedef {import('../plugins/cors').CorsOptions} CorsOptions
+ * @typedef {import('../utils/logger').Level} Level
+ */
+
 import { isAbsolute, join } from 'node:path'
 import { cwd } from 'node:process'
 
 import Ajv from 'ajv/dist/jtd.js'
 
 import { makeLogger } from '../utils/index.js'
-
-/** @typedef {import('../plugins/graphql').GraphQLOptions} GraphQLOptions */
-/** @typedef {import('../plugins/static').StaticOptions} StaticOptions */
-/** @typedef {import('../plugins/cors').CorsOptions} CorsOptions */
 
 /**
  * @typedef {object} DataOptions
@@ -17,7 +21,7 @@ import { makeLogger } from '../utils/index.js'
 
 /**
  * @typedef {object} LoggerOptions
- * @property {import('../utils/logger.js').Level} level - level used for logging.
+ * @property {Level} level - level used for logging.
  */
 
 /**
@@ -34,7 +38,7 @@ import { makeLogger } from '../utils/index.js'
  * @property {LoggerOptions} logger - Pino logger options, including:
  * @property {DataOptions} data - configuration to connect to the database:
  * @property {GamesOpptions} games - game engine properties, including;
- * @property {import('../plugins/auth').AuthOptions} auth - options for the authentication plugin.
+ * @property {AuthOptions} auth - options for the authentication plugin.
  * @property {object} plugins - options for all plugin used:
  * @property {GraphQLOptions} plugins.graphql - options for the GraphQL plugin.
  * @property {StaticOptions} plugins.static - options for the static files plugin.

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -206,11 +206,13 @@ import { canAccess } from './catalog.js'
  */
 
 /**
- * @typedef {Record<string, any>} PlayerPreference
+ * @typedef {object} _PlayerPreference
  * @property {string} playerId - if of this player.
  * @property {string} [color] - hex color for this player, if any.
  * @property {number} [angle] - yaw (Y angle) on the table, if any.
  */
+
+/** @typedef {Record<string, any> & _PlayerPreference} PlayerPreference */
 
 /** @typedef {import('ajv').JSONSchemaType<?>} Schema */
 

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -189,7 +189,7 @@ import { canAccess } from './catalog.js'
 
 /**
  * @typedef {object} CameraPosition a saved Arc rotate camera position
- * @property {string} [hash] - hash for this position, to ease comparisons and change detections.
+ * @property {string} hash - hash for this position, to ease comparisons and change detections.
  * @property {string} playerId - id of the player for who this camera position is relevant.
  * @property {number} index - 0-based index for this saved position.
  * @property {number[]} target - 3D cooordinates of the camera target, as per Babylon's specs.

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -1,4 +1,10 @@
 // @ts-check
+/**
+ * @typedef {import('./players').Player} Player
+ * @typedef {import('./catalog').GameDescriptor} GameDescriptor
+ * @typedef {import('../repositories/players').Friendship} Friendship
+ */
+
 import Ajv from 'ajv/dist/2020.js'
 import { concatMap, mergeMap, Subject } from 'rxjs'
 
@@ -15,9 +21,6 @@ import {
   pickRandom
 } from '../utils/index.js'
 import { canAccess } from './catalog.js'
-
-/** @typedef {import('./players.js').Player} Player */
-/** @typedef {import('./catalog.js').GameDescriptor} GameDescriptor */
 
 /**
  * @typedef {object} Game an active game, or a lobby
@@ -69,7 +72,7 @@ import { canAccess } from './catalog.js'
  * @property {InitialTransform} [transform] - initial transformation baked into the mesh's vertices.
  * @property {number} [borderRadius] - corner radius, for rounded tiles.
  * @property {string} [file] - path to the custom mesh OBJ file.
- * @property {number} [edge] - number of edge, for prisms.
+ * @property {number} [edges] - number of edges, for prisms.
  * @property {number} [prismRotation] - initial rotation angle, baked in vertices, for prisms.
  * @property {number} [faces] - number of faces, for dice.
  * @property {DetailableState} [detailable] - if this mesh could be detailed, contains details.
@@ -86,7 +89,7 @@ import { canAccess } from './catalog.js'
 /** @typedef {_Mesh & Point & Dimension} Mesh */
 
 /**
- * @typedef {object} Targetable commonn properties for targets (stacks, anchors, quantifiable...)
+ * @typedef {object} Targetable common properties for targets (stacks, anchors, quantifiable...)
  * @property {string[]} [kinds] - acceptable meshe kinds, that could be snapped to the anchor. Leave undefined to accept all.
  * @property {number} [extent=2] - dimension multiplier applied to the drop target.
  * @property {number} [priority=0] - priority applied when multiple targets with same altitude apply.
@@ -212,7 +215,7 @@ import { canAccess } from './catalog.js'
  * @property {number} [angle] - yaw (Y angle) on the table, if any.
  */
 
-/** @typedef {Record<string, any> & _PlayerPreference} PlayerPreference */
+/** @typedef { Record<string, ?> & _PlayerPreference } PlayerPreference */
 
 /** @typedef {import('ajv').JSONSchemaType<?>} Schema */
 
@@ -686,7 +689,7 @@ function isGuestAlreadyPlaying(userId, { playerIds, guestIds }) {
 
 /**
  * @param {string} guestId - checked guest id.
- * @param {import('../repositories/players.js').Friendship[]} friendships - current player existing relationships.
+ * @param {Friendship[]} friendships - current player existing relationships.
  * @returns {boolean} whether this guest is a friend of the current player.
  */
 function isGuestAFriend(guestId, friendships) {

--- a/apps/server/src/utils/games.js
+++ b/apps/server/src/utils/games.js
@@ -1,21 +1,24 @@
 // @ts-check
+/**
+ * @typedef {import('../services/players').Player} Player
+ * @typedef {import('../services/catalog').GameDescriptor} GameDescriptor
+ * @typedef {import('../services/games').GameData} GameData
+ * @typedef {import('../services/games').StartedGameData} StartedGameData
+ * @typedef {import('../services/games').GameParameters} GameParameters
+ * @typedef {import('../services/games').Schema} Schema
+ * @typedef {import('../services/games').Mesh} Mesh
+ * @typedef {import('../services/games').Anchor} Anchor
+ * @typedef {import('../services/games').Hand} Hand
+ * @typedef {import('../services/games').CameraPosition} CameraPosition
+ * @typedef {import('../services/games').PlayerPreference} PlayerPreference
+ */
+
 import { randomUUID } from 'node:crypto'
 
 import merge from 'deepmerge'
 
 import { shuffle } from './collections.js'
 
-/** @typedef {import('../services/players.js').Player} Player */
-/** @typedef {import('../services/catalog.js').GameDescriptor} GameDescriptor */
-/** @typedef {import('../services/games.js').GameData} GameData */
-/** @typedef {import('../services/games.js').StartedGameData} StartedGameData */
-/** @typedef {import('../services/games.js').GameParameters} GameParameters */
-/** @typedef {import('../services/games.js').Schema} Schema */
-/** @typedef {import('../services/games.js').Mesh} Mesh */
-/** @typedef {import('../services/games.js').Anchor} Anchor */
-/** @typedef {import('../services/games.js').Hand} Hand */
-/** @typedef {import('../services/games.js').CameraPosition} CameraPosition */
-/** @typedef {import('../services/games.js').PlayerPreference} PlayerPreference */
 /** @typedef {Map<string, string[]>} Bags */
 
 /**

--- a/apps/server/src/utils/games.js
+++ b/apps/server/src/utils/games.js
@@ -467,6 +467,7 @@ export function buildCameraPosition({
     throw new Error('camera position requires playerId')
   }
   return addHash({
+    hash: '',
     playerId,
     index,
     target,

--- a/apps/server/src/utils/logger.js
+++ b/apps/server/src/utils/logger.js
@@ -1,10 +1,12 @@
 // @ts-check
+/**
+ * @typedef {import('pino').Logger} Logger
+ * @typedef {import('pino').LevelWithSilent} Level
+ */
+
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 import pino from 'pino'
-
-/** @typedef {import('pino').Logger} Logger */
-/** @typedef {import('pino').LevelWithSilent} Level */
 
 /** @typedef {Record<string, unknown>} LogContext */
 

--- a/apps/server/tests/graphql/catalog-resolver.test.js
+++ b/apps/server/tests/graphql/catalog-resolver.test.js
@@ -26,7 +26,7 @@ vi.mock('../../src/services/index.js', () => ({
 describe('given a started server', () => {
   /** @type {import('fastify').FastifyInstance} */
   let server
-  /** @type {import('../../src/services/index.js').default} */
+  /** @type {import('../../src/services/index').default} */
   let services
   vi.spyOn(makeLogger('graphql-plugin'), 'warn').mockImplementation(() => {})
   const player = { id: faker.string.uuid(), username: faker.person.firstName() }

--- a/apps/server/tests/graphql/games-resolver.test.js
+++ b/apps/server/tests/graphql/games-resolver.test.js
@@ -1,4 +1,12 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('../../src/services/players').Player} Player
+ * @typedef {import('../../src/services/games').GameData} GameData
+ * @typedef {import('../../src/services/games').GameListUpdate} GameListUpdate
+ * @typedef {import('../../src/services/games').GameParameters} GameParameters
+ */
+
 import { faker } from '@faker-js/faker'
 import fastify from 'fastify'
 import { Subject } from 'rxjs'
@@ -26,19 +34,15 @@ import {
   waitOnMessage
 } from '../test-utils.js'
 
-/** @typedef {import('../../src/services/players.js').Player} Player */
-/** @typedef {import('../../src/services/games.js').GameData} GameData */
-/** @typedef {import('../../src/services/games.js').GameListUpdate} GameListUpdate */
-
 describe('given a started server', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
   /** @type {import('ws')} */
   let ws
   /** @type {ReturnType<typeof mockMethods>} */
   let restoreServices
   const services =
-    /** @type {import('../test-utils.js').MockedMethods<typeof realServices> & {gameListsUpdate: Subject<GameListUpdate>}} */ (
+    /** @type {import('../test-utils').MockedMethods<typeof realServices> & {gameListsUpdate: Subject<GameListUpdate>}} */ (
       realServices
     )
   vi.spyOn(makeLogger('graphql-plugin'), 'warn').mockImplementation(() => {})
@@ -450,14 +454,13 @@ describe('given a started server', () => {
 
       it('loads game parameters', async () => {
         const [player] = players
-        const gameParameters =
-          /** @type {import('../../src/services/games.js').GameParameters} */ ({
-            id: faker.string.uuid(),
-            schema: {},
-            ownerId: player.id,
-            playerIds: players.map(({ id }) => id),
-            guestIds: guests.map(({ id }) => id)
-          })
+        const gameParameters = /** @type {GameParameters} */ ({
+          id: faker.string.uuid(),
+          schema: {},
+          ownerId: player.id,
+          playerIds: players.map(({ id }) => id),
+          guestIds: guests.map(({ id }) => id)
+        })
         const value = faker.lorem.words()
         services.getPlayerById
           .mockResolvedValueOnce(player)

--- a/apps/server/tests/graphql/logger-resolver.test.js
+++ b/apps/server/tests/graphql/logger-resolver.test.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('../../src/services/players').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import fastify from 'fastify'
 import {
@@ -21,17 +26,15 @@ import {
 } from '../test-utils.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
-/** @typedef {import('../../src/services/players.js').Player} Player */
-
 describe('given a started server', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
   /** @type {import('ws')} */
   let ws
   /** @type {ReturnType<typeof mockMethods>} */
   let restoreServices
   const services =
-    /** @type {import('../test-utils.js').MockedMethods<typeof realServices>} */ (
+    /** @type {import('../test-utils').MockedMethods<typeof realServices>} */ (
       realServices
     )
   const pubsubUrl = getRedisTestUrl()

--- a/apps/server/tests/graphql/players-resolver.test.js
+++ b/apps/server/tests/graphql/players-resolver.test.js
@@ -1,4 +1,10 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('../../src/services/players').Player} Player
+ * @typedef {import('../../src/services/players').FriendshipUpdate} FriendshipUpdate
+ */
+
 import { faker } from '@faker-js/faker'
 import { createVerifier } from 'fast-jwt'
 import fastify from 'fastify'
@@ -27,11 +33,8 @@ import {
   waitOnMessage
 } from '../test-utils.js'
 
-/** @typedef {import('../../src/services/players.js').Player} Player */
-/** @typedef {import('../../src/services/players.js').FriendshipUpdate} FriendshipUpdate */
-
 describe('given a started server', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
   /** @type {import('ws')} */
   let ws

--- a/apps/server/tests/graphql/signals-resolver.test.js
+++ b/apps/server/tests/graphql/signals-resolver.test.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('../../src/services/players').Player} Player
+ */
+
 import { setTimeout } from 'node:timers/promises'
 
 import { faker } from '@faker-js/faker'
@@ -27,17 +32,15 @@ import {
 } from '../test-utils.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
-/** @typedef {import('../../src/services/players.js').Player} Player */
-
 describe('given a started server', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
   /** @type {import('ws')} */
   let ws
   /** @type {ReturnType<typeof mockMethods>} */
   let restoreServices
   const services =
-    /** @type {import('../test-utils.js').MockedMethods<typeof realServices>} */ (
+    /** @type {import('../test-utils').MockedMethods<typeof realServices>} */ (
       realServices
     )
   vi.spyOn(makeLogger('graphql-plugin'), 'warn').mockImplementation(() => {})

--- a/apps/server/tests/plugins/auth.test.js
+++ b/apps/server/tests/plugins/auth.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ */
+
 import { faker } from '@faker-js/faker'
 import { createVerifier } from 'fast-jwt'
 import fastify from 'fastify'
@@ -37,11 +41,11 @@ describe('auth plugin', () => {
   const domain = 'https://localhost:3000'
   const jwtOptions = { key: faker.string.uuid() }
   const allowedOrigins = `http:\\/\\/localhost:80`
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
-  /** @type {import('../../src/plugins/auth.js')} */
+  /** @type {import('../../src/plugins/auth')} */
   let authPlugin
-  /** @type {import('vitest').Mocked<import('../../src/services/index.js').default>} */
+  /** @type {import('vitest').Mocked<import('../../src/services/index').default>} */
   let services
 
   beforeAll(async () => {

--- a/apps/server/tests/plugins/cors.test.js
+++ b/apps/server/tests/plugins/cors.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ */
+
 import { faker } from '@faker-js/faker'
 import fastify from 'fastify'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -7,7 +11,7 @@ import corsPlugin from '../../src/plugins/cors.js'
 import graphqlPlugin from '../../src/plugins/graphql.js'
 
 describe('cors plugin', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
 
   afterEach(() => server?.close())

--- a/apps/server/tests/plugins/graphql.test.js
+++ b/apps/server/tests/plugins/graphql.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ */
+
 import { faker } from '@faker-js/faker'
 import fastify from 'fastify'
 import {
@@ -19,13 +23,13 @@ import { makeLogger } from '../../src/utils/index.js'
 import { mockMethods } from '../test-utils.js'
 
 describe('graphql plugin', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
   /** @type {ReturnType<typeof mockMethods>} */
   let restoreServices
   let warn = vi.spyOn(makeLogger('graphql-plugin'), 'warn')
   const services =
-    /** @type {import('../test-utils.js').MockedMethods<typeof realServices>} */ (
+    /** @type {import('../test-utils').MockedMethods<typeof realServices>} */ (
       realServices
     )
 

--- a/apps/server/tests/plugins/static.test.js
+++ b/apps/server/tests/plugins/static.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ */
+
 import fastify from 'fastify'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -7,7 +11,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import staticPlugin from '../../src/plugins/static.js'
 
 describe('static plugin', () => {
-  /** @type {import('fastify').FastifyInstance} */
+  /** @type {FastifyInstance} */
   let server
 
   afterEach(() => server?.close())

--- a/apps/server/tests/repositories/games.test.js
+++ b/apps/server/tests/repositories/games.test.js
@@ -1,11 +1,13 @@
 // @ts-check
+/**
+ * @typedef {import('../../src/services/games').Game} Game
+ */
+
 import { faker } from '@faker-js/faker'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { games } from '../../src/repositories/games.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
-
-/** @typedef {import('../../src/services/games.js').Game} Game */
 
 describe('given a connected repository and several games', () => {
   const redisUrl = getRedisTestUrl()

--- a/apps/server/tests/repositories/players.test.js
+++ b/apps/server/tests/repositories/players.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src/services/players').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -11,8 +15,6 @@ import {
   players
 } from '../../src/repositories/players.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
-
-/** @typedef {import('../../src/services/players.js').Player} Player */
 
 describe('given a connected repository and several players', () => {
   const redisUrl = getRedisTestUrl()

--- a/apps/server/tests/server.test.js
+++ b/apps/server/tests/server.test.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('../src/server').Server} Server
+ * @typedef {import('../src/services/configuration').Configuration} Configuration
+ */
+
 // mandatory side effect for vi to load auth plugin
 import '../src/plugins/utils.js'
 
@@ -20,7 +25,7 @@ import repositories from '../src/repositories/index.js'
 import { startServer } from '../src/server.js'
 
 describe('startServer()', () => {
-  /** @type {import('../src/server.js').Server}} */
+  /** @type {Server}} */
   let app
   /** @type {number} */
   let port
@@ -96,7 +101,7 @@ describe('startServer()', () => {
   })
 
   it('decorates app with configuration property', async () => {
-    /** @type {import('../src/services/configuration.js').Configuration} */
+    /** @type {Configuration} */
     const conf = {
       isProduction: true,
       serverUrl: { host: undefined, port },

--- a/apps/server/tests/services/auth/github.test.js
+++ b/apps/server/tests/services/auth/github.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('undici').Interceptable} Interceptable
+ */
+
 import { faker } from '@faker-js/faker'
 import { MockAgent, setGlobalDispatcher } from 'undici'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,9 +25,9 @@ describe('Github authentication service', () => {
     const secret = faker.internet.password()
     /** @type {MockAgent} */
     let mockAgent
-    /** @type {import('undici').Interceptable} */
+    /** @type {Interceptable} */
     let githubMock
-    /** @type {import('undici').Interceptable} */
+    /** @type {Interceptable} */
     let githubApiMock
 
     beforeEach(() => {

--- a/apps/server/tests/services/auth/google.test.js
+++ b/apps/server/tests/services/auth/google.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('undici').Interceptable} Interceptable
+ */
+
 import { faker } from '@faker-js/faker'
 import { createSigner } from 'fast-jwt'
 import { MockAgent, setGlobalDispatcher } from 'undici'
@@ -25,7 +29,7 @@ describe('Google authentication service', () => {
     const redirect = faker.internet.url()
     /** @type {MockAgent} */
     let mockAgent
-    /** @type {import('undici').Interceptable} */
+    /** @type {Interceptable} */
     let googleApiMock
 
     beforeEach(() => {

--- a/apps/server/tests/services/catalog.test.js
+++ b/apps/server/tests/services/catalog.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src/services/players').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import { join } from 'path'
 import {
@@ -20,23 +24,22 @@ import {
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
 describe('Catalog service', () => {
-  const players =
-    /** @type {import('../../src/services/players.js').Player[]} */ ([
-      {
-        id: faker.string.uuid(),
-        username: faker.person.fullName(),
-        catalog: ['splendor', '6-takes']
-      },
-      {
-        id: faker.string.uuid(),
-        username: faker.person.fullName()
-      },
-      {
-        id: faker.string.uuid(),
-        username: faker.person.fullName(),
-        catalog: ['6-takes']
-      }
-    ])
+  const players = /** @type {Player[]} */ ([
+    {
+      id: faker.string.uuid(),
+      username: faker.person.fullName(),
+      catalog: ['splendor', '6-takes']
+    },
+    {
+      id: faker.string.uuid(),
+      username: faker.person.fullName()
+    },
+    {
+      id: faker.string.uuid(),
+      username: faker.person.fullName(),
+      catalog: ['6-takes']
+    }
+  ])
 
   const items = [
     {

--- a/apps/server/tests/services/games.test.js
+++ b/apps/server/tests/services/games.test.js
@@ -754,16 +754,17 @@ describe('given a subscription to game lists and an initialized repository', () 
         })
 
         it('can save cameras', async () => {
-          const cameras = [
-            {
-              playerId: player.id,
-              index: 0,
-              target: [0, 0, 0],
-              alpha: Math.PI,
-              beta: 0,
-              elevation: 10
-            }
-          ]
+          const cameras =
+            /** @type {import('../../src/services/games.js').CameraPosition[]} */ ([
+              {
+                playerId: player.id,
+                index: 0,
+                target: [0, 0, 0],
+                alpha: Math.PI,
+                beta: 0,
+                elevation: 10
+              }
+            ])
           expect(await saveGame({ id: game.id, cameras }, player.id)).toEqual({
             ...game,
             cameras,

--- a/apps/server/tests/services/games.test.js
+++ b/apps/server/tests/services/games.test.js
@@ -1,4 +1,12 @@
 // @ts-check
+/**
+ * @typedef {import('rxjs').Subscription} Subscription
+ * @typedef {import('../../src/services/players').Player} Player
+ * @typedef {import('../../src/services/games').GameData} GameData
+ * @typedef {import('../../src/services/games').GameListUpdate} GameListUpdate
+ * @typedef {import('../../src/services/games').CameraPosition} CameraPosition
+ */
+
 import { faker } from '@faker-js/faker'
 import { join } from 'path'
 import { setTimeout } from 'timers/promises'
@@ -30,12 +38,9 @@ import {
 } from '../../src/services/games.js'
 import { clearDatabase, getRedisTestUrl } from '../test-utils.js'
 
-/** @typedef {import('../../src/services/players.js').Player} Player */
-/** @typedef {import('../../src/services/games.js').GameData} GameData */
-
 describe('given a subscription to game lists and an initialized repository', () => {
   const redisUrl = getRedisTestUrl()
-  /** @type {import('../../src/services/games.js').GameListUpdate[]} */
+  /** @type {GameListUpdate[]} */
   const updates = []
   /** @type {Player} */
   const player = { id: 'player', username: '', currentGameId: null }
@@ -54,7 +59,7 @@ describe('given a subscription to game lists and an initialized repository', () 
   let game
   /** @type {GameData} */
   let lobby
-  /** @type {import('rxjs').Subscription} */
+  /** @type {Subscription} */
   let subscription
 
   beforeAll(async () => {
@@ -754,17 +759,16 @@ describe('given a subscription to game lists and an initialized repository', () 
         })
 
         it('can save cameras', async () => {
-          const cameras =
-            /** @type {import('../../src/services/games.js').CameraPosition[]} */ ([
-              {
-                playerId: player.id,
-                index: 0,
-                target: [0, 0, 0],
-                alpha: Math.PI,
-                beta: 0,
-                elevation: 10
-              }
-            ])
+          const cameras = /** @type {CameraPosition[]} */ ([
+            {
+              playerId: player.id,
+              index: 0,
+              target: [0, 0, 0],
+              alpha: Math.PI,
+              beta: 0,
+              elevation: 10
+            }
+          ])
           expect(await saveGame({ id: game.id, cameras }, player.id)).toEqual({
             ...game,
             cameras,

--- a/apps/server/tests/services/players.test.js
+++ b/apps/server/tests/services/players.test.js
@@ -1,4 +1,9 @@
 // @ts-check
+/**
+ * @typedef {import('rxjs').Subscription} Subscription
+ * @typedef {import('../../src/services/players').Player} Player
+ */
+
 import { faker } from '@faker-js/faker'
 import { vi } from 'vitest'
 import {
@@ -198,7 +203,7 @@ describe('given initialized repository', () => {
         avatar: faker.internet.avatar(),
         isAdmin: true
       })
-      /** @type {Partial<import('../../src/services/players.js').Player>} */
+      /** @type {Partial<Player>} */
       let update = {
         id: original.id,
         avatar: faker.internet.avatar(),
@@ -243,41 +248,40 @@ describe('given initialized repository', () => {
   })
 
   describe('given some players', () => {
-    let players =
-      /** @type {import('../../src/services/players.js').Player[]} */ ([
-        {
-          id: `adam-${faker.number.int(100)}`,
-          username: 'Adam Destine',
-          usernameSearchable: true
-        },
-        {
-          id: `batman-${faker.number.int(100)}`,
-          username: 'Batman',
-          usernameSearchable: true
-        },
-        {
-          id: `adaptoid-${faker.number.int(100)}`,
-          username: 'Adaptoid',
-          usernameSearchable: true
-        },
-        {
-          id: `adversary-${faker.number.int(100)}`,
-          username: 'Adversary',
-          usernameSearchable: true
-        },
-        {
-          id: `hulk-${faker.number.int(100)}`,
-          username: 'Hulk',
-          usernameSearchable: true
-        },
-        {
-          id: `thor-${faker.number.int(100)}`,
-          username: 'Thor',
-          usernameSearchable: true
-        }
-      ])
+    let players = /** @type {Player[]} */ ([
+      {
+        id: `adam-${faker.number.int(100)}`,
+        username: 'Adam Destine',
+        usernameSearchable: true
+      },
+      {
+        id: `batman-${faker.number.int(100)}`,
+        username: 'Batman',
+        usernameSearchable: true
+      },
+      {
+        id: `adaptoid-${faker.number.int(100)}`,
+        username: 'Adaptoid',
+        usernameSearchable: true
+      },
+      {
+        id: `adversary-${faker.number.int(100)}`,
+        username: 'Adversary',
+        usernameSearchable: true
+      },
+      {
+        id: `hulk-${faker.number.int(100)}`,
+        username: 'Hulk',
+        usernameSearchable: true
+      },
+      {
+        id: `thor-${faker.number.int(100)}`,
+        username: 'Thor',
+        usernameSearchable: true
+      }
+    ])
 
-    /** @type {import('rxjs').Subscription} */
+    /** @type {Subscription} */
     let subscription
     const friendshipUpdateReceived = vi.fn()
 

--- a/apps/server/tests/utils/games.test.js
+++ b/apps/server/tests/utils/games.test.js
@@ -1,4 +1,15 @@
 // @ts-check
+/**
+ * @typedef {import('../../src/services/games').Anchor} Anchor
+ * @typedef {import('../../src/services/games').GameDescriptor} GameDescriptor
+ * @typedef {import('../../src/services/games').GameParameters} GameParameters
+ * @typedef {import('../../src/services/games').Mesh} Mesh
+ * @typedef {import('../../src/services/games').Point} Point
+ * @typedef {import('../../src/services/games').StartedGameData} StartedGameData
+ * @typedef {import('../../src/services/players').Player} Player
+ * @typedef {import('../../src/utils/games').Slot} Slot
+ */
+
 import { faker } from '@faker-js/faker'
 import { vi } from 'vitest'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -20,14 +31,6 @@ import {
   unsnap
 } from '../../src/utils/games.js'
 import { cloneAsJSON } from '../test-utils.js'
-
-/** @typedef {import('../../src/services/games.js').Mesh} Mesh */
-/** @typedef {import('../../src/services/games.js').Anchor} Anchor */
-/** @typedef {import('../../src/services/games.js').StartedGameData} StartedGameData */
-/** @typedef {import('../../src/services/games.js').GameDescriptor} GameDescriptor */
-/** @typedef {import('../../src/services/games.js').GameParameters} GameParameters */
-/** @typedef {import('../../src/services/players.js').Player} Player */
-/** @typedef {import('../../src/utils/games.js').Slot} Slot */
 
 describe('createMeshes()', () => {
   it('throws on invalid descriptor', async () => {
@@ -1209,7 +1212,7 @@ describe('findAvailableValues()', () => {
   it('returns nothing when all possible values were used', () => {
     expect(
       findAvailableValues(
-        colors.map(color => ({ color })),
+        colors.map(color => ({ color, playerId: '' })),
         'color',
         colors
       )
@@ -1220,10 +1223,10 @@ describe('findAvailableValues()', () => {
     expect(
       findAvailableValues(
         [
-          { color: 'red' },
-          { color: 'lime' },
-          { color: 'azure' },
-          { color: 'blue' }
+          { color: 'red', playerId: '' },
+          { color: 'lime', playerId: '' },
+          { color: 'azure', playerId: '' },
+          { color: 'blue', playerId: '' }
         ],
         'color',
         colors
@@ -1235,10 +1238,10 @@ describe('findAvailableValues()', () => {
     expect(
       findAvailableValues(
         [
-          { color: 'red' },
-          { color: 'lime' },
-          { color: 'azure' },
-          { color: 'blue' }
+          { color: 'red', playerId: '' },
+          { color: 'lime', playerId: '' },
+          { color: 'azure', playerId: '' },
+          { color: 'blue', playerId: '' }
         ],
         'unknown',
         colors
@@ -1249,7 +1252,7 @@ describe('findAvailableValues()', () => {
 
 /**
  * @param {Mesh[]} meshes
- * @param {Slot & import('../../src/services/games.js').Point} [slot]
+ * @param {Slot & Point} [slot]
  * @param {number} [count]
  * @returns {Mesh}
  */

--- a/apps/server/tests/utils/logger.test.js
+++ b/apps/server/tests/utils/logger.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * @typedef {import('../../src/utils/logger').Logger} Logger
+ */
+
 import { setTimeout } from 'node:timers/promises'
 
 import { faker } from '@faker-js/faker'
@@ -50,7 +54,7 @@ describe('makeLogger()', () => {
 
   describe('given a logger', () => {
     let name = ''
-    /** @type {import('../../src/utils/logger.js').Logger} */
+    /** @type {Logger} */
     let logger
 
     beforeEach(() => {

--- a/apps/web/jsconfig.json
+++ b/apps/web/jsconfig.json
@@ -1,13 +1,19 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
+    // "checkJs": true,
     "baseUrl": ".",
+    "esModuleInterop": true,
+
     "paths": {
       "@src/*": ["src/*"],
       "@tests/*": ["tests/*"],
       "@tabulous/*": ["../*"]
     },
-    "strict": true
+    "sourceMap": true,
+    "strict": true,
+    "typeRoots": ["./src/types", "node_modules/@types"]
   },
   "exclude": ["./node_modules/**", "./coverage/**", "./test_results/**"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "test:integration": "pnpm test:integration:prepare && pnpm test:integration:run",
     "test:integration:prepare": "NODE_OPTIONS=--max-old-space-size=4096 vite build --mode integration",
     "test:integration:show": "playwright show-report coverage/integration",
-    "test:integration:run": "playwright test"
+    "test:integration:run": "playwright test",
+    "typecheck": "svelte-check --tsconfig jsconfig.json --compiler-warnings \"a11y-autofocus:ignore,a11y-no-noninteractive-element-interactions:ignore,a11y-no-static-element-interactions:ignore\""
   },
   "devDependencies": {
     "@atelier-wb/svelte": "^0.11.0",
@@ -44,6 +45,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
+    "@types/testing-library__jest-dom": "^5.14.9",
     "@urql/core": "^4.0.10",
     "@vitejs/plugin-basic-ssl": "^1.0.1",
     "accept-language-parser": "^1.5.0",
@@ -75,10 +77,12 @@
     "rfdc": "^1.3.0",
     "rxjs": "^7.8.1",
     "svelte": "^4.0.5",
+    "svelte-check": "^3.4.6",
     "svelte-htm": "^1.2.0",
     "svelte-intl": "^1.1.4",
     "svelte-markdown": "^0.2.3",
     "svelte-portal": "^2.2.0",
+    "svelte-windicss-preprocess": "^4.2.8",
     "v8-to-istanbul": "^9.1.0",
     "vite": "^4.4.2",
     "vite-plugin-windicss": "^1.9.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "atelier": "NODE_OPTIONS=--max-old-space-size=4096 vite build --mode export-atelier",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "prepare": "svelte-kit sync",
     "preview": "vite preview",
     "start": "vite dev --open https://localhost:3000",
     "test": "NODE_OPTIONS=--max-old-space-size=7000 vitest run --coverage",
@@ -14,7 +15,7 @@
     "test:integration:prepare": "NODE_OPTIONS=--max-old-space-size=4096 vite build --mode integration",
     "test:integration:show": "playwright show-report coverage/integration",
     "test:integration:run": "playwright test",
-    "typecheck": "svelte-check --tsconfig jsconfig.json --compiler-warnings \"a11y-autofocus:ignore,a11y-no-noninteractive-element-interactions:ignore,a11y-no-static-element-interactions:ignore\""
+    "typecheck": "svelte-kit sync && svelte-check --tsconfig jsconfig.json --compiler-warnings \"a11y-autofocus:ignore,a11y-no-noninteractive-element-interactions:ignore,a11y-no-static-element-interactions:ignore\""
   },
   "devDependencies": {
     "@atelier-wb/svelte": "^0.11.0",

--- a/apps/web/src/3d/behaviors/animatable.js
+++ b/apps/web/src/3d/behaviors/animatable.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Vector3} Vector3
+ * @typedef {import('@src/3d/utils').Vector3KeyFrame} Vector3KeyFrame
+ */
+
 import { Animation } from '@babylonjs/core/Animations/animation'
 import { Observable } from '@babylonjs/core/Misc/observable'
 
@@ -6,27 +13,23 @@ import { applyGravity } from '../utils/gravity'
 import { convertToLocal } from '../utils/vector'
 import { AnimateBehaviorName } from './names'
 
-/** @typedef {import('@babylonjs/core').Vector3} Vector3 */
-
 export class AnimateBehavior {
   /**
    * Creates behavior to make a mesh's position animatable.
    * It ignores any animations triggered while a previous animation is running.
-   *
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {boolean} isAnimated - true when this mesh is being animated.
-   * @property {number} frameRate - number of frames per second.
-   * @property {Observable} onAnimationEndObservable - emits when animation has ended.
-   *
    * @param {object} params - parameters, including:
    * @param {number} [params.frameRate=60] - number of frames per second.
    */
   constructor({ frameRate } = {}) {
+    /** @type {?Mesh} mesh - the related mesh. */
     this.mesh = null
+    /** @type {boolean} isAnimated - true when this mesh is being animated. */
     this.isAnimated = false
+    /** @type {number} frameRate - number of frames per second. */
     this.frameRate = frameRate ?? 60
+    /** @type {Observable<void>} onAnimationEndObservable - emits when animation has ended. */
     this.onAnimationEndObservable = new Observable()
-    // private
+    /** @type {Animation} */
     this.moveAnimation = new Animation(
       'move',
       'position',
@@ -34,6 +37,7 @@ export class AnimateBehavior {
       Animation.ANIMATIONTYPE_VECTOR3,
       Animation.ANIMATIONLOOPMODE_CONSTANT
     )
+    /** @type {Animation} */
     this.rotateAnimation = new Animation(
       'rotate',
       'rotation',
@@ -52,13 +56,13 @@ export class AnimateBehavior {
 
   /**
    * Does nothing.
-   * @see {@link import('@babylonjs/core').Behavior.init}
+   * @see https://doc.babylonjs.com/typedoc/interfaces/babylon.behavior#init
    */
   init() {}
 
   /**
    * Attaches this behavior to a mesh.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes detailable.
+   * @param {Mesh} mesh - which becomes detailable.
    */
   attach(mesh) {
     this.mesh = mesh
@@ -77,12 +81,11 @@ export class AnimateBehavior {
    * - applies gravity (if requested)
    * - returns
    * Does nothing if the mesh is already being animated.
-   *
-   * @async
    * @param {Vector3} to - the desired new absolute position.
-   * @param {Vector3} rotation - its final rotation (set to null to leave unmodified).
+   * @param {?Vector3} rotation - its final rotation (set to null to leave unmodified).
    * @param {number} duration - move duration (in milliseconds).
    * @param {boolean} [gravity=true] - applies gravity at the end.
+   * @returns {Promise<void>}
    */
   async moveTo(to, rotation, duration, gravity = true) {
     const { isAnimated, mesh, moveAnimation, rotateAnimation } = this
@@ -93,23 +96,23 @@ export class AnimateBehavior {
       {
         animation: moveAnimation,
         duration: mesh.getEngine().isLoading ? 0 : duration,
-        keys: [
+        keys: /** @type {Vector3KeyFrame[]} */ ([
           {
             frame: 0,
             values: convertToLocal(mesh.absolutePosition, mesh).asArray()
           },
           { frame: 100, values: convertToLocal(to, mesh).asArray() }
-        ]
+        ])
       }
     ]
     if (rotation) {
       frameSpecs.push({
         animation: rotateAnimation,
         duration: mesh.getEngine().isLoading ? 0 : duration,
-        keys: [
+        keys: /** @type {Vector3KeyFrame[]} */ ([
           { frame: 0, values: mesh.rotation.asArray() },
           { frame: 100, values: rotation.asArray() }
-        ]
+        ])
       })
     }
     await runAnimation(

--- a/apps/web/src/3d/behaviors/detailable.js
+++ b/apps/web/src/3d/behaviors/detailable.js
@@ -1,5 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').DetailableState} DetailableState
+ */
+
 import { controlManager } from '../managers/control'
-import { actionNames } from '../utils/actions'
 import {
   attachFunctions,
   attachProperty,
@@ -7,23 +12,15 @@ import {
 } from '../utils/behaviors'
 import { DetailBehaviorName } from './names'
 
-/**
- * @typedef {object} DetailableState behavior persistent state, including:
- * @property {string} frontImage - front image url.
- * @property {string} backImage - back image url.
- */
-
 export class DetailBehavior {
   /**
    * Creates behavior to get details of a mesh.
-   *
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {DetailableState} state - the behavior's current state.
-   *
    * @param {DetailableState} state - behavior state.
    */
-  constructor(state = {}) {
+  constructor(state = { frontImage: '' }) {
+    /** @type {?Mesh} mesh - the related mesh. */
     this.mesh = null
+    /**  @type {DetailableState} state - the behavior's current state. */
     this.state = state
   }
 
@@ -36,7 +33,7 @@ export class DetailBehavior {
 
   /**
    * Does nothing.
-   * @see {@link import('@babylonjs/core').Behavior.init}
+   * @see https://doc.babylonjs.com/typedoc/interfaces/babylon.behavior#init
    */
   init() {}
 
@@ -45,7 +42,7 @@ export class DetailBehavior {
    * - `frontImage` property.
    * - `backImage` property.
    * - the `detail()` method.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes detailable.
+   * @param {Mesh} mesh - which becomes detailable.
    */
   attach(mesh) {
     this.mesh = mesh
@@ -67,7 +64,7 @@ export class DetailBehavior {
     controlManager.onDetailedObservable.notifyObservers({
       mesh: this.mesh,
       data: {
-        image: selectDetailedFace(this.mesh)
+        image: /** @type {string} */ (selectDetailedFace(this.mesh))
       }
     })
   }
@@ -76,12 +73,12 @@ export class DetailBehavior {
    * Updates this behavior's state and mesh to match provided data.
    * @param {DetailableState} state - state to update to.
    */
-  fromState({ frontImage = null, backImage = null } = {}) {
+  fromState({ frontImage = '', backImage }) {
     if (!this.mesh) {
       throw new Error('Can not restore state without mesh')
     }
     this.state = { frontImage, backImage }
-    attachFunctions(this, actionNames.detail)
+    attachFunctions(this, 'detail')
     attachProperty(this, 'frontImage', () => this.state.frontImage)
     attachProperty(this, 'backImage', () => this.state.backImage)
   }

--- a/apps/web/src/3d/behaviors/flippable.js
+++ b/apps/web/src/3d/behaviors/flippable.js
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').FlippableState} FlippableState
+ */
+
 import { makeLogger } from '../../utils/logger'
 import { controlManager } from '../managers/control'
 import { actionNames } from '../utils/actions'
@@ -13,29 +19,21 @@ import { getDimensions } from '../utils/mesh'
 import { AnimateBehavior } from './animatable'
 import { FlipBehaviorName } from './names'
 
+/** @typedef {FlippableState & Required<Pick<FlippableState, 'duration'>>} RequiredFlippableState */
+
 const Tolerance = 0.000001
 
 const logger = makeLogger(FlipBehaviorName)
 
-/**
- * @typedef {object} FlippableState behavior persistent state, including:
- * @property {boolean} isFlipped - current flip status.
- * @property {number} [duration=500] - duration (in milliseconds) of the flip animation.
- */
-
 export class FlipBehavior extends AnimateBehavior {
   /**
    * Creates behavior to make a mesh flippable with animation.
-   *
-   * @extends {AnimateBehavior}
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {FlippableState} state - the behavior's current state.
-   *
    * @param {FlippableState} state - behavior state.
    */
   constructor(state = {}) {
-    super(state)
-    this.state = state
+    super()
+    /** @type {RequiredFlippableState} state - the behavior's current state. */
+    this.state = /** @type {RequiredFlippableState} */ (state)
   }
 
   /**
@@ -50,7 +48,7 @@ export class FlipBehavior extends AnimateBehavior {
    * - the `isFlipped` property.
    * - the `flip()` method.
    * It initializes its rotation according to the flip status.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes detailable.
+   * @param {Mesh} mesh - which becomes detailable.
    */
   attach(mesh) {
     super.attach(mesh)
@@ -64,8 +62,7 @@ export class FlipBehavior extends AnimateBehavior {
    * - applies gravity
    * - returns
    * Does nothing if the mesh is already being animated.
-   *
-   * @async
+   * @returns {Promise<void>}
    */
   async flip() {
     const {
@@ -80,7 +77,7 @@ export class FlipBehavior extends AnimateBehavior {
     }
     logger.debug({ mesh }, `start flipping ${mesh.id}`)
 
-    controlManager.record({ mesh, fn: actionNames.flip, duration })
+    controlManager.record({ mesh, fn: actionNames.flip, duration, args: [] })
 
     const attach = detachFromParent(mesh)
     const [x, y, z] = mesh.position.asArray()
@@ -136,7 +133,7 @@ export class FlipBehavior extends AnimateBehavior {
     const attach = detachFromParent(this.mesh)
     this.mesh.rotation.z = this.state.isFlipped ? Math.PI : 0
     attach()
-    attachFunctions(this, actionNames.flip)
+    attachFunctions(this, 'flip')
     attachProperty(this, 'isFlipped', () => this.state.isFlipped)
   }
 }

--- a/apps/web/src/3d/behaviors/movable.js
+++ b/apps/web/src/3d/behaviors/movable.js
@@ -1,38 +1,28 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').MovableState} MovableState
+ */
+
 import { moveManager } from '../managers/move'
 import { attachProperty } from '../utils/behaviors'
 import { AnimateBehavior } from './animatable'
 import { MoveBehaviorName } from './names'
 
-/**
- * @typedef {object} MovableState behavior persistent state, including:
- * @property {string} kind - drag kind, used to select targets.
- * @property {Point[]} partCenters? - when the mesh is made of several parts, a list of their centers.
- * @property {boolean} [snapDistance=0.25] - snap grid unit, in 3D world coordinate.
- * @property {number} [duration=100] - duration (in milliseconds) of the snap animation.
- */
-
-/**
- * @typedef {object} Point a coordinate in space
- * @property {number} x? - horizontal coordinate.
- * @property {number} y? - vertical coordinate.
- * @property {number} z? - depth coordinate.
- */
+/** @typedef {MovableState & Required<Pick<MovableState, 'duration'|'snapDistance'>>} RequiredMovableState */
 
 export class MoveBehavior extends AnimateBehavior {
   /**
    * Creates behavior to make a mesh movable, and droppable over target zones.
    * When moving mesh, its final position will snap to a virtual grid.
    * A mesh can only be dropped onto zones with the same kind.
-   *
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {boolean} enabled - activity status (true by default).
-   * @property {MovableState} state - the behavior's current state.
-   *
    * @param {MovableState} state - behavior state.
    */
   constructor(state = {}) {
-    super(state)
-    this.state = state
+    super()
+    /** @type {RequiredMovableState} state - the behavior's current state. */
+    this.state = /** @type {RequiredMovableState} */ (state)
+    /** @type {boolean} enabled - activity status (true by default). */
     this.enabled = true
   }
 
@@ -46,7 +36,7 @@ export class MoveBehavior extends AnimateBehavior {
   /**
    * Attaches this behavior to a mesh, registering it to the drag manager. Adds to the mesh metadata:
    * - `partCenters` property.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes movable.
+   * @param {Mesh} mesh - which becomes movable.
    */
   attach(mesh) {
     super.attach(mesh)

--- a/apps/web/src/3d/behaviors/names.js
+++ b/apps/web/src/3d/behaviors/names.js
@@ -1,3 +1,4 @@
+// @ts-check
 // we use constants instead of static class fields to break cyclic dependencies.
 // Keep this file free from @babylon (in)direct imports, to allow Svelte component referencing them
 // Otherwise this would bloat production chunks with Babylonjs (1.6Mb uncompressed)

--- a/apps/web/src/3d/behaviors/rotable.js
+++ b/apps/web/src/3d/behaviors/rotable.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').RotableState} RotableState
+ * @typedef {import('@src/3d/utils').Vector3KeyFrame} Vector3KeyFrame
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math'
 
 import { makeLogger } from '../../utils/logger'
@@ -14,15 +21,11 @@ import { convertToLocal, getAbsoluteRotation } from '../utils/vector'
 import { AnimateBehavior } from './animatable'
 import { RotateBehaviorName } from './names'
 
+/** @typedef {RotableState & Required<Pick<RotableState, 'duration'>>} RequiredRotableState */
+
 const logger = makeLogger('rotable')
 
 const rotationStep = Math.PI * 0.5
-
-/**
- * @typedef {object} RotableState behavior persistent state, including:
- * @property {number} angle - current rotation (in radian).
- * @property {number} [duration=200] - duration (in milliseconds) of the rotation animation.
- */
 
 export class RotateBehavior extends AnimateBehavior {
   /**
@@ -30,16 +33,11 @@ export class RotateBehavior extends AnimateBehavior {
    * It will add to this mesh's metadata:
    * - a `rotate()` function to rotate by 45°.
    * - a rotation `angle` (in radian).
-   *
-   * @extends {AnimateBehavior}
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {RotableState} state - the behavior's current state.
-   *
    * @param {RotableState} state - behavior state.
    */
   constructor(state = {}) {
-    super(state)
-    this._state = state
+    super()
+    this._state = /** @type {RequiredRotableState} */ (state)
   }
 
   /**
@@ -50,8 +48,7 @@ export class RotateBehavior extends AnimateBehavior {
   }
 
   /**
-   * Gets this behavior's state.
-   * @returns {RotableState} this behavior's state for serialization.
+   * @property {RequiredRotableState} state - this behavior's current state.
    */
   get state() {
     const angle = this.mesh
@@ -68,7 +65,7 @@ export class RotateBehavior extends AnimateBehavior {
    * When attaching/detaching this mesh to a parent, adjust rotation angle
    * according to the parent's own rotation, so that rotating the parent
    * will accordingly rotate the child.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes detailable.
+   * @param {Mesh} mesh - which becomes detailable.
    */
   attach(mesh) {
     super.attach(mesh)
@@ -83,7 +80,7 @@ export class RotateBehavior extends AnimateBehavior {
    * - returns
    * Does nothing if the mesh is already being animated.
    *
-   * @param {number} angle? - new rotation angle. When not set, adds PI/2 to the current rotation.
+   * @param {number} [angle] - new rotation angle. When not set, adds PI/2 to the current rotation.
    * @returns {Promise<void>}
    */
   async rotate(angle) {
@@ -133,7 +130,7 @@ export class RotateBehavior extends AnimateBehavior {
       {
         animation: moveAnimation,
         duration,
-        keys: [
+        keys: /** @type {Vector3KeyFrame[]} */ ([
           { frame: 0, values: [x, y, z] },
           {
             frame: 50,
@@ -143,7 +140,7 @@ export class RotateBehavior extends AnimateBehavior {
             ).asArray()
           },
           { frame: 100, values: [x, y, z] }
-        ]
+        ])
       }
     )
   }
@@ -161,7 +158,7 @@ export class RotateBehavior extends AnimateBehavior {
     this.mesh.setParent(null)
     this.mesh.rotation.y = angle
     this.mesh.setParent(parent)
-    attachFunctions(this, actionNames.rotate)
+    attachFunctions(this, 'rotate')
     attachProperty(this, 'angle', () => this.state.angle)
   }
 }

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -1,3 +1,21 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').Anchor} Anchor
+ * @typedef {import('@tabulous/server/src/graphql/types').StackableState} StackableState
+ * @typedef {import('@src/3d/behaviors/animatable').AnimateBehavior} AnimateBehavior
+ * @typedef {import('@src/3d/behaviors/targetable').DropDetails} DropDetails
+ * @typedef {import('@src/3d/managers/control').Action} Action
+ * @typedef {import('@src/3d/managers/control').Move} Move
+ * @typedef {import('@src/3d/managers/move').MoveDetails} MoveDetails
+ * @typedef {import('@src/3d/managers/target').SingleDropZone} SingleDropZone
+ * @typedef {import('@src/3d/utils').Vector3KeyFrame} Vector3KeyFrame
+ */
+/**
+ * @template T
+ * @typedef {import('@babylonjs/core').Observer<T>} Observer
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 
 import { makeLogger } from '../../utils/logger'
@@ -34,17 +52,10 @@ import {
 } from './names'
 import { TargetBehavior } from './targetable'
 
-const logger = makeLogger('stackable')
+/** @typedef {StackableState & Required<Pick<StackableState, 'duration'|'extent'>> & Required<Pick<Anchor, 'ignoreParts'>>} RequiredStackableState */
+/** @typedef {StackBehavior & { mesh: Mesh }} AttachedStackBehavior */
 
-/**
- * @typedef {object} StackableState behavior persistent state, including:
- * @property {string[]} stackIds - array of stacked mesh ids, not including the current mesh if alone.
- * @property {string[]} kinds? - an optional array of allowed drag kinds for this zone (allows all if not specified).
- * @property {number} priority? - priority applied when multiple targets with same altitude apply.
- * @property {number} [duration=100] - duration (in milliseconds) when pushing or shuffling individual meshes.
- * @property {number} [extent=2] - allowed distance between mesh and stack center when dropping.
- * @property {number} angle? - angle, in Radian, applied to the stacked mesh.
- */
+const logger = makeLogger('stackable')
 
 export class StackBehavior extends TargetBehavior {
   /**
@@ -53,25 +64,30 @@ export class StackBehavior extends TargetBehavior {
    * Once a mesh is stacked bellow others, it can not be moved independently, and its targets and anchors are disabled.
    * Only the highest mesh on stack can be moved (it is automatically poped out) and be targeted.
    *
-   * @extends {TargetBehavior}
-   * @property {import('@babylonjs/core').Mesh} mesh - the related mesh.
-   * @property {import('@babylonjs/core').Mesh[]} stack - array of meshes (initially contains this mesh).
    * @property {StackableState} state - the behavior's current state.
    *
    * @param {StackableState} state - behavior state.
    */
   constructor(state = {}) {
     super()
-    this._state = state
+    /** @type {RequiredStackableState} */
+    this._state = /** @type {RequiredStackableState} */ (state)
+    /** @type {Mesh[]} array of meshes (initially contains this mesh). */
     this.stack = []
-    // private
-    this.moveObserver = null
-    this.dropObserver = null
-    this.actionObserver = null
-    this.base = null
+    /** @type {boolean} */
     this.inhibitControl = false
-    this.dropZone = null
+    /** @internal @type {?AttachedStackBehavior} */
+    this.base = null
+    /** @protected @type {?Observer<MoveDetails>} */
+    this.moveObserver = null
+    /** @protected @type {?Observer<DropDetails>} */
+    this.dropObserver = null
+    /** @protected @type {?Observer<Action|Move>} */
+    this.actionObserver = null
+    /** @protected @type {boolean} */
     this.isReordering = false
+    /** @protected @type {SingleDropZone}} */
+    this.dropZone
   }
 
   /**
@@ -91,7 +107,7 @@ export class StackBehavior extends TargetBehavior {
    * - a `canPush()` function to determin whether a mesh could be pushed on this stack.
    * It binds to its drop observable to push dropped meshes to the stack.
    * It binds to the drag manager drag observable to pop the first stacked mesh when dragging it.
-   * @param {import('@babylonjs/core').Mesh} mesh - which becomes detailable.
+   * @param {Mesh} mesh - which becomes detailable.
    */
   attach(mesh) {
     super.attach(mesh)
@@ -126,8 +142,13 @@ export class StackBehavior extends TargetBehavior {
           stack.length > 1 &&
           stack[stack.length - 1].id === meshId
         ) {
-          const poped = stack.pop()
-          setStatus([poped], 0, true, setBase(poped, null, [poped]))
+          const poped = /** @type {Mesh} */ (stack.pop())
+          setStatus(
+            [poped],
+            0,
+            true,
+            /** @type {StackBehavior} */ (setBase(poped, null, [poped]))
+          )
           setStatus(stack, stack.length - 1, true, this)
         }
       }
@@ -146,7 +167,7 @@ export class StackBehavior extends TargetBehavior {
 
   /**
    * Determines whether a movable mesh can be stack onto this mesh (or its stack).
-   * @param {import('@babel/core').Mesh} mesh - tested (movable) mesh.
+   * @param {Mesh} mesh - tested (movable) mesh.
    * @returns {boolean} true if this mesh can be stacked.
    */
   canPush(mesh) {
@@ -157,7 +178,7 @@ export class StackBehavior extends TargetBehavior {
             this.dropZone,
             mesh.getBehaviorByName(MoveBehaviorName)?.state.kind
           )
-      : last?.getBehaviorByName(StackBehaviorName).canPush(mesh) ?? false
+      : last?.getBehaviorByName(StackBehaviorName)?.canPush(mesh) ?? false
   }
 
   /**
@@ -168,16 +189,17 @@ export class StackBehavior extends TargetBehavior {
    * - runs a move animation with gravity until completion
    * - updates the base stack array
    * Does nothing if the mesh is already on stack (or unknown).
-   *
-   * @async
    * @param {string} meshId - id of the pushed mesh.
    * @param {boolean} [immediate=false] - set to true to disable animation.
+   * @returns {Promise<void>}
    */
   async push(meshId, immediate = false) {
-    const mesh = this.stack[0].getScene().getMeshById(meshId)
+    const mesh = /** @type {?Mesh} */ (
+      this.stack[0].getScene().getMeshById(meshId)
+    )
     if (!mesh || this.stack.includes(mesh)) return
 
-    const base = this.base ?? this
+    const base = /** @type {AttachedStackBehavior} */ (this.base ?? this)
     const { stack } = base
     const duration = this.inhibitControl || immediate ? 0 : this._state.duration
     const { angle } = this._state
@@ -195,7 +217,7 @@ export class StackBehavior extends TargetBehavior {
     // when hydrating, we must break existing stacks, because they are meant to be broken by serialization
     // otherwise we may push a stack onto itself, which would lead to a Maximum call stack size exceeded error in Mesh.computWorldMatrix()
     const meshPushed = (!this.inhibitControl
-      ? getTargetableBehavior(mesh)?.stack
+      ? /** @type {?StackBehavior} */ (getTargetableBehavior(mesh))?.stack
       : undefined) ?? [mesh]
     const pushed = meshPushed[0]
     const y =
@@ -247,13 +269,12 @@ export class StackBehavior extends TargetBehavior {
    * - enables new highest mesh's targets and moves
    * - updates stack indicators
    * - records the action into the control manager
-   *
-   * @async
    * @param {number} [count=1] - number of mesh poped
    * @param {boolean} [withMove=false] - when set to true, moves the poped meshes aside the stack.
-   * @return {import('@babylonjs/core').Mesh[]} the poped meshes, if any.
+   * @returns {Promise<Mesh[]>} the poped meshes, if any.
    */
   async pop(count = 1, withMove = false) {
+    /** @type {Mesh[]} */
     const poped = []
     const stack = this.base?.stack ?? this.stack
     if (stack.length <= 1) return poped
@@ -263,7 +284,7 @@ export class StackBehavior extends TargetBehavior {
     const duration = withMove ? this._state.duration : undefined
     const limit = Math.min(count, stack.length - 1)
     for (let times = 0; times < limit; times++) {
-      const mesh = stack.pop()
+      const mesh = /** @type {Mesh} */ (stack.pop())
       poped.push(mesh)
       setBase(mesh, null, [mesh])
       updateIndicator(mesh, 0)
@@ -280,7 +301,7 @@ export class StackBehavior extends TargetBehavior {
             mesh,
             mesh.absolutePosition.add(new Vector3(shift, 0, 0)),
             null,
-            duration,
+            /** @type {number} */ (duration),
             true
           )
         )
@@ -314,21 +335,20 @@ export class StackBehavior extends TargetBehavior {
    * - moves each mesh to their final position, applying gravity, with no animation
    * - (when requested) moves in parallel all meshes to "explode" the stack and wait until they complete
    * - (when requestd) moves in serie all meshes to their final position and wait until completion
-   *
-   * @async
    * @param {string[]} ids - array or mesh ids givin the new order.
    * @param {boolean} [animate = true] - enables visual animation
+   * @returns {Promise<void>}
    */
   async reorder(ids, animate = true) {
     const old = this.base?.stack ?? this.stack
     if (
       old.length <= 1 ||
-      old[0].getBehaviorByName(StackBehaviorName).isReordering
+      old[0]?.getBehaviorByName(StackBehaviorName)?.isReordering
     )
       return
 
     const posById = new Map(old.map(({ id }, i) => [id, i]))
-    const stack = ids.map(id => old[posById.get(id)])
+    const stack = ids.map(id => old[posById.get(id) ?? -1]).filter(Boolean)
 
     controlManager.record({
       mesh: old[0],
@@ -369,7 +389,10 @@ export class StackBehavior extends TargetBehavior {
         mesh.setAbsolutePosition(position)
         newPositions.push(position)
       }
-      mesh.getBehaviorByName(StackBehaviorName).isReordering = true
+      const behavior = /** @type {StackBehavior} */ (
+        mesh.getBehaviorByName(StackBehaviorName)
+      )
+      behavior.isReordering = true
       last = mesh
     }
 
@@ -381,11 +404,14 @@ export class StackBehavior extends TargetBehavior {
       const interval = this._state.duration * 0.2
 
       // first, explode
+      /** @type {{x:number, y:number, z:number, pitch:number, yaw:number, roll:number }[]} */
       const positionsAndRotations = []
       const shift = getDimensions(stack[0]).width * 0.75
       await Promise.all(
         stack.slice(1).map((mesh, rank) => {
-          const behavior = getAnimatableBehavior(mesh)
+          const behavior = /** @type {AnimateBehavior} */ (
+            getAnimatableBehavior(mesh)
+          )
           const [x, y, z] = mesh.position.asArray()
           const [pitch, yaw, roll] = mesh.rotation.asArray()
           positionsAndRotations.push({ x, y, z, pitch, yaw, roll })
@@ -438,7 +464,9 @@ export class StackBehavior extends TargetBehavior {
       // then restore
       await Promise.all(
         stack.slice(1).map((mesh, rank) => {
-          const behavior = getAnimatableBehavior(mesh)
+          const behavior = /** @type {AnimateBehavior} */ (
+            getAnimatableBehavior(mesh)
+          )
           const { x, y, z, pitch, yaw, roll } = positionsAndRotations[rank++]
           return sleep(rank * interval).then(() =>
             runAnimation(
@@ -447,18 +475,18 @@ export class StackBehavior extends TargetBehavior {
               {
                 animation: behavior.rotateAnimation,
                 duration: restoreDuration,
-                keys: [
+                keys: /** @type {Vector3KeyFrame[]} */ ([
                   { frame: 0, values: mesh.rotation.asArray() },
                   { frame: 100, values: [pitch, yaw, roll] }
-                ]
+                ])
               },
               {
                 animation: behavior.moveAnimation,
                 duration: restoreDuration,
-                keys: [
+                keys: /** @type {Vector3KeyFrame[]} */ ([
                   { frame: 0, values: mesh.position.asArray() },
                   { frame: 100, values: [x, y, z] }
-                ]
+                ])
               }
             )
           )
@@ -468,7 +496,10 @@ export class StackBehavior extends TargetBehavior {
     for (const mesh of stack) {
       mesh.isPickable = true
       mesh.isHittable = true
-      mesh.getBehaviorByName(StackBehaviorName).isReordering = false
+      const behavior = /** @type {StackBehavior} */ (
+        mesh.getBehaviorByName(StackBehaviorName)
+      )
+      behavior.isReordering = false
     }
   }
 
@@ -480,12 +511,17 @@ export class StackBehavior extends TargetBehavior {
    * When the base mesh is flipped, re-ordering happens first so the highest mesh doesn't change after flipping.
    *
    * Controllable meshes are unregistered during the operation to avoid triggering individual actions
-   * @async
+   * @returns {Promise<void>}
    */
   async flipAll() {
     const base = this.base ?? this
-    controlManager.record({ mesh: base.stack[0], fn: actionNames.flipAll })
+    controlManager.record({
+      mesh: base.stack[0],
+      fn: actionNames.flipAll,
+      args: []
+    })
 
+    /** @type {Mesh[]} */
     const ignored = []
     for (const mesh of base.stack) {
       if (controlManager.isManaging(mesh)) {
@@ -566,18 +602,17 @@ export class StackBehavior extends TargetBehavior {
     }
     this.inhibitControl = false
     this.isReordering = false
-    attachFunctions(
-      this,
-      actionNames.push,
-      actionNames.pop,
-      actionNames.reorder,
-      actionNames.flipAll,
-      'canPush'
-    )
+    attachFunctions(this, 'push', 'pop', 'reorder', 'flipAll', 'canPush')
     attachProperty(this, 'stack', () => this.stack)
   }
 }
 
+/**
+ * @param {Mesh[]} stack - stack of meshes.
+ * @param {number} rank - rank of the updated mesh in the stack.
+ * @param {boolean} enabled - new status applied.
+ * @param {StackBehavior} behavior - current stack behavior
+ */
 function setStatus(stack, rank, enabled, behavior) {
   const operation = enabled ? 'enable' : 'disable'
   const mesh = stack[rank]
@@ -605,8 +640,16 @@ function setStatus(stack, rank, enabled, behavior) {
   updateIndicator(mesh, enabled ? stack.length : 0)
 }
 
+/**
+ * @param {Mesh} mesh - updated mesh.
+ * @param {?AttachedStackBehavior} base - base behavior applied.
+ * @param {Mesh[]} stack - stack applied.
+ * @returns {?AttachedStackBehavior}
+ */
 function setBase(mesh, base, stack) {
-  const targetable = getTargetableBehavior(mesh)
+  const targetable = /** @type {?AttachedStackBehavior} */ (
+    getTargetableBehavior(mesh)
+  )
   if (targetable) {
     targetable.base = base
     targetable.stack = stack
@@ -615,6 +658,10 @@ function setBase(mesh, base, stack) {
   return targetable
 }
 
+/**
+ * @param {Mesh} mesh - concerned mesh.
+ * @param {number} size - stack size.
+ */
 function updateIndicator(mesh, size) {
   const id = `${mesh.id}.stack-size`
   if (size > 1) {
@@ -624,10 +671,17 @@ function updateIndicator(mesh, size) {
   }
 }
 
+/**
+ * @param {StackBehavior} behavior - concerned stack behavior.
+ */
 function invertStack(behavior) {
   behavior.reorder(behavior.stack.map(({ id }) => id).reverse(), false)
 }
 
+/**
+ * @param {Mesh[]} stack - stack of meshes
+ * @returns {number} altritude above the stack.
+ */
 function getFinalAltitudeAboveStack(stack) {
   let y = stack[0].absolutePosition.y - getDimensions(stack[0]).height * 0.5
   for (const mesh of stack) {

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -194,9 +194,7 @@ export class StackBehavior extends TargetBehavior {
    * @returns {Promise<void>}
    */
   async push(meshId, immediate = false) {
-    const mesh = /** @type {?Mesh} */ (
-      this.stack[0].getScene().getMeshById(meshId)
-    )
+    const mesh = this.stack[0].getScene().getMeshById(meshId)
     if (!mesh || this.stack.includes(mesh)) return
 
     const base = /** @type {AttachedStackBehavior} */ (this.base ?? this)

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -346,6 +346,7 @@ export class StackBehavior extends TargetBehavior {
       return
 
     const posById = new Map(old.map(({ id }, i) => [id, i]))
+    /** @type {Mesh[]} */
     const stack = ids.map(id => old[posById.get(id) ?? -1]).filter(Boolean)
 
     controlManager.record({
@@ -651,7 +652,15 @@ function setBase(mesh, base, stack) {
   if (targetable) {
     targetable.base = base
     targetable.stack = stack
-    mesh.setParent(base?.mesh ?? null)
+    if (base) {
+      mesh.setParent(base.mesh)
+    } else if (
+      mesh.parent &&
+      stack.includes(/** @type {Mesh} */ (mesh.parent))
+    ) {
+      // only reset's mesh parent if it is in the stack
+      mesh.setParent(null)
+    }
   }
   return targetable
 }

--- a/apps/web/src/3d/index.js
+++ b/apps/web/src/3d/index.js
@@ -1,1 +1,2 @@
+// @ts-check
 export * from './engine'

--- a/apps/web/src/3d/managers/control.js
+++ b/apps/web/src/3d/managers/control.js
@@ -1,28 +1,43 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@tabulous/server/src/graphql/types').ZoomSpec} ZoomSpec
+ * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+ * @typedef {import('@src/3d/utils').ScreenPosition} ScreenPosition
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { Observable } from '@babylonjs/core/Misc/observable.js'
 
 import { actionNames } from '../utils/actions'
 
 /**
- * @typedef {object} Action applied action to a given mesh:
+ * @typedef {object} _Action
  * @property {string} meshId - modified mesh id.
- * @property {string} fn? - optionnal name of the applied action (default to 'pos').
- * @property {any[]} args? - optional argument array for this action.
- * @property {number} duration? - optional animation duration, in milliseconds.
- * @property {boolean} fromHand? - indicates whether this action comes from hand or main scene.
- */
-
-/**
+ * @property {boolean} fromHand - indicates whether this action comes from hand or main scene.
+ *
+ * @typedef {Omit<RecordedAction, 'mesh'> & _Action & { pos: undefined }} Action applied action to a given mesh.
+ *
+ * @typedef {object} _Move applied move to a given mesh:
+ * @property {string} meshId - modified mesh id.
+ * @property {boolean} fromHand - indicates whether this action comes from hand or main scene.
+ *
+ * @typedef {Omit<RecordedMove, 'mesh'> & _Move & { fn: undefined, args: undefined }} Move applied move to a given mesh.
+ *
  * @typedef {object} RecordedAction applied action to a given mesh:
- * @property {import('@babylonjs/core').Mesh} mesh - modified mesh.
- * @property {string} fn? - optionnal name of the applied action (default to 'pos').
- * @property {any[]} args? - optional argument array for this action.
- * @property {number} duration? - optional animation duration, in milliseconds.
- */
-
-/**
+ * @property {Mesh} mesh - modified mesh.
+ * @property {string} fn - name of the applied action.
+ * @property {any[]} args - argument array for this action.
+ * @property {number} [duration] - optional animation duration, in milliseconds.
+ *
+ * @typedef {object} RecordedMove applied action to a given mesh:
+ * @property {Mesh} mesh - modified mesh.
+ * @property {number[]} pos - absolute position.
+ * @property {number} [duration] - optional animation duration, in milliseconds.
+ *
  * @typedef {object} MeshDetails details of a given mesh.
- * @property {import('@babylonjs/core').Mesh} mesh - the detailed mesh.
+ * @property {Mesh} mesh - the detailed mesh.
  * @property {object} data - detailed data, including:
  * @property {string} data.image? - image for that mesh.
  */
@@ -33,21 +48,23 @@ class ControlManager {
    * - applies actions received to specific meshes
    * - propagates applied actions to observers (with cycle breaker)
    * Clears all observers on scene disposal.
-   *
-   * @property {Observable<Action>} onActionObservable - emits applied actions.
-   * @property {Observable<MeshDetails>} onDetailedObservable - emits when displaying details of a given mesh.
-   * @property {Observable<Map<String, import('@babylonjs/core').Mesh>>} onControlledObservable - emits the list of controlled meshes.
    */
   constructor() {
+    /** @type {Observable<Action|Move>} emits applied actions. */
     this.onActionObservable = new Observable()
+    /** @type {Observable<MeshDetails>} emits when displaying details of a given mesh. */
     this.onDetailedObservable = new Observable()
+    /** @type {Observable<Map<String, Mesh>>} emits the list of controlled meshes. */
     this.onControlledObservable = new Observable()
 
-    // private
+    /** @private @type {?Scene} */
     this.scene = null
+    /** @private @type {?Scene} */
     this.handScene = null
+    /** @private @type {Map<string, Mesh>} */
     this.controlables = new Map()
     // prevents loops when applying an received action
+    /** @private @type {Set<string>} */
     this.inhibitedKeys = new Set()
   }
 
@@ -70,7 +87,7 @@ class ControlManager {
   /**
    * Registers a new controllable mesh.
    * Does nothing if this mesh is already managed.
-   * @param {import('@babel/core').Mesh} mesh - controled mesh (needs at least an id property).
+   * @param {Mesh} mesh - controled mesh (needs at least an id property).
    */
   registerControlable(mesh) {
     this.controlables.set(mesh.id, mesh)
@@ -85,7 +102,7 @@ class ControlManager {
   /**
    * Unregisters a controlled mesh.
    * Does nothing on unmanaged mesh.
-   * @param {import('@babel/core').Mesh} mesh - controlled mesh (needs at least an id property).
+   * @param {Mesh} mesh - controlled mesh (needs at least an id property).
    */
   unregisterControlable(mesh) {
     if (this.controlables.delete(mesh?.id)) {
@@ -94,7 +111,7 @@ class ControlManager {
   }
 
   /**
-   * @param {import('@babel/core').Mesh} mesh - tested mesh
+   * @param {Mesh} mesh - tested mesh
    * @returns {boolean} whether this mesh is controlled or not
    */
   isManaging(mesh) {
@@ -104,20 +121,23 @@ class ControlManager {
   /**
    * Records an actions from one of the controlled meshes, and notifies observers.
    * Does nothing if the source mesh is not controlled.
-   * @param {RecordedAction} action - recorded action.
+   * @param {RecordedAction|RecordedMove} action - recorded action.
    */
-  record(action = {}) {
+  record(action) {
     const { mesh, ...actionProps } = action
     if (
       !this.inhibitedKeys.has(getKey({ meshId: mesh?.id, ...actionProps })) &&
       this.isManaging(mesh)
     ) {
       this.onActionObservable.notifyObservers({
+        pos: undefined,
+        fn: undefined,
+        args: undefined,
         ...actionProps,
         meshId: mesh.id,
         fromHand:
           this.handScene === mesh.getScene() &&
-          actionProps.fn !== actionNames.draw
+          /** @type {RecordedAction} */ (actionProps).fn !== actionNames.draw
       })
       this.onControlledObservable.notifyObservers(this.controlables)
     }
@@ -127,9 +147,9 @@ class ControlManager {
    * Applies an actions to a controlled meshes (`fn` in its metadatas), or changes its position (action.pos is defined).
    * Does nothing if the target mesh is not controlled.
    * Returns when the action is fully applied.
-   * @async
-   * @param {Action} action - applied action.
+   * @param {Action|Move} action - applied action.
    * @param {boolean} fromPeer - true to indicate this action comes from a remote peer.
+   * @returns {Promise<void>}
    */
   async apply(action, fromPeer = false) {
     const mesh = this.controlables.get(action?.meshId)
@@ -156,6 +176,10 @@ class ControlManager {
  */
 export const controlManager = new ControlManager()
 
+/**
+ * @param {Partial<Pick<Action, 'meshId'|'fn'>>} action - keyed action
+ * @returns {string} key for this action
+ */
 function getKey(action) {
   return `${action?.meshId}-${action.fn?.toString() || 'pos'}`
 }

--- a/apps/web/src/3d/managers/indicator.js
+++ b/apps/web/src/3d/managers/indicator.js
@@ -1,3 +1,14 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Animatable} Animatable
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+ * @typedef {import('@tabulous/server/src/graphql/types').ZoomSpec} ZoomSpec
+ * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+ * @typedef {import('@src/3d/utils').ScreenPosition} ScreenPosition
+ */
+
 import { BoundingBox } from '@babylonjs/core/Culling/boundingBox.js'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { Observable } from '@babylonjs/core/Misc/observable.js'
@@ -6,32 +17,62 @@ import { makeLogger } from '../../utils/logger'
 import { getDimensions } from '../utils/mesh'
 import { getMeshScreenPosition, getScreenPosition } from '../utils/vector'
 
-const logger = makeLogger('indicator')
+/**
+ * @typedef {object} MeshSizeIndicator indicates the size (or quantity) of a given mesh.
+ * @property {string} id - indicator unique id.
+ * @property {Mesh} mesh - concerned mesh.
+ * @property {number} size - size displayed.
+ */
 
 /**
- * Details of an indicator (could be for a mesh, or peer pointer).
- * Other properties can be used to convey specific data (like mesh, playerId...).
- * Feedback are special, temporary indicators. The manager assign them a unique id, and will not notify
- * them only once. `getById()` on a feedback will always return false.
- * @typedef {object} Indicator
- * @property {string} id - unique id for this indicator.
- * @property {import('../utils').ScreenPosition} screenPosition - 2D position.
- * @property {boolean} isFeedback - indicates temporary feedback.
+ * @typedef {object} MeshPlayerIndicator indicates belonging to a specific player.
+ * @property {string} id - indicator unique id.
+ * @property {Mesh} mesh - concerned mesh.
+ * @property {string} playerId - id of the related player.
  */
+
+/**
+ * @typedef {object} PointerIndicator another player's pointer position.
+ * @property {number[]} position - pointer 3D coordinates.
+ * @property {string} playerId - id of the related player.
+ */
+
+/**
+ * @typedef {object} FeedbackIndicator temporary feedback for a given action.
+ * @property {ActionName|'unlock'|'lock'} action - the related action
+ * @property {number[]} position - feedback position in 3D coordinates.
+ * @property {string} [playerId] - id of the related player, if any.
+ */
+
+/**
+ * @typedef {object} _ManagedIndicator
+ * @property {string} id - indicator unique id.
+ * @property {ScreenPosition} screenPosition - 2D position in pixels.
+ * @property {boolean} [isFeedback] - indicates temporary feedback.
+ *
+ * @typedef {(MeshSizeIndicator|MeshPlayerIndicator) & _ManagedIndicator} ManagedIndicator indicator managed by this manager.
+ * @typedef {PointerIndicator & _ManagedIndicator} ManagedPointer pointer managed by this manager.
+ * @typedef {FeedbackIndicator & _ManagedIndicator} ManagedFeedback feedback managed by this manager.
+ */
+
+/** @typedef {ManagedIndicator|ManagedPointer|ManagedFeedback} Indicator */
+
+const logger = makeLogger('indicator')
 
 class IndicatorManager {
   /**
    * Creates a manager for indications above meshes.
-   *
-   * @property {import('@babylon/core').Scene} scene? - main scene.
-   * @property {Observable<Indicator[]>} onChangeObservable - emits when the indicator list has changed.
    */
   constructor() {
-    this.scene = null
+    /** @type {Scene} the main scene. */
+    this.scene
+    /** @type {Observable<Indicator[]>} emits when the indicator list has changed. */
     this.onChangeObservable = new Observable()
-    // private
+    /** @internal @type {Map<string, ManagedIndicator|ManagedPointer>} a map of displayed indicator by their id. */
     this.indicators = new Map()
+    /** @internal @type {Map<string, ManagedPointer>} a map of pointers by their player id. */
     this.pointerByPlayerId = new Map()
+    /** @internal @type {?() => void} */
     this.unsubscribeOnRender = null
   }
 
@@ -53,14 +94,14 @@ class IndicatorManager {
       this.indicators.clear()
       this.pointerByPlayerId.clear()
     }
-    engine.onDisposeObservable.addOnce(() => this.unsubscribeOnRender())
+    engine.onDisposeObservable.addOnce(() => this.unsubscribeOnRender?.())
   }
 
   /**
    * Registers an indicator for a given mesh.
    * Does nothing if this indicator is already managed.
-   * @param {Indicator} indicator - new indicator.
-   * @returns {Indicator} the registered indicator.
+   * @param {MeshPlayerIndicator|MeshSizeIndicator} indicator - new size or player indicator.
+   * @returns {ManagedIndicator} the registered indicator.
    */
   registerMeshIndicator(indicator) {
     const existing = this.getById(indicator?.id)
@@ -69,23 +110,31 @@ class IndicatorManager {
         this.unregisterIndicator(indicator)
       )
     }
-    this.indicators.set(indicator.id, indicator)
-    setMeshPosition(indicator)
+    this.indicators.set(
+      indicator.id,
+      /** @type {ManagedIndicator} */ (indicator)
+    )
+    setMeshPosition(/** @type {ManagedIndicator} */ (indicator))
     logger.debug({ indicator }, `registers indicator ${indicator.id}`)
     notifyChange(this)
-    return indicator
+    return /** @type {ManagedIndicator} */ (indicator)
   }
 
   /**
    * Registers an indicator for a given player.
    * @param {string} playerId - id of the corresponding player.
    * @param {number[]} position - Vector3 components describing the pointer position in 3D engine.
-   * @returns {Indicator} the registered indicator.
+   * @returns {ManagedPointer} the registered indicator.
    */
   registerPointerIndicator(playerId, position) {
     let indicator = this.pointerByPlayerId.get(playerId)
     if (!indicator) {
-      indicator = { id: `pointer-${playerId}`, playerId, position }
+      indicator = {
+        id: `pointer-${playerId}`,
+        playerId,
+        position,
+        screenPosition: { x: 0, y: 0 }
+      }
       this.indicators.set(indicator.id, indicator)
       logger.debug({ indicator }, `registers pointer ${indicator.id}`)
       this.pointerByPlayerId.set(playerId, indicator)
@@ -99,22 +148,24 @@ class IndicatorManager {
 
   /**
    * Registers a temporary indicator, or feedback.
-   * @param {Indicator} indicator
+   * Feedback gets a random id, but can not be retrieved with getById() or isManaged()
+   * @param {FeedbackIndicator} indicator - the feedback registered.
    */
   registerFeedback(indicator) {
     if (Array.isArray(indicator?.position)) {
-      indicator.id = crypto.randomUUID()
-      indicator.isFeedback = true
+      const managedIndicator = /** @type {ManagedFeedback} */ (indicator)
+      managedIndicator.id = crypto.randomUUID()
+      managedIndicator.isFeedback = true
       logger.debug({ indicator }, `registers feedback`)
-      setPointerPosition(indicator, this)
-      notifyChange(this, [indicator, ...this.indicators.values()])
+      setPointerPosition(managedIndicator, this)
+      notifyChange(this, [managedIndicator, ...this.indicators.values()])
     }
   }
 
   /**
    * Unregisters an indicator.
    * Does nothing on a unknown indicator.
-   * @param {Indicator} indicator - controlled indicator.
+   * @param {Pick<ManagedIndicator, 'id'>} indicator - managed indicator or pointer
    */
   unregisterIndicator(indicator) {
     if (this.indicators.delete(indicator?.id)) {
@@ -124,7 +175,7 @@ class IndicatorManager {
   }
 
   /**
-   * @param {Indicator} indicator - tested indicator
+   * @param {Pick<ManagedIndicator, 'id'>} indicator - tested indicator
    * @returns {boolean} whether this indicator is controlled or not
    */
   isManaging(indicator) {
@@ -132,11 +183,11 @@ class IndicatorManager {
   }
 
   /**
-   * @param {string} id - requested indicator id.
-   * @returns {Indicator?} the indicator found, if any.
+   * @param {string} [id] - requested indicator id.
+   * @returns {ManagedIndicator|ManagedPointer|undefined} the indicator found, if any.
    */
   getById(id) {
-    return this.indicators.get(id)
+    return id ? this.indicators.get(id) : undefined
   }
 
   /**
@@ -159,10 +210,13 @@ class IndicatorManager {
  */
 export const indicatorManager = new IndicatorManager()
 
+/**
+ * @param {IndicatorManager} manager - manager instance
+ */
 function handleFrame(manager) {
   let hasChanged = false
   for (const [, indicator] of manager.indicators) {
-    if (indicator.mesh) {
+    if ('mesh' in indicator) {
       hasChanged = setMeshPosition(indicator) || hasChanged
     } else {
       hasChanged = setPointerPosition(indicator, manager) || hasChanged
@@ -173,9 +227,15 @@ function handleFrame(manager) {
   }
 }
 
+/**
+ * @param {ManagedIndicator} indicator - updated indicator.
+ * @returns {boolean} if this indicator position has changed.
+ */
 function setMeshPosition(indicator) {
   const { depth } = getDimensions(indicator.mesh)
-  const { x, y } = getMeshScreenPosition(indicator.mesh, [0, 0, depth / 2])
+  const { x, y } = /** @type {ScreenPosition} */ (
+    getMeshScreenPosition(indicator.mesh, [0, 0, depth / 2])
+  )
   const hasChanged =
     x !== indicator.screenPosition?.x || y !== indicator.screenPosition?.y
   if (hasChanged) {
@@ -184,6 +244,11 @@ function setMeshPosition(indicator) {
   return hasChanged
 }
 
+/**
+ * @param {ManagedPointer|ManagedFeedback} indicator - updated indicator.
+ * @param {IndicatorManager} manager - instance manager.
+ * @returns {boolean} if this indicator position has changed.
+ */
 function setPointerPosition(indicator, { scene }) {
   const { x, y } = getScreenPosition(
     scene,
@@ -197,6 +262,11 @@ function setPointerPosition(indicator, { scene }) {
   return hasChanged
 }
 
+/**
+ * @param {IndicatorManager} manager - instance manager.
+ * @param {Iterable<Indicator>} [indicators] - indicator to notify (default to all managed indicators).
+ * @param {boolean} [notifyEmpty=false] - also send notification when there are no indicators.
+ */
 function notifyChange(
   manager,
   indicators = manager.indicators.values(),
@@ -213,7 +283,15 @@ function notifyChange(
   }
 }
 
-function isInFrustum({ scene }, { mesh, position }) {
-  let point = mesh?.getAbsolutePosition() ?? Vector3.FromArray(position)
+/**
+ * @param {IndicatorManager} manager - manager instance.
+ * @param {Indicator} indicator - checked indicator.
+ * @returns {boolean} whether this indicator is in the current camera frustum.
+ */
+function isInFrustum({ scene }, indicator) {
+  let point =
+    'mesh' in indicator
+      ? indicator.mesh.getAbsolutePosition()
+      : Vector3.FromArray(indicator.position)
   return scene?.cameras[0]?.isInFrustum(new BoundingBox(point, point)) ?? false
 }

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -73,9 +73,7 @@ class MaterialManager {
    */
   configure(mesh, texture) {
     const scene = mesh.getScene()
-    const materialByUrl = getMaterialCache(this, scene)
-    mesh.material =
-      materialByUrl.get(texture) ?? buildMaterials(this, texture, scene)
+    mesh.material = buildMaterials(this, texture, scene)
     mesh.receiveShadows = true
   }
 
@@ -87,10 +85,7 @@ class MaterialManager {
    * @returns {PBRSpecularGlossinessMaterial} the build (or cached) material.
    */
   buildOnDemand(texture, scene) {
-    return (
-      getMaterialCache(this, scene).get(texture) ??
-      buildMaterials(this, texture, scene)
-    )
+    return buildMaterials(this, texture, scene)
   }
 
   /**
@@ -155,6 +150,11 @@ function preloadMaterials(manager, game) {
  * @returns {PBRSpecularGlossinessMaterial} built material.
  */
 function buildMaterials(manager, url, usedScene) {
+  const cachedMaterial = getMaterialCache(manager, usedScene).get(url)
+  if (cachedMaterial) {
+    return cachedMaterial
+  }
+
   const { scene, handScene, mainMaterialByUrl, handMaterialByUrl } = manager
   buildMaterial(mainMaterialByUrl, manager, url, scene)
   if (handScene) {

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').ShadowGenerator} ShadowGenerator
+ * @typedef {import('@src/graphql').Game} Game
+ */
+
 // mandatory side effect
 import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent.js'
 
@@ -19,19 +27,19 @@ class MaterialManager {
    * - reuse built materials based on their texture file (or color)
    * - allows using the same texture in between hand and main scene
    * - automatically clears cache scene disposal.
-   *
-   * @property {import('@babylon/core').Scene} scene? - main scene.
-   * @property {import('@babylon/core').Scene} handScene? - hand scene.
-   * @property {string} gameAssetsUrl? - base url hosting the game textures.
-   * @property {string} locale? - locale used to download the game textures.
    */
   constructor() {
-    this.scene = null
-    this.handScene = null
+    /** @type {Scene} main scene. */
+    this.scene
+    /** @type {Scene|undefined} hand scene. */
+    this.handScene
+    /** @type {string} base url hosting the game textures. */
     this.gameAssetsUrl = ''
+    /** @property {string} locale used to download the game textures. */
     this.locale = ''
-    // private
+    /** @internal @type {Map<string, PBRSpecularGlossinessMaterial>} map of material for the main scene. */
     this.mainMaterialByUrl = new Map()
+    /** @internal @type {Map<string, PBRSpecularGlossinessMaterial>} map of material for the hand scene.*/
     this.handMaterialByUrl = new Map()
   }
 
@@ -39,10 +47,10 @@ class MaterialManager {
    * Initialize manager with scene and configuration values.
    * @param {object} params - parameters, including:
    * @param {Scene} params.scene - main scene.
-   * @param {Scene} params.handScene? - scene for meshes in hand.
-   * @param {string} params.gameAssetsUrl? - base url hosting the game textures.
-   * @param {string} params.locale? - locale used to download the game textures.
-   * @param {import('../../graphql').Game} game - loaded game data.
+   * @param {Scene} [params.handScene] - scene for meshes in hand.
+   * @param {string} [params.gameAssetsUrl] - base url hosting the game textures.
+   * @param {string} [params.locale] - locale used to download the game textures.
+   * @param {Game} [game] - loaded game data.
    */
   init({ scene, handScene, gameAssetsUrl, locale }, game) {
     this.scene = scene
@@ -60,7 +68,7 @@ class MaterialManager {
   /**
    * Creates a material from provided texture and attaches it to a mesh.
    * Configures mesh to receive shadows and to have an overlay color.
-   * @param {import('@babylonjs/core').Mesh} mesh - related mesh.
+   * @param {Mesh} mesh - related mesh.
    * @param {string} texture - texture url or hexadecimal string color.
    */
   configure(mesh, texture) {
@@ -75,8 +83,8 @@ class MaterialManager {
    * Creates or reuse an existing material, on a given scene.
    * It is not attached to any mesh
    * @param {string} texture - texture url or hexadecimal string color.
-   * @param {import('@babylonjs/core').Scene} scene - scene used.
-   * @returns {StandardMaterial} the build (or reused) material.
+   * @param {Scene} scene - scene used.
+   * @returns {PBRSpecularGlossinessMaterial} the build (or cached) material.
    */
   buildOnDemand(texture, scene) {
     return (
@@ -104,7 +112,9 @@ class MaterialManager {
    * @returns {boolean} whether this material is managed or not
    */
   isManaging(texture) {
-    return this.mainMaterialByUrl.has(texture)
+    return (
+      this.mainMaterialByUrl.has(texture) || this.handMaterialByUrl.has(texture)
+    )
   }
 }
 
@@ -114,36 +124,61 @@ class MaterialManager {
  */
 export const materialManager = new MaterialManager()
 
+/**
+ * @param {MaterialManager} manager - manager instance.
+ * @param {Scene} scene - concerned scene.
+ * @returns {Map<string, PBRSpecularGlossinessMaterial>} map of cached materials for this scene.
+ */
 function getMaterialCache(manager, scene) {
   return manager.scene === scene
     ? manager.mainMaterialByUrl
     : manager.handMaterialByUrl
 }
 
+/**
+ * @param {MaterialManager} manager - manager instance.
+ * @param {Game} game - parsed game data.
+ */
 function preloadMaterials(manager, game) {
   for (const { texture } of [
-    ...game.meshes,
-    ...game.hands.flatMap(({ meshes }) => meshes)
+    ...(game.meshes ?? []),
+    ...(game.hands ?? []).flatMap(({ meshes }) => meshes)
   ]) {
     buildMaterials(manager, texture, manager.scene)
   }
 }
 
+/**
+ * @param {MaterialManager} manager - manager instance.
+ * @param {string} url - material texture url or color code.
+ * @param {Scene} usedScene - concerned scene.
+ * @returns {PBRSpecularGlossinessMaterial} built material.
+ */
 function buildMaterials(manager, url, usedScene) {
   const { scene, handScene, mainMaterialByUrl, handMaterialByUrl } = manager
   buildMaterial(mainMaterialByUrl, manager, url, scene)
   if (handScene) {
     buildMaterial(handMaterialByUrl, manager, url, handScene)
   }
-  return getMaterialCache(manager, usedScene).get(url)
+  return /** @type {PBRSpecularGlossinessMaterial} */ (
+    getMaterialCache(manager, usedScene).get(url)
+  )
 }
 
+/**
+ * @param {Map<string, PBRSpecularGlossinessMaterial>} materialByUrl cached material for this scene
+ * @param {MaterialManager} manager - manager instance.
+ * @param {string} url - material texture url or color code.
+ * @param {Scene} scene - concerned scene.
+ * @returns {PBRSpecularGlossinessMaterial} built material.
+ */
 function buildMaterial(materialByUrl, { gameAssetsUrl, locale }, url, scene) {
   const material = new PBRSpecularGlossinessMaterial(url, scene)
   if (url?.startsWith('#')) {
     material.transparencyMode = PBRBaseMaterial.PBRMATERIAL_ALPHABLEND
-    material.diffuseColor = Color4.FromHexString(url).toLinearSpace()
-    material.alpha = material.diffuseColor.a
+    const color = Color4.FromHexString(url).toLinearSpace()
+    material.diffuseColor = Color3.FromArray(color.asArray())
+    material.alpha = color.a
   } else {
     material.transparencyMode = PBRBaseMaterial.PBRMATERIAL_ALPHATEST
     material.diffuseTexture = new Texture(
@@ -174,7 +209,7 @@ function adaptTextureUrl(base, texture, locale) {
   return !texture
     ? texture
     : injectLocale(
-        Engine.LastCreatedEngine.version === 1
+        Engine.LastCreatedEngine?.version === 1
           ? `${base}${texture.replace('.ktx2', '.gl1.webp')}`
           : `${base}${texture}`,
         'textures',
@@ -185,13 +220,15 @@ function adaptTextureUrl(base, texture, locale) {
 /**
  * Gracefully handles material error due to shadow casting on some Android mobiles.
  * It'll downgrade the shadowGenerator to some supported configuration.
- * @param {import('@babel/core').Material} material - a mesh's material.
- * @see {@link https://forum.babylonjs.com/t/mobile-shadows-pcf-filter/22104/3}
+ * @param {PBRSpecularGlossinessMaterial} material - a mesh's material.
+ * @see https://forum.babylonjs.com/t/mobile-shadows-pcf-filter/22104/3
  */
 function attachMaterialError(material) {
   material.onError = (effect, errors) => {
     if (errors?.includes('FRAGMENT SHADER')) {
-      const shadowGenerator = material.getScene().lights[0].getShadowGenerator()
+      const shadowGenerator = /** @type {ShadowGenerator} */ (
+        material.getScene().lights[0].getShadowGenerator()
+      )
       shadowGenerator.usePercentageCloserFiltering = false
       shadowGenerator.useContactHardeningShadow = false
     }

--- a/apps/web/src/3d/managers/move.js
+++ b/apps/web/src/3d/managers/move.js
@@ -103,6 +103,7 @@ class MoveManager {
       }
     }
 
+    // TODO what if no last position?
     let lastPosition = /** @type {Vector3} */ (screenToGround(sceneUsed, event))
 
     /** @type {Set<DropZone>} */
@@ -156,6 +157,7 @@ class MoveManager {
       zones.clear()
 
       if (sceneUsed !== this.scene || isAboveTable(this.scene, event)) {
+        // TODO what if no current position?
         const currentPosition = /** @type {Vector3} */ (
           screenToGround(sceneUsed, event)
         )

--- a/apps/web/src/3d/managers/target.js
+++ b/apps/web/src/3d/managers/target.js
@@ -61,7 +61,7 @@ class TargetManager {
     this.color
     /** @internal @type {Set<TargetBehavior>} set of managed behaviors. */
     this.behaviors = new Set()
-    /** @internal @type {Map<SingleDropZone|MultiDropZone, Mesh[]>} map of droppable meshes by drop zone.*/
+    /** @internal @type {Map<DropZone, Mesh[]>} map of droppable meshes by drop zone.*/
     this.droppablesByDropZone = new Map()
     /** @internal @type {StandardMaterial} material applied to active drop zones. */
     this.material
@@ -122,7 +122,7 @@ class TargetManager {
    *
    * @param {Mesh} dragged - a dragged mesh.
    * @param {string} [kind] - drag kind.
-   * @returns {?SingleDropZone|MultiDropZone} matching zone, if any.
+   * @returns {?DropZone} matching zone, if any.
    */
   findPlayerZone(dragged, kind) {
     logger.debug(
@@ -145,7 +145,7 @@ class TargetManager {
    *
    * @param {Mesh} dragged - a dragged mesh.
    * @param {string} [kind] - drag kind.
-   * @returns {?SingleDropZone|MultiDropZone} matching zone, if any.
+   * @returns {?DropZone} matching zone, if any.
    */
   findDropZone(dragged, kind) {
     logger.debug(
@@ -165,7 +165,7 @@ class TargetManager {
 
   /**
    * Clears all droppable meshes of a given drop zone, and stops highlighting it.
-   * @param {?SingleDropZone|MultiDropZone} [zone] - the cleared drop zone.
+   * @param {?DropZone} [zone] - the cleared drop zone.
    */
   clear(zone) {
     if (!zone) return
@@ -183,7 +183,7 @@ class TargetManager {
    * If the provided target as droppable meshes, performs a drop operation, that is,
    * notifying drop observers of the corresponding Targetable behavior.
    * It clears the target.
-   * @param {SingleDropZone|MultiDropZone} zone - the zone dropped onto.
+   * @param {DropZone} zone - the zone dropped onto.
    * @param {Partial<DropDetails>} props - other properties passed to the drop zone observables
    * @returns {Mesh[]} list of droppable meshes, if any.
    */
@@ -236,7 +236,7 @@ export const targetManager = new TargetManager()
  * @param {Mesh} dragged - dragged mesh to check.
  * @param {(zone: SingleDropZone, partCenters: Vector3[]) => boolean} isMatching - matching function to test candidate zones.
  * @param {string} [kind] - dragged kind.
- * @returns {?SingleDropZone|MultiDropZone} matching zone, if any.
+ * @returns {?DropZone} matching zone, if any.
  */
 function findZone(manager, dragged, isMatching, kind) {
   const { behaviors, scene: mainScene } = manager
@@ -273,10 +273,10 @@ function findZone(manager, dragged, isMatching, kind) {
 
 /**
  * @param {TargetManager} manager - manager instance.
- * @param {?SingleDropZone|MultiDropZone} zone - matching zone to highlight.
+ * @param {?DropZone} zone - matching zone to highlight.
  * @param {Mesh} dragged - dragged mesh to check.
  * @param {string} [kind] - dragged kind.
- * @returns {?SingleDropZone|MultiDropZone} matching zone, if any.
+ * @returns {?DropZone} matching zone, if any.
  */
 function highlightZone(manager, zone, dragged, kind) {
   if (!zone) {

--- a/apps/web/src/3d/meshes/box.js
+++ b/apps/web/src/3d/meshes/box.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
+ */
+
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder.js'
 
@@ -15,19 +22,10 @@ import { applyInitialTransform } from '../utils/mesh'
  *   4. positive X (-90°)
  *   5. negative Z (0°)
  *   6. positive Z (180°)
- * @param {object} params - box parameters, including (all other properties will be passed to the created mesh):
- * @param {string} params.id - box's unique id.
- * @param {string} params.texture - box's texture url or hexadecimal string color.
- * @param {number[][]} params.faceUV? - up to 6 face UV (Vector4 components), to map texture on the box.
- * @param {number} params.x? - initial position along the X axis.
- * @param {number} params.y? - initial position along the Y axis.
- * @param {number} params.z? - initial position along the Z axis.
- * @param {number} params.width? - box's width (X axis).
- * @param {number} params.height? - box's height (Y axis).
- * @param {number} params.depth? - box's depth (Z axis).
- * @param {import('../utils').InitialTransform} params.transform? - initial transformation baked into the mesh's vertice.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host this box (default to last scene).
- * @returns the created box mesh.
+ * By default, boxes have a dimension of 1.
+ * @param {Omit<SerializedMesh, 'shape'>} params - box parameters.
+ * @param {Scene} scene - scene for the created mesh.
+ * @returns {Mesh} the created box mesh.
  */
 export function createBox(
   {
@@ -49,7 +47,7 @@ export function createBox(
     ],
     transform = undefined,
     ...behaviorStates
-  } = {},
+  },
   scene
 ) {
   const mesh = CreateBox(
@@ -71,7 +69,7 @@ export function createBox(
 
   mesh.metadata = {
     serialize: () => ({
-      shape: mesh.name,
+      shape: /** @type {'box'} */ (mesh.name),
       id,
       x: mesh.absolutePosition.x,
       y: mesh.absolutePosition.y,

--- a/apps/web/src/3d/meshes/card.js
+++ b/apps/web/src/3d/meshes/card.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
+ */
+
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder.js'
 
@@ -11,19 +18,9 @@ import { applyInitialTransform } from '../utils/mesh'
  * Cards are boxes whith a given width, height and depth. Only top and back faces UVs can be specified
  * By default, the card dimension follows American poker card standard (beetween 1.39 & 1.41).
  * A card's texture must have 2 faces, back then front, aligned horizontally.
- * @param {object} params - card parameters, including (all other properties will be passed to the created mesh):
- * @param {string} params.id - card's unique id.
- * @param {string} params.texture - card's texture url or hexadecimal string color.
- * @param {number[][]} params.faceUV? - up to 2 face UV (Vector4 components), to map texture on the card.
- * @param {number} params.x? - initial position along the X axis.
- * @param {number} params.y? - initial position along the Y axis.
- * @param {number} params.z? - initial position along the Z axis.
- * @param {number} params.width? - card's width (X axis).
- * @param {number} params.height? - card's height (Y axis).
- * @param {number} params.depth? - card's depth (Z axis).
- * @param {import('../utils').InitialTransform} params.transform? - initial transformation baked into the mesh's vertice.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host this card (default to last scene).
- * @returns {import('@babylonjs/core').Mesh} the created card mesh.
+ * @param {Omit<SerializedMesh, 'shape'>} params - card parameters.
+ * @param {Scene} scene - scene for the created mesh.
+ * @returns {Mesh} the created card mesh.
  */
 export function createCard(
   {
@@ -41,7 +38,7 @@ export function createCard(
     ],
     transform = undefined,
     ...behaviorStates
-  } = {},
+  },
   scene
 ) {
   const mesh = CreateBox(
@@ -71,7 +68,7 @@ export function createCard(
 
   mesh.metadata = {
     serialize: () => ({
-      shape: mesh.name,
+      shape: /** @type {'card'} */ (mesh.name),
       id,
       x: mesh.absolutePosition.x,
       y: mesh.absolutePosition.y,

--- a/apps/web/src/3d/meshes/custom.js
+++ b/apps/web/src/3d/meshes/custom.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
+ */
+
 import { SceneLoader } from '@babylonjs/core/Loading/sceneLoader.js'
 import { Vector2, Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { OBJFileLoader } from '@babylonjs/loaders/OBJ'
@@ -12,19 +19,11 @@ import { applyInitialTransform } from '../utils/mesh'
 OBJFileLoader.UV_SCALING = new Vector2(-1, 1)
 
 /**
- * Creates a custom mesh by importing .babylon format.
- * @param {object} params - mesh parameters, including:
- * @param {string} params.id - mesh's unique id.
- * @param {string} params.file - file containing the mesh's shape.
- * @param {string} params.texture - mesh's texture url or hexadecimal string color.
- * @param {number[][]} params.faceUV? - as manuy face UV (Vector4 components), as needed to map texture on the shape.
- * @param {number} params.x? - initial position along the X axis.
- * @param {number} params.y? - initial position along the Y axis.
- * @param {number} params.z? - initial position along the Z axis.
- * @param {import('../utils').InitialTransform} params.transform? - initial transformation baked into the mesh's vertice.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host this mesh (default to last scene).
- * @returns {Promise<import('@babylonjs/core').Mesh>} the created custom mesh.
- * @throws {Error} when the required file does not exist or contain invalid mesh data.
+ * Creates a custom mesh by importing .obj file.
+ * It must contain the file parameter.
+ * @param {Omit<SerializedMesh, 'shape'> & Required<Pick<SerializedMesh, 'file'>>} params - custom mesh parameters.
+ * @param {Scene} scene - scene for the created mesh.
+ * @returns {Promise<Mesh>} the created custom mesh.
  */
 export async function createCustom(
   {
@@ -40,6 +39,7 @@ export async function createCustom(
   scene
 ) {
   const encodedData = `data:;base64,${customShapeManager.get(file)}`
+  /** @type {?Mesh} */
   const mesh = await new Promise((resolve, reject) =>
     SceneLoader.ImportMesh(
       null,
@@ -50,7 +50,7 @@ export async function createCustom(
         const mesh = meshes?.[0]
         resolve(
           mesh?.getTotalVertices() > 0 || mesh?.getChildMeshes()?.length
-            ? mesh
+            ? /** @type {Mesh} */ (mesh)
             : null
         )
       },

--- a/apps/web/src/3d/meshes/prism.js
+++ b/apps/web/src/3d/meshes/prism.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
+ */
+
 import { Matrix, Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder.js'
 
@@ -9,20 +16,10 @@ import { applyInitialTransform } from '../utils/mesh'
 /**
  * Creates a prism, with a given number of base edge (starting at 3).
  * A prism's texture must have edges + 2 faces, starting with back and ending with front, aligned horizontally.
- * @param {object} params - prism parameters, including (all other properties will be passed to the created mesh):
- * @param {string} params.id - prism's unique id.
- * @param {string} params.texture - prism's texture url or hexadecimal string color.
- * @param {number[][]} params.faceUV? - up to 3 face UV (Vector4 components), to map texture to the prism.
- * @param {number} params.edges? - number of edges for this prism.
- * @param {number} params.prismRotation? - fixed rotation applied to the prism.
- * @param {number} params.x? - initial position along the X axis.
- * @param {number} params.y? - initial position along the Y axis.
- * @param {number} params.z? - initial position along the Z axis.
- * @param {number} params.width? - prism's base size (X axis, size on Z depends on the number of edges).
- * @param {number} params.height? - prism's height (Y axis).
- * @param {import('../utils').InitialTransform} params.transform? - initial transformation baked into the mesh's vertice.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host this round prism (default to last scene).
- * @returns the created prism mesh.
+ * By default, prisms have 6 edges and a width of 3.
+ * @param {Omit<SerializedMesh, 'shape'>} params - prism parameters.
+ * @param {Scene} scene - scene for the created mesh.
+ * @returns {Mesh} the created prism mesh.
  */
 export function createPrism(
   {
@@ -42,7 +39,7 @@ export function createPrism(
     ],
     transform = undefined,
     ...behaviorStates
-  } = {},
+  },
   scene
 ) {
   const mesh = CreateCylinder(
@@ -69,7 +66,7 @@ export function createPrism(
 
   mesh.metadata = {
     serialize: () => ({
-      shape: mesh.name,
+      shape: /** @type {'prism'} */ (mesh.name),
       id,
       x: mesh.absolutePosition.x,
       y: mesh.absolutePosition.y,

--- a/apps/web/src/3d/meshes/round-token.js
+++ b/apps/web/src/3d/meshes/round-token.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
+ */
+
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder.js'
 
@@ -10,18 +17,10 @@ import { applyInitialTransform } from '../utils/mesh'
  * Creates a round token, like a pocker one.
  * Tokens are cylinders, so their position is their center.
  * A token's texture must have 3 faces, back then edge then front, aligned horizontally.
- * @param {object} params - token parameters, including (all other properties will be passed to the created mesh):
- * @param {string} params.id - token's unique id.
- * @param {string} params.texture - token's texture url or hexadecimal string color.
- * @param {number[][]} params.faceUV? - up to 3 face UV (Vector4 components), to map texture on the token.
- * @param {number} params.x? - initial position along the X axis.
- * @param {number} params.y? - initial position along the Y axis.
- * @param {number} params.z? - initial position along the Z axis.
- * @param {number} params.diameter? - token's diameter (X+Z axis).
- * @param {number} params.height? - token's height (Y axis).
- * @param {import('../utils').InitialTransform} params.transform? - initial transformation baked into the mesh's vertice.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host this round token (default to last scene).
- * @returns the created token mesh.
+ * By default tokens have a diameter of 2.
+ * @param {Omit<SerializedMesh, 'shape'>} params - token parameters.
+ * @param {Scene} scene - scene for the created mesh.
+ * @returns {Mesh} the created token mesh.
  */
 export function createRoundToken(
   {
@@ -39,7 +38,7 @@ export function createRoundToken(
     ],
     transform = undefined,
     ...behaviorStates
-  } = {},
+  },
   scene
 ) {
   const mesh = CreateCylinder(
@@ -62,7 +61,7 @@ export function createRoundToken(
 
   mesh.metadata = {
     serialize: () => ({
-      shape: mesh.name,
+      shape: /** @type {'roundToken'} */ (mesh.name),
       id,
       x: mesh.absolutePosition.x,
       y: mesh.absolutePosition.y,

--- a/apps/web/src/3d/utils/actions.js
+++ b/apps/web/src/3d/utils/actions.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+ * @typedef {import('@tabulous/server/src/graphql/types').ButtonName} ButtonName
+ * @typedef {import('@tabulous/server/src/graphql/types').Mesh} SerializedMesh
+ * @typedef {import('@src/types').Translate} Translate
+ */
+
 // Keep this file free from @babylon (in)direct imports, to allow Svelte component referencing them
 // Otherwise this would bloat production chunks with Babylonjs (1.6Mb uncompressed)
 import {
@@ -14,6 +22,7 @@ import {
 /**
  * Action names defined in beheviors, attached to mesh metadata,
  * and that can be used in actionNamesByKey map.
+ * @type {Record<string, ActionName>}
  */
 export const actionNames = {
   decrement: 'decrement',
@@ -36,6 +45,7 @@ export const actionNames = {
 
 /**
  * button ids triggered in game-interaction and used in actionNamesByButton map
+ * @type {Record<string, ButtonName>}
  */
 export const buttonIds = {
   button1: 'button1',
@@ -45,11 +55,12 @@ export const buttonIds = {
 
 /**
  * Parse game data to build a map of supported action names by their shortcuts.
- * @param {object[]} meshes - serialized meshes to be analyzed.
- * @param {(key: string) => string} translate - translation
- * @returns {Map<string, [string]>} map of supported action names by shortcut.
+ * @param {SerializedMesh[]} meshes - serialized meshes to be analyzed.
+ * @param {Translate} translate - translation
+ * @returns {Map<string, ActionName[]>} map of supported action names by shortcut.
  */
 export function buildActionNamesByKey(meshes, translate) {
+  /** @type {Map<string, ActionName[]>} */
   const actionNamesByKey = new Map()
   let hasStackable = false
   let hasQuantifiable = false
@@ -88,17 +99,21 @@ export function buildActionNamesByKey(meshes, translate) {
   if (hasStackable || hasQuantifiable) {
     actionNamesByKey.set(
       translate('shortcuts.push'),
-      [
-        hasStackable ? actionNames.push : undefined,
-        hasQuantifiable ? actionNames.increment : undefined
-      ].filter(Boolean)
+      /** @type {ActionName[]} */ (
+        [
+          hasStackable ? actionNames.push : undefined,
+          hasQuantifiable ? actionNames.increment : undefined
+        ].filter(Boolean)
+      )
     )
     actionNamesByKey.set(
       translate('shortcuts.pop'),
-      [
-        hasStackable ? actionNames.pop : undefined,
-        hasQuantifiable ? actionNames.decrement : undefined
-      ].filter(Boolean)
+      /** @type {ActionName[]} */ (
+        [
+          hasStackable ? actionNames.pop : undefined,
+          hasQuantifiable ? actionNames.decrement : undefined
+        ].filter(Boolean)
+      )
     )
   }
   return actionNamesByKey

--- a/apps/web/src/3d/utils/lights.js
+++ b/apps/web/src/3d/utils/lights.js
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@tabulous/server/src/graphql/types').TableSpec} TableSpec
+ */
+
 // mandatory side effect
 import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent.js'
 
@@ -10,7 +16,7 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
  * @typedef {object} LightResult
  * @property {DirectionalLight} light - directional light for main scene
  * @property {HemisphericLight} ambientLight - ambient light for main scene
- * @property {DirectionalLight} handLight - directional light for hand scene
+ * @property {HemisphericLight} handLight - directional light for hand scene
  * @property {ShadowGenerator} shadowGenerator - created shadow generator
  */
 
@@ -19,17 +25,18 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
  * Creates directional light for the hand scene
  * Note: all meshes created before this light will not project any shadow.
  * @param {object} params - parameters, including:
- * @param {import('@babylonjs/core').Scene} params.scene? - main scene.
- * @param {import('@babylonjs/core').Scene} params.handScene? - hand scene.
+ * @param {Scene} params.scene - main scene.
+ * @param {Scene} params.handScene - hand scene.
  * @returns {LightResult} an object containing created light and shadowGenerator.
  */
-export function createLights({ scene, handScene } = {}) {
+export function createLights({ scene, handScene }) {
   const light = makeDirectionalLight(scene)
   const ambientLight = makeAmbientLight(scene)
 
   const shadowGenerator = new ShadowGenerator(1024, light)
   shadowGenerator.usePercentageCloserFiltering = true
   // https://forum.babylonjs.com/t/shadow-darkness-darker-than-0/22837
+  // @ts-expect-error _darkness is private
   shadowGenerator._darkness = -1.5
 
   const handLight = makeAmbientLight(handScene)
@@ -41,6 +48,10 @@ export function createLights({ scene, handScene } = {}) {
   return { light, ambientLight, handLight, shadowGenerator }
 }
 
+/**
+ * @param {Scene} scene
+ * @returns {DirectionalLight}
+ */
 function makeDirectionalLight(scene) {
   const light = new DirectionalLight('sun', new Vector3(0, -1, 0), scene)
   light.position = new Vector3(0, 20, 0)
@@ -48,6 +59,10 @@ function makeDirectionalLight(scene) {
   return light
 }
 
+/**
+ * @param {Scene} scene
+ * @returns {HemisphericLight}
+ */
 function makeAmbientLight(scene) {
   const light = new HemisphericLight('ambient', new Vector3(0, 1, 0), scene)
   light.intensity = 0.8

--- a/apps/web/src/3d/utils/mesh.js
+++ b/apps/web/src/3d/utils/mesh.js
@@ -1,11 +1,15 @@
+// @ts-check
 /**
+ * @typedef {import('@babylonjs/core').AbstractMesh} AbstractMesh
  * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').InitialTransform} InitialTransform
  */
 
 /**
  * Indicates whether a given container completely contain the tested mesh, using their bounding boxes.
- * @param {Mesh} container - container that may contain the mesh.
- * @param {Mesh} mesh - tested mesh.
+ * @template {AbstractMesh} T
+ * @param {T} container - container that may contain the mesh.
+ * @param {T} mesh - tested mesh.
  * @returns {boolean} true if container contains mesh, false otherwise.
  */
 export function isContaining(container, mesh) {
@@ -26,16 +30,11 @@ export function isContaining(container, mesh) {
 }
 
 /**
- * @typedef {object} Dimensions mesh's bounding box
- * @property {number} height - the mesh's height.
- * @property {number} width - the mesh's width.
- */
-
-/**
  * Returns a given mesh's dimension, that is its extent on Y and X axes.
  * **Requires a fresh world matrix**.
- * @param {Mesh} mesh - sized mesh.
- * @returns {Dimensions} mesh's dimensions.
+ * @template {AbstractMesh} T
+ * @param {T} mesh - sized mesh.
+ * @returns {{ width: number, height: number, depth: number }} mesh's dimensions.
  */
 export function getDimensions(mesh) {
   mesh.computeWorldMatrix(true)
@@ -44,19 +43,9 @@ export function getDimensions(mesh) {
 }
 
 /**
- * @typedef {object} InitialTransform mesh's bounding box
- * @property {number} yaw? - yaw (rotation on x) applied.
- * @property {number} pitch? - pitch (rotation on y) applied.
- * @property {number} roll? - yaw (rotation on z) applied.
- * @property {number} scaleX? - scale on x applied.
- * @property {number} scaleY? - scale on y applied.
- * @property {number} scaleZ? - scale on z applied.
- */
-
-/**
  * Applies an initial transformation to the built mesh, baking it into the vertices.
  * @param {Mesh} mesh - transformed mesh.
- * @param {InitialTransform} transform? - initial transform applied (may be undefined).
+ * @param {InitialTransform} [transform] - initial transform applied (may be undefined).
  */
 export function applyInitialTransform(mesh, transform) {
   if (transform) {

--- a/apps/web/src/3d/utils/scene-loader.js
+++ b/apps/web/src/3d/utils/scene-loader.js
@@ -1,3 +1,15 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@tabulous/server/src/graphql/types').AnchorableState} AnchorableState
+ * @typedef {import('@tabulous/server/src/graphql/types').Mesh} SerializedMesh
+ * @typedef {import('@tabulous/server/src/graphql/types').Shape} Shape
+ * @typedef {import('@tabulous/server/src/graphql/types').StackableState} StackableState
+ * @typedef {import('@src/3d/behaviors/anchorable').AnchorBehavior} AnchorBehavior
+ * @typedef {import('@src/3d/behaviors/stackable').StackBehavior} StackBehavior
+ */
+
 // mandatory side effect
 import '@babylonjs/core/Loading/loadingScreen.js'
 
@@ -15,35 +27,39 @@ import { createRoundToken } from '../meshes/round-token'
 import { createRoundedTile } from '../meshes/rounded-tile'
 import { restoreBehaviors } from './behaviors'
 
+/** @typedef {(state: Omit<SerializedMesh, 'shape'>, scene: Scene) => Mesh|Promise<Mesh>} MeshCreator */
+
 const logger = makeLogger('scene-loader')
 
+/** @type {Map<Shape, MeshCreator>} */
 const meshCreatorByName = new Map([
-  ['box', createBox],
-  ['card', createCard],
-  ['custom', createCustom],
-  ['die', createDie],
-  ['prism', createPrism],
-  ['roundToken', createRoundToken],
-  ['roundedTile', createRoundedTile]
+  ['box', /** @type {MeshCreator} */ (createBox)],
+  ['card', /** @type {MeshCreator} */ (createCard)],
+  ['custom', /** @type {MeshCreator} */ (createCustom)],
+  ['die', /** @type {MeshCreator} */ (createDie)],
+  ['prism', /** @type {MeshCreator} */ (createPrism)],
+  ['roundToken', /** @type {MeshCreator} */ (createRoundToken)],
+  ['roundedTile', /** @type {MeshCreator} */ (createRoundedTile)]
 ])
 
 const supportedNames = new Set([...meshCreatorByName.keys()])
 
 /**
  * Indicates whether a mesh can be serialized and loaded
- * @param {import('@babel/core').Mesh} mesh - tested mesh.
+ * @param {Mesh} mesh - tested mesh.
  * @returns {boolean} whether this mesh could be serialized and loaded.
  */
 export function isSerializable(mesh) {
-  return supportedNames.has(mesh.name)
+  return supportedNames.has(/** @type {Shape} */ (mesh.name))
 }
 
 /**
  * Serializes a scene's meshes.
- * @param {import('@babel/core').Scene} scene - 3D scene serialized.
- * @returns {object[]} list of serialized meshes TODO.
+ * @param {Scene} [scene] - 3D scene serialized.
+ * @returns {SerializedMesh[]} list of serialized meshes.
  */
 export function serializeMeshes(scene) {
+  /** @type {SerializedMesh[]} */
   const meshes = []
   for (const mesh of scene?.meshes ?? []) {
     if (isSerializable(mesh) && !mesh.isPhantom) {
@@ -56,9 +72,9 @@ export function serializeMeshes(scene) {
 
 /**
  * Creates a meshes into the provided scene.
- * @param {object} state - serialized mesh state.
- * @param {import('@babel/core').Scene} scene - 3D scene used.
- * @returns {Promise<import('@babel/core').Mesh>} mesh created
+ * @param {SerializedMesh} state - serialized mesh state.
+ * @param {Scene} scene - 3D scene used.
+ * @returns {Promise<Mesh>} mesh created.
  */
 export async function createMeshFromState(state, scene) {
   const { shape } = state
@@ -66,15 +82,15 @@ export async function createMeshFromState(state, scene) {
   if (!supportedNames.has(shape)) {
     throw new Error(`mesh shape ${shape} is not supported`)
   }
-  return meshCreatorByName.get(shape)(state, scene)
+  return /** @type {MeshCreator} */ (meshCreatorByName.get(shape))(state, scene)
 }
 
 /**
  * Loads meshes into the provided scene:
  * - either creates new mesh, or updates existing ones, based on their ids
  * - deletes existing mesh that are not found in the provided data
- * @param {import('@babel/core').Scene} scene - 3D scene used.
- * @param {Promise<object[]>} meshes - a list of serialized meshes data TODO.
+ * @param {Scene} scene - 3D scene used.
+ * @param {SerializedMesh[]} meshes - a list of serialized meshes data.
  */
 export async function loadMeshes(scene, meshes) {
   const disposables = new Set(scene.meshes)
@@ -84,7 +100,9 @@ export async function loadMeshes(scene, meshes) {
     }
   }
 
+  /** @type {{stackBehavior: StackBehavior, stackable: StackableState, y: number}[]} */
   const stackables = []
+  /** @type {{anchorBehavior: AnchorBehavior, anchorable: AnchorableState, y: number}[]} */
   const anchorables = []
   logger.debug({ meshes }, `loads meshes`)
 
@@ -105,8 +123,8 @@ export async function loadMeshes(scene, meshes) {
       mesh = await createMeshFromState(skipDelayableBehaviors(state), scene)
     }
     const stackBehavior = mesh.getBehaviorByName(StackBehaviorName)
-    if (stackBehavior) {
-      if (stackable?.stackIds?.length > 0) {
+    if (stackable && stackBehavior) {
+      if ((stackable.stackIds?.length ?? 0) > 0) {
         // stores for later
         stackables.push({
           stackBehavior,
@@ -119,8 +137,8 @@ export async function loadMeshes(scene, meshes) {
       }
     }
     const anchorBehavior = mesh.getBehaviorByName(AnchorBehaviorName)
-    if (anchorBehavior) {
-      if (anchorable?.anchors.find(({ snappedId }) => snappedId)) {
+    if (anchorable && anchorBehavior) {
+      if ((anchorable.anchors ?? []).find(({ snappedId }) => snappedId)) {
         // stores for later
         anchorables.push({
           anchorBehavior,
@@ -151,6 +169,10 @@ export async function loadMeshes(scene, meshes) {
   }
 }
 
+/**
+ * @param {SerializedMesh} mesh - serialized mesh to trim.
+ * @return {SerializedMesh} the same mesh without its anchorable and stackable behaviors.
+ */
 function skipDelayableBehaviors({ stackable, anchorable, ...state }) {
   return {
     ...state,
@@ -161,24 +183,31 @@ function skipDelayableBehaviors({ stackable, anchorable, ...state }) {
 
 /**
  * Recursively removes null values (graphQL doesn't return undefined, which prevents from applying default values)
- * @param {object} object - sanitized object
- * @returns {object} a cloned object with no null values.
+ * @template T
+ * @param {T} object - sanitized object
+ * @returns {Exclude<T, null>} a cloned object with no null values.
  */
 export function removeNulls(object) {
   if (object === null) {
+    // @ts-expect-error
     return
   }
   let result = object
   if (Array.isArray(object)) {
+    // @ts-expect-error
     result = new Array(object.length)
     for (const [rank, item] of object.entries()) {
+      // @ts-expect-error
       result[rank] = removeNulls(item)
     }
   } else if (typeof object === 'object') {
+    // @ts-expect-error
     result = {}
     for (const key in object) {
+      // @ts-expect-error
       result[key] = removeNulls(object[key])
     }
   }
+  // @ts-expect-error
   return result
 }

--- a/apps/web/src/3d/utils/scene-loader.js
+++ b/apps/web/src/3d/utils/scene-loader.js
@@ -33,13 +33,13 @@ const logger = makeLogger('scene-loader')
 
 /** @type {Map<Shape, MeshCreator>} */
 const meshCreatorByName = new Map([
-  ['box', /** @type {MeshCreator} */ (createBox)],
-  ['card', /** @type {MeshCreator} */ (createCard)],
-  ['custom', /** @type {MeshCreator} */ (createCustom)],
-  ['die', /** @type {MeshCreator} */ (createDie)],
-  ['prism', /** @type {MeshCreator} */ (createPrism)],
-  ['roundToken', /** @type {MeshCreator} */ (createRoundToken)],
-  ['roundedTile', /** @type {MeshCreator} */ (createRoundedTile)]
+  ['box', /** @type {?} */ (createBox)],
+  ['card', /** @type {?} */ (createCard)],
+  ['custom', /** @type {?} */ (createCustom)],
+  ['die', /** @type {?} */ (createDie)],
+  ['prism', /** @type {?} */ (createPrism)],
+  ['roundToken', /** @type {?} */ (createRoundToken)],
+  ['roundedTile', /** @type {?} */ (createRoundedTile)]
 ])
 
 const supportedNames = new Set([...meshCreatorByName.keys()])

--- a/apps/web/src/3d/utils/scene.js
+++ b/apps/web/src/3d/utils/scene.js
@@ -1,33 +1,57 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { Scene } from '@babylonjs/core/scene.js'
 
 /**
  * Optimized version of Babylon's Scene that uses map to reference meshes by id.
  */
 export class ExtendedScene extends Scene {
-  /** @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#constructor */
-  constructor(...args) {
-    super(...args)
+  /**
+   * @param {Engine} engine - rendering engine.
+   * @param {?} [options] - scene options.
+   * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#constructor
+   */
+  constructor(engine, options) {
+    super(engine, options)
+    /** @type {Map<string, Mesh>} */
     this.meshById = new Map()
     this.detachControl()
   }
 
-  /** @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#addmesh */
-  addMesh(mesh, ...args) {
+  /**
+   * @param {Mesh} mesh - added mesh.
+   * @param {boolean} [recursive] - whether to add children meshes as well.
+   * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#addMesh
+   */
+  addMesh(mesh, recursive) {
     if (mesh?.id) {
       this.meshById.set(mesh.id, mesh)
     }
-    super.addMesh(mesh, ...args)
+    super.addMesh(mesh, recursive)
   }
 
-  /** @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#removemesh */
-  removeMesh(mesh, ...args) {
+  /**
+   * @param {Mesh} mesh - removed mesh.
+   * @param {boolean} [recursive] - whether to remove children meshes as well.
+   * @returns {number} removed mesh index.
+   * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#removeMesh
+   */
+  removeMesh(mesh, recursive) {
     this.meshById.delete(mesh?.id)
-    super.removeMesh(mesh, ...args)
+    return super.removeMesh(mesh, recursive)
   }
 
-  /** @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#getmeshbyid-1 */
+  /**
+   * @param {string} id - searched mesh id.
+   * @returns {?Mesh} found mesh.
+   * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#getMeshByID
+   */
   getMeshById(id) {
-    return this.meshById.get(id) ?? null
+    return /** @type {?Mesh} */ (this.meshById.get(id) ?? null)
   }
 
   /** @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#dispose */

--- a/apps/web/src/3d/utils/table.js
+++ b/apps/web/src/3d/utils/table.js
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Material} Material
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Texture} Texture
+ * @typedef {import('@tabulous/server/src/graphql/types').TableSpec} TableSpec
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateGround } from '@babylonjs/core/Meshes/Builders/groundBuilder.js'
 
@@ -6,12 +15,9 @@ import { materialManager } from '../managers/material'
 /**
  * Creates ground mesh to act as table, that received shadows but can not receive rays.
  * Table is always 0.01 unit bellow (Y axis) origin.
- * @param {object} params - table parameters, including:
- * @param {number} params.width? - table's width (X axis).
- * @param {number} params.height? - table's height (Y axis).
- * @param {string} params.texture - table's texture url or hexadecimal string color.
- * @param {import('@babylonjs/core').Scene} scene? - scene to host the table (default to last scene).
- * @returns {import('@babylonjs/core').Mesh} the created table ground.
+ * @param {TableSpec|undefined} tableSpec - table parameters
+ * @param {Scene} scene - scene to host the table (default to last scene).
+ * @returns {Mesh} the created table ground.
  */
 export function createTable(
   { width = 400, height = 400, texture } = {},
@@ -21,10 +27,15 @@ export function createTable(
   table.setAbsolutePosition(new Vector3(0, -0.01, 0))
   table.receiveShadows = true
   table.isPickable = false
-  table.material = materialManager.buildOnDemand(texture, scene)
-  if (table.material?.diffuseTexture) {
-    table.material.diffuseTexture.uScale = 5
-    table.material.diffuseTexture.vScale = 5
+  if (texture) {
+    table.material = materialManager.buildOnDemand(texture, scene)
+    const material = /** @type {Material & { diffuseTexture: Texture? }} */ (
+      table.material
+    )
+    if (material.diffuseTexture) {
+      material.diffuseTexture.uScale = 5
+      material.diffuseTexture.vScale = 5
+    }
   }
   return table
 }

--- a/apps/web/src/3d/utils/vector.js
+++ b/apps/web/src/3d/utils/vector.js
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').AbstractMesh} AbstractMesh
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Camera} Camera
+ * @typedef {import('@babylonjs/core').Node} Node
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+
 import { Ray } from '@babylonjs/core/Culling/ray.js'
 import {
   Matrix,
@@ -5,48 +14,51 @@ import {
   Vector3
 } from '@babylonjs/core/Maths/math.vector.js'
 
-let table
-
 /**
  * @typedef {object} ScreenPosition position on screen (2D, DOM)
  * @property {number} x - x coordinate.
  * @property {number} y - y coordinate.
  */
 
+/** @type {?Mesh} */
+let table = null
+
 /**
  * Converts a screen position into a point on the ground (3D, scene).
  * Useful to know where on the ground a player has clicked.
- * @param {import('@babylonjs/core').Scene} scene - current scene.
+ * @param {Scene} scene - current scene.
  * @param {ScreenPosition} position - screen position.
- * @returns {Vector3} 3D point on the ground plane (Y axis) for this position.
+ * @returns {?Vector3} 3D point on the ground plane (Y axis) for this position, if any.
  */
 export function screenToGround(scene, { x, y }) {
-  return scene.createPickingRay(x, y).intersectsAxis('y')
+  return scene.createPickingRay(x, y, null, null).intersectsAxis('y')
 }
 
 /**
  * Indicates whether a screen position (2D, DOM) is above the table mesh.
- * @param {import('@babylonjs/core').Scene} scene - current scene.
+ * @param {Scene} scene - current scene.
  * @param {ScreenPosition} position - screen position.
  * @returns {boolean} true if the point is within the table area, false otherwise.
  */
 export function isAboveTable(scene, { x, y }) {
   /* istanbul ignore next */
-  if (!table || table.isDisposed) {
+  if (!table || table.isDisposed()) {
     table = scene.getMeshById('table')
   }
-  return table ? scene.createPickingRay(x, y).intersectsMesh(table).hit : false
+  return table
+    ? scene.createPickingRay(x, y, null, null).intersectsMesh(table).hit
+    : false
 }
 
 /**
  * Indicates whether a world position (3D, scene) is above the table mesh.
- * @param {import('@babylonjs/core').Scene} scene - current scene.
+ * @param {Scene} scene - current scene.
  * @param {Vector3} position - 3D position.
  * @returns {boolean} true if the point is within the table area, false otherwise.
  */
 export function isPositionAboveTable(scene, position) {
   /* istanbul ignore next */
-  if (!table || table.isDisposed) {
+  if (!table || table.isDisposed()) {
     table = scene.getMeshById('table')
   }
   return table
@@ -58,8 +70,9 @@ export function isPositionAboveTable(scene, position) {
 
 /**
  * Returns screen coordinate of a given mesh.
- * @param {import('@babylonjs/core').Mesh} mesh - the tested mesh.
- * @param {number[]} [offset = [0, 0, 0]] - optional offset (3D coordinates) applied.
+ * @template {AbstractMesh} T
+ * @param {T?} [mesh] - the tested mesh.
+ * @param {[number, number, number]} [offset = [0, 0, 0]] - optional offset (3D coordinates) applied.
  * @returns {ScreenPosition|null} this mesh's screen position.
  */
 export function getMeshScreenPosition(mesh, offset = [0, 0, 0]) {
@@ -75,7 +88,7 @@ export function getMeshScreenPosition(mesh, offset = [0, 0, 0]) {
 
 /**
  * Returns screen coordinate of a 3D position given a scene's active camera.
- * @param {import('@babylonjs/core').Scene} scene - current scene.
+ * @param {Scene} scene - current scene.
  * @param {Vector3} position - 3D position.
  * @returns {ScreenPosition} the corresponding screen position
  */
@@ -85,7 +98,7 @@ export function getScreenPosition(scene, position) {
     position,
     Matrix.Identity(),
     scene.getTransformMatrix(),
-    scene.activeCamera.viewport.toGlobal(
+    /** @type {Camera} */ (scene.activeCamera).viewport.toGlobal(
       engine.getRenderWidth(),
       engine.getRenderHeight()
     )
@@ -95,8 +108,9 @@ export function getScreenPosition(scene, position) {
 
 /**
  * Converts a position in world space into a given mesh's local space.
+ * @template {AbstractMesh} T
  * @param {Vector3} absolutePosition - absolute position to convert.
- * @param {import('@babylonjs/core').Mesh} mesh - mesh into which position is converted.
+ * @param {T} mesh - mesh into which position is converted.
  * @returns {Vector3} the converted position in mesh's local space.
  */
 export function convertToLocal(absolutePosition, mesh) {
@@ -110,7 +124,8 @@ export function convertToLocal(absolutePosition, mesh) {
 
 /**
  * Returns mesh local rotation in world space.
- * @param {import('@babylonjs/core').Mesh} mesh - related mesh.
+ * @template {Node} T
+ * @param {T} mesh - related mesh.
  * @returns {Vector3} absolute rotation (Euler angles).
  */
 export function getAbsoluteRotation(mesh) {

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-unused-vars */
+import '@poppanator/sveltekit-svg/dist/svg'
+
+import type { Locale } from '@src/common'
+import type { PlayerWithTurnCredentials } from '@src/graphql'
+import type { DeepRequired } from '@src/types'
+
+// for information about these interfaces
+// See https://kit.svelte.dev/docs/types#app
+declare global {
+  namespace App {
+    // interface Error {}
+    interface Locals {
+      bearer: string
+      session: ?DeepRequired<PlayerWithTurnCredentials>
+      timeZone: string | undefined
+    }
+    interface PageData {
+      lang: Locale
+    }
+    // interface Platform {}
+  }
+}
+
+export {}

--- a/apps/web/src/common.js
+++ b/apps/web/src/common.js
@@ -1,13 +1,17 @@
+// @ts-check
 import 'virtual:windi.css'
 import './style.postcss'
 
 import { locale, options, translations } from 'svelte-intl'
 
+/** @typedef {'fr'|'en'} Locale Supported locales */
+// @ts-expect-error: can not find module
 import en from './locales/en.yaml'
+// @ts-expect-error: can not find module
 import fr from './locales/fr.yaml'
 translations.update({ fr, en })
 
-function enrichWithTz(obj = {}, timeZone) {
+function enrichWithTz(obj = {}, /** @type {string|undefined} */ timeZone) {
   return Object.fromEntries(
     Object.entries(obj).map(([name, definition]) => [
       name,
@@ -16,6 +20,11 @@ function enrichWithTz(obj = {}, timeZone) {
   )
 }
 
+/**
+ * Initialize the locale used in svelte-intl, by selecting the right language and time zone.
+ * @param {Locale} [lang='fr'] - locale used.
+ * @param {string} [timeZone] - time zone used (UTC by default).
+ */
 export function initLocale(lang = 'fr', timeZone = undefined) {
   locale.set(lang)
   const {

--- a/apps/web/src/components/Aside/PlayerAvatar.svelte
+++ b/apps/web/src/components/Aside/PlayerAvatar.svelte
@@ -1,16 +1,28 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/stores/game-manager').Player} Player
+   * @typedef {import('@src/graphql').PlayerFragment} PlayerFragment
+   */
+
   import { stream$ } from '@src/stores/stream'
   import { _ } from 'svelte-intl'
 
   import PlayerThumbnail from '../PlayerThumbnail.svelte'
 
-  export let player = null
+  /** @type {Player|undefined} player displayed. */
+  export let player = undefined
+  /** @type {?MediaStream} video/audio stream for this player. */
   export let stream = null
+  /** @type {boolean} whether this avatar is for the authenticated local user. */
   export let isLocal = false
+  /** @type {boolean} whether the stream audio was muted. */
   export let muted = false
+  /** @type {boolean} whether the stream video was stopped. */
   export let stopped = false
 
-  let video
+  /** @type {?HTMLVideoElement} */
+  let video = null
 
   $: mediaStream = isLocal ? $stream$ : stream
   $: hasStream = Boolean(mediaStream) && !stopped

--- a/apps/web/src/components/Aside/VideoCommands.svelte
+++ b/apps/web/src/components/Aside/VideoCommands.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import {
     acquireMediaStream,
     cameras$,
@@ -12,7 +13,9 @@
   import Dropdown from '../Dropdown.svelte'
   import SoundMeter from '../SoundMeter.svelte'
 
+  /** @type {boolean} whether the stream audio was muted. */
   export let muted = false
+  /** @type {boolean} whether the stream video was stopped. */
   export let stopped = false
 
   function toggleMic() {
@@ -35,7 +38,9 @@
     }
   }
 
-  function selectMedia({ detail: media }) {
+  function selectMedia(
+    /** @type {CustomEvent<MediaDeviceInfo>} */ { detail: media }
+  ) {
     acquireMediaStream(media)
   }
 </script>

--- a/apps/web/src/components/Aside/index.js
+++ b/apps/web/src/components/Aside/index.js
@@ -1,2 +1,3 @@
+// @ts-check
 import Container from './Container.svelte'
 export default Container

--- a/apps/web/src/components/Breadcrumb.svelte
+++ b/apps/web/src/components/Breadcrumb.svelte
@@ -1,5 +1,9 @@
 <script>
+  // @ts-check
+
+  /** @type {{ href?: ?string, label: string }[]} list of breadcrumb elements, with a friendly label and possibly a link (all but last one ) */
   export let steps = []
+
   const lastRank = steps?.length - 1
 </script>
 

--- a/apps/web/src/components/Button.svelte
+++ b/apps/web/src/components/Button.svelte
@@ -1,9 +1,17 @@
 <script>
+  // @ts-check
+
+  /** @type {?string} button's text. */
   export let text = null
+  /** @type {?string} optional icon. */
   export let icon = null
+  /** @type {?number|string} optional badge displayed. */
   export let badge = null
+  /** @type {boolean} whether to use primary or base color scheme. */
   export let primary = false
+  /** @type {boolean} whether this button has no border nor background. */
   export let transparent = false
+  /** @type {?HTMLButtonElement} optional reference to the HTML button element. */
   export let ref = null
 </script>
 
@@ -25,7 +33,7 @@
       >{:else if text}<span class="text">{text}</span>{/if}<slot />
   </div>
   {#if badge != undefined}
-    <span class="badge">{badge > 999 ? `+999` : badge}</span>
+    <span class="badge">{!isNaN(+badge) && +badge > 999 ? `+999` : badge}</span>
   {/if}</button
 >
 

--- a/apps/web/src/components/ConfirmDialogue.svelte
+++ b/apps/web/src/components/ConfirmDialogue.svelte
@@ -39,7 +39,7 @@
   }
 </script>
 
-<Dialogue closable {open} {title} {...$$restProps} on:close={handleClose}>
+<Dialogue closable {open} {title} on:close={handleClose}>
   {message}
   <slot />
   <svelte:fragment slot="buttons">

--- a/apps/web/src/components/ConfirmDialogue.svelte
+++ b/apps/web/src/components/ConfirmDialogue.svelte
@@ -1,24 +1,37 @@
 <script>
+  // @ts-check
+
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
   import Button from './Button.svelte'
   import Dialogue from './Dialogue.svelte'
 
+  /** @type {boolean} whether this dialogur is open. */
   export let open
+  /** @type {string} dialogue main title. */
+  export let title
+  /** @type {?} dialogue message (could be any content). */
   export let message = ''
+  /** @type {string} text of the cancellation button (default to 'actions.cancel'). */
   export let cancelText = $_('actions.cancel')
+  /** @type {string} text of the confirmation button (default to 'actions.confirm'). */
   export let confirmText = $_('actions.confirm')
 
+  /** @type {import('svelte').EventDispatcher<{ close: boolean }>}*/
   const dispatch = createEventDispatcher()
+  /** @type {?boolean} */
   let confirmed = null
+  /** @type {?HTMLButtonElement} */
   let cancelButtonRef = null
 
   $: if (cancelButtonRef) {
     cancelButtonRef.focus()
   }
 
-  function handleClose(event) {
+  function handleClose(
+    /** @type {import('svelte').ComponentEvents<Dialogue>['close']} */ event
+  ) {
     event.stopImmediatePropagation()
     dispatch('close', confirmed ?? false)
     confirmed = null
@@ -26,7 +39,7 @@
   }
 </script>
 
-<Dialogue closable {open} {...$$restProps} on:close={handleClose}>
+<Dialogue closable {open} {title} {...$$restProps} on:close={handleClose}>
   {message}
   <slot />
   <svelte:fragment slot="buttons">

--- a/apps/web/src/components/ControlsHelp.svelte
+++ b/apps/web/src/components/ControlsHelp.svelte
@@ -1,4 +1,10 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@tabulous/server/src/graphql/types').ActionSpec} ActionSpec
+   * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+   */
+
   import { buttonIds } from '@src/3d/utils/actions'
   import { isTouchScreen } from '@src/utils'
   import { _ } from 'svelte-intl'
@@ -9,7 +15,9 @@
   import HelpKey from './HelpKey.svelte'
   import Skeleton from './Skeleton.svelte'
 
+  /** @type {Map<keyof ActionSpec, ActionName[]>} map of action names by a given button. */
   export let actionNamesByButton = new Map()
+  /** @type {Map<string, ActionName[]>} map of action names by a given shorcut. */
   export let actionNamesByKey = new Map()
 
   const isTouch = isTouchScreen()
@@ -21,11 +29,12 @@
   $: button2Actions = actionNamesByButton?.get(buttonIds.button2)
   $: button3Actions = actionNamesByButton?.get(buttonIds.button3)
 
-  function mapToLabels(actions) {
+  function mapToLabels(/** @type {ActionName[]} */ actions) {
     return actions.map(action => $_(`labels.help-${action}`)).join('<br/>')
   }
 </script>
 
+<!-- eslint-disable svelte/no-at-html-tags -->
 <div>
   <h3>{$_('titles.object-controls')}</h3>
   <dl>
@@ -33,7 +42,8 @@
       {#await iconPromise}
         <Skeleton height="74px" {tone} />
       {:then { RightObject, TwoPointersObject }}
-        {#if isTouch}<TwoPointersObject />{:else} <RightObject />{/if}
+        {#if isTouch}<TwoPointersObject />{:else}
+          <RightObject />{/if}
       {/await}
     </dt>
     <dd>{$_('labels.help-open-menu')}</dd>
@@ -53,7 +63,8 @@
       {#await iconPromise}
         <Skeleton height="55px" {tone} />
       {:then { LeftDragObject, PointerDragObject }}
-        {#if isTouch}<PointerDragObject />{:else} <LeftDragObject />{/if}
+        {#if isTouch}<PointerDragObject />{:else}
+          <LeftDragObject />{/if}
       {/await}
     </dt>
     <dd>{$_('labels.help-move')}</dd>
@@ -61,7 +72,8 @@
       {#await iconPromise}
         <Skeleton height="55px" {tone} />
       {:then { LeftDrag, PointerDrag }}
-        {#if isTouch}<PointerDrag />{:else} <LeftDrag />{/if}
+        {#if isTouch}<PointerDrag />{:else}
+          <LeftDrag />{/if}
       {/await}
     </dt>
     <dd>{$_('labels.help-add-to-selection')}</dd>
@@ -69,7 +81,8 @@
       {#await iconPromise}
         <Skeleton height="80px" {tone} />
       {:then { LeftOutside, PointerOutside }}
-        {#if isTouch}<PointerOutside />{:else} <LeftOutside />{/if}
+        {#if isTouch}<PointerOutside />{:else}
+          <LeftOutside />{/if}
       {/await}
     </dt>
     <dd>{$_('labels.help-clear-selection')}</dd>
@@ -81,7 +94,8 @@
       {#await iconPromise}
         <Skeleton height="55px" {tone} />
       {:then { Arrows, RightDrag, TwoPointersDrag }}
-        {#if isTouch}<TwoPointersDrag />{:else} <RightDrag />{/if}
+        {#if isTouch}<TwoPointersDrag />{:else}
+          <RightDrag />{/if}
         <Arrows />
       {/await}
     </dt>
@@ -90,7 +104,8 @@
       {#await iconPromise}
         <Skeleton height="74px" {tone} />
       {:then { CtrlArrows, MiddleDrag, ThreePointersDrag }}
-        {#if isTouch}<ThreePointersDrag />{:else} <MiddleDrag />{/if}
+        {#if isTouch}<ThreePointersDrag />{:else}
+          <MiddleDrag />{/if}
         <CtrlArrows />
       {/await}
     </dt>
@@ -99,7 +114,8 @@
       {#await iconPromise}
         <Skeleton height="70px" {tone} />
       {:then { MouseWheel, Pinch }}
-        {#if isTouch}<Pinch />{:else} <MouseWheel />{/if}
+        {#if isTouch}<Pinch />{:else}
+          <MouseWheel />{/if}
       {/await}
     </dt>
     <dd>{$_('labels.help-zoom')}</dd>

--- a/apps/web/src/components/Dialogue.svelte
+++ b/apps/web/src/components/Dialogue.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { afterUpdate, createEventDispatcher, onMount } from 'svelte'
   import { fly } from 'svelte/transition'
   import Portal from 'svelte-portal'
@@ -6,12 +7,18 @@
   import Button from './Button.svelte'
   import Pane from './Pane.svelte'
 
+  /** @type {boolean} whether this dialogur is open. */
   export let open
+  /** @type {string} dialogue main title. */
   export let title
+  /** @type {boolean} whether this dialogue could be closed by clicking on the backdrop or hitting ESC key. */
   export let closable = true
 
+  /** @type {import('svelte').EventDispatcher<{ close: void, open: void }>}*/
   const dispatch = createEventDispatcher()
+  /** @type {number} */
   const duration = 150
+  /** @type {?boolean} */
   let previous = null
 
   onMount(() => {
@@ -35,7 +42,7 @@
     }
   }
 
-  function handleKey({ key }) {
+  function handleKey(/** @type {KeyboardEvent} */ { key }) {
     if (key === 'Escape') {
       close()
     }

--- a/apps/web/src/components/Discussion.svelte
+++ b/apps/web/src/components/Discussion.svelte
@@ -1,14 +1,24 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').Game} Game
+   * @typedef {import('@src/stores/game-manager').Player} Player
+   */
+
   import { Button, Input } from '@src/components'
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
+  /** @type {Game['messages']} discussion thread. */
   export let thread
+  /** @type {Map<string, Player>} a map of player details by their id. */
   export let playerById
 
+  /** @type {import('svelte').EventDispatcher<{ sendMessage: { text: string } }>} */
   const dispatch = createEventDispatcher()
   let text = ''
-  let messageContainer
+  /** @type {?HTMLDivElement} */
+  let messageContainer = null
 
   $: if (messageContainer && thread) {
     // automatically scrolls to last when receiving a new message

--- a/apps/web/src/components/Dropdown.svelte
+++ b/apps/web/src/components/Dropdown.svelte
@@ -1,28 +1,48 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/components').MenuOption} MenuOption */
+
   import { createEventDispatcher } from 'svelte'
 
   import Button from './Button.svelte'
   import Menu from './Menu.svelte'
 
+  /** @type {MenuOption[]} options displayed in the drop down menu. */
   export let options
+  /** @type {?MenuOption} currently active option. */
   export let value = null
+  /** @type {boolean} whether to use the active option as button text, or fixed text. */
   export let valueAsText = true
+  /** @type {boolean} whether to display a drop down arrow in the button. */
   export let withArrow = true
+  /** @type {?string} fixed button text, unless using `valueAsText`. */
   export let text = null
+  /** @type {boolean} whether the drop down menu is open. */
   export let open = false
+  /** @type {boolean} whether the drop down menu should open when clicking on the button. */
   export let openOnClick = true
 
+  /** @type {import('svelte').EventDispatcher<{ click: void, select: ?MenuOption, close: void }>} */
   const dispatch = createEventDispatcher()
+  /** @type {?HTMLUListElement } reference to the menu. */
   let menu
+  /** @type {?HTMLSpanElement } reference to the button's wrapper. */
   let anchor
 
   $: iconOnly = !valueAsText && !text
+  $: optionAColor =
+    value && typeof value === 'object' && 'color' in value ? value.color : null
   $: if (valueAsText) {
-    text = value?.color
-      ? ' '
-      : value && options?.includes(value)
-      ? value.label || value
-      : null
+    text =
+      !value || (typeof value === 'object' && 'color' in value)
+        ? ' '
+        : options?.includes(value)
+        ? typeof value === 'object' && 'Component' in value
+          ? null
+          : typeof value === 'string'
+          ? value
+          : value.label
+        : null
   }
 
   function handleClick() {
@@ -40,7 +60,7 @@
     }
   }
 
-  function handleKey(event) {
+  function handleKey(/** @type {KeyboardEvent} */ event) {
     if (event.key === ' ' || event.key === 'Enter') {
       event.preventDefault()
       handleArrowClick()
@@ -60,8 +80,8 @@
     <slot name="icon" />
     <span
       slot="text"
-      style:--color={value?.color}
-      class:color={Boolean(value?.color)}>{text || ''}</span
+      style:--color={optionAColor}
+      class:color={Boolean(optionAColor)}>{text || ''}</span
     >
     {#if withArrow && options.length > 1}
       <i

--- a/apps/web/src/components/Dropdown.svelte
+++ b/apps/web/src/components/Dropdown.svelte
@@ -30,11 +30,11 @@
   let anchor
 
   $: iconOnly = !valueAsText && !text
-  $: optionAColor =
+  $: optionColor =
     value && typeof value === 'object' && 'color' in value ? value.color : null
   $: if (valueAsText) {
     text =
-      !value || (typeof value === 'object' && 'color' in value)
+      !value || optionColor
         ? ' '
         : options?.includes(value)
         ? typeof value === 'object' && 'Component' in value
@@ -80,8 +80,8 @@
     <slot name="icon" />
     <span
       slot="text"
-      style:--color={optionAColor}
-      class:color={Boolean(optionAColor)}>{text || ''}</span
+      style:--color={optionColor}
+      class:color={Boolean(optionColor)}>{text || ''}</span
     >
     {#if withArrow && options.length > 1}
       <i

--- a/apps/web/src/components/FriendList/FriendList.svelte
+++ b/apps/web/src/components/FriendList/FriendList.svelte
@@ -1,15 +1,25 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').Friendship} Friendship
+   * @typedef {import('@src/graphql').PlayerFragment} PlayerFragment
+   */
+
   import { acceptFriendship, endFriendship } from '@src/stores'
   import { _ } from 'svelte-intl'
 
   import { Button, ConfirmDialogue, PlayerThumbnail } from '..'
 
+  /** @type {Friendship[]} list of displayed friendships. */
   export let friends = []
 
-  let friendToRemove
+  /** @type {?PlayerFragment}*/
+  let friendToRemove = null
 
-  function handleEndingFriendship({ detail: isConfirmed }) {
-    if (isConfirmed) {
+  function handleEndingFriendship(
+    /** @type {CustomEvent<boolean>} */ { detail: isConfirmed }
+  ) {
+    if (isConfirmed && friendToRemove) {
       endFriendship(friendToRemove)
     }
     friendToRemove = null

--- a/apps/web/src/components/FriendList/InviteDialogue.svelte
+++ b/apps/web/src/components/FriendList/InviteDialogue.svelte
@@ -1,23 +1,37 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').GameOrGameParameters} GameOrGameParameters
+   * @typedef {import('@src/graphql').PlayerFragment} Player
+   * @typedef {import('@src/graphql').Friendship} Friendship
+   */
+
   import { invite } from '@src/stores'
   import { isLobby } from '@src/utils'
   import { _ } from 'svelte-intl'
 
   import { Button, Dialogue, PlayerThumbnail } from '..'
 
-  /** @type {boolean} */
+  /** @type {boolean} whether this dialogue is opened. */
   export let open
+  /** @type {GameOrGameParameters} game data.*/
   export let game
+  /** @type {Friendship[]} */
   export let friends
 
+  /** @type {Player[]} */
   let selected = []
+  /** @type {?HTMLOListElement} */
   let listRef
 
   $: if (open && listRef?.children.length) {
-    listRef.children[0].focus({ focusVisible: true })
+    // @ts-expect-error: focusVisible does exist, but TS did not got the memo (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus)
+    /** @type {HTMLElement} */ listRef.children[0].focus({
+      focusVisible: true
+    })
   }
 
-  function handleToggle(player) {
+  function handleToggle(/** @type {Player}*/ player) {
     const index = selected.indexOf(player)
     if (index >= 0) {
       selected = [...selected.slice(0, index), ...selected.slice(index + 1)]
@@ -26,7 +40,10 @@
     }
   }
 
-  function handleKeyDown(evt, player) {
+  function handleKeyDown(
+    /** @type {KeyboardEvent} */ evt,
+    /** @type {Player} */ player
+  ) {
     if (evt.key === 'Enter' || evt.key === ' ') {
       handleToggle(player)
     }
@@ -46,7 +63,7 @@
   on:close
 >
   <ol role="listbox" bind:this={listRef}>
-    {#each friends as { player, isRequest, isProposal } (player.id)}
+    {#each friends as { player, isRequest } (player.id)}
       {#if !isRequest}
         <li
           role="option"

--- a/apps/web/src/components/FriendList/PlayerList.svelte
+++ b/apps/web/src/components/FriendList/PlayerList.svelte
@@ -1,17 +1,25 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').GameOrGameParameters} GameOrGameParameters
+   * @typedef {import('@src/graphql').LightPlayer} Player
+   */
+
   import { kick } from '@src/stores'
   import { isLobby } from '@src/utils'
-import { createEventDispatcher } from 'svelte'
+  import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
   import { Button, PlayerThumbnail } from '..'
 
+  /** @type {({ player: Player, isNotFriend: boolean })[]} list of game/lobby active players. */
   export let players
+  /** @type {GameOrGameParameters} game data. */
   export let game
 
   const dispatch = createEventDispatcher()
 
-  function canBeKicked(player) {
+  function canBeKicked(/** @type {Player} */ player) {
     return game && !player.isOwner && (player.isGuest || isLobby(game))
   }
 </script>

--- a/apps/web/src/components/FriendList/index.js
+++ b/apps/web/src/components/FriendList/index.js
@@ -1,2 +1,3 @@
+// @ts-check
 import Container from './Container.svelte'
 export default Container

--- a/apps/web/src/components/Header.svelte
+++ b/apps/web/src/components/Header.svelte
@@ -1,4 +1,14 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').PlayerFragment} PlayerFragment
+   * @typedef {import('@src/components').MenuOption} MenuOption
+   */
+  /**
+   * @template {import('svelte').SvelteComponent} T
+   * @typedef {import('svelte').ComponentEvents<T>} ComponentEvents
+   */
+
   import { supportedLanguages } from '@src/params/lang'
   import { logOut } from '@src/stores'
   import Logo from '@src/svg/tabulous-logo.svg?component'
@@ -11,8 +21,12 @@
   import Dropdown from './Dropdown.svelte'
   import PlayerThumbnail from './PlayerThumbnail.svelte'
 
+  /** @typedef {MenuOption & { act: () => void }} Option   */
+
+  /** @type {?PlayerFragment} current authenticated user, if any. */
   export let user = null
 
+  /** @type {Option[]}*/
   const menu = [
     {
       icon: 'settings',
@@ -27,7 +41,9 @@
     act: () => goto($page.url.href.replace(`/${$locale}/`, `/${lang}/`))
   }))
 
-  function handleSelectMenuItem({ detail: item }) {
+  function handleSelectMenuItem(
+    /** @type {CustomEvent<Option>} */ { detail: item }
+  ) {
     item.act()
   }
 
@@ -88,7 +104,8 @@
 
     button {
       @apply relative text-$primary transform-gpu transition-all p-2 rounded-full;
-      box-shadow: 0 3px var(--shadow-blur) var(--shadow-color),
+      box-shadow:
+        0 3px var(--shadow-blur) var(--shadow-color),
         inset 0 2px var(--primary);
 
       &:hover,

--- a/apps/web/src/components/HelpButton1.svelte
+++ b/apps/web/src/components/HelpButton1.svelte
@@ -1,4 +1,5 @@
 <script>
+  // ts-check
   import { LeftObject, PointerObject } from '@src/svg/help'
   import { isTouchScreen } from '@src/utils'
 </script>

--- a/apps/web/src/components/HelpButton2.svelte
+++ b/apps/web/src/components/HelpButton2.svelte
@@ -1,4 +1,5 @@
 <script>
+  // ts-check
   import { DoubleLeftObject, DoublePointerObject } from '@src/svg/help'
   import { isTouchScreen } from '@src/utils'
 </script>

--- a/apps/web/src/components/HelpButton3.svelte
+++ b/apps/web/src/components/HelpButton3.svelte
@@ -1,4 +1,5 @@
 <script>
+  // ts-check
   import { LongLeftObject, LongPointerObject } from '@src/svg/help'
   import { isTouchScreen } from '@src/utils'
 </script>

--- a/apps/web/src/components/HelpKey.svelte
+++ b/apps/web/src/components/HelpKey.svelte
@@ -1,8 +1,16 @@
 <script>
+  // ts-check
+  /**
+   * @typedef {import('@src/utils').CssColorVariables} CssColorVariables
+   */
+
   import Skeleton from './Skeleton.svelte'
 
+  /** @type {string} documented key. */
   export let key = ''
+  /** @type {string} skeleton's height (css style). */
   export let height
+  /** @type {CssColorVariables} skeleton's color scheme variable */
   export let tone
 
   const iconPromise = import('@src/svg/help')

--- a/apps/web/src/components/InfoDialogue.svelte
+++ b/apps/web/src/components/InfoDialogue.svelte
@@ -1,22 +1,28 @@
 <script>
+  // @ts-check
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
   import Button from './Button.svelte'
   import Dialogue from './Dialogue.svelte'
 
+  /** @type {string} displayed information message. */
   export let message = ''
+  /** @type {string} text displayed on the single button. */
   export let okText = $_('actions.ok')
 
+  /** @type {import('svelte').EventDispatcher<{ close: void }>} */
   const dispatch = createEventDispatcher()
+  /** @type {?HTMLButtonElement} */
   let okButtonRef = null
+  let restProps = /** @type {{ title: string, open: boolean }} */ ($$restProps)
 
   $: if (okButtonRef) {
     okButtonRef.focus()
   }
 </script>
 
-<Dialogue closable {...$$restProps} on:close>
+<Dialogue closable {...restProps} on:close>
   {message}
   <slot />
   <svelte:fragment slot="buttons">

--- a/apps/web/src/components/Input.svelte
+++ b/apps/web/src/components/Input.svelte
@@ -1,14 +1,20 @@
 <script>
+  // @ts-check
   import { createEventDispatcher } from 'svelte'
 
-  export let placeholder = null
+  /** @type {string} input current value. */
   export let value = ''
-  export let ref = null
+  /** @type {boolean} whether this input is disabled. */
   export let disabled = false
+  /** @type {?string} optional displayed placeholder. */
+  export let placeholder = null
+  /** @type {?HTMLInputElement} optional reference to the input element. */
+  export let ref = null
 
+  /** @type {import('svelte').EventDispatcher<{ enter: { value: string } }>} */
   const dispatch = createEventDispatcher()
 
-  function handleKey(event) {
+  function handleKey(/** @type {KeyboardEvent} */ event) {
     if (event.key === 'Enter') {
       dispatch('enter', { value })
     }

--- a/apps/web/src/components/Label.svelte
+++ b/apps/web/src/components/Label.svelte
@@ -1,9 +1,19 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/utils').ScreenPosition} ScreenPosition
+   */
+
+  /** @type {string} label's content. */
   export let content
+  /** @type {undefined|(() => void)} an optional callback when label is clicked. */
   export let onClick
+  /** @type {boolean|undefined} whether this label is currently hovered. */
   export let hovered
+  /** @type {ScreenPosition} absolute screen position for this label (0,0 by default). */
   export let screenPosition = { x: 0, y: 0 }
-  export let color = '#7a7a7a'
+  /** @type {string|undefined} label's color (hexcode or color name). */
+  export let color = undefined
 
   function interact() {
     onClick?.()
@@ -12,9 +22,8 @@
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
-  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}; pointer-events:{onClick
-    ? 'auto'
-    : 'none'};"
+  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color ??
+    '#7a7a7a'}; pointer-events:{onClick ? 'auto' : 'none'};"
   class:hovered
   on:click={interact}
   on:keydown={interact}

--- a/apps/web/src/components/Markdown.svelte
+++ b/apps/web/src/components/Markdown.svelte
@@ -1,10 +1,14 @@
 <script>
+  // @ts-check
   import { _ } from 'svelte-intl'
   import SvelteMarkdown from 'svelte-markdown'
 
-  export let options = {}
-  export let titleKey
+  /** @type {string} i18n key for the markdown content. */
   export let contentKey
+  /** @type {?string} optional i18n key for the title.*/
+  export let titleKey = null
+  /** @type {Omit<import('svelte-markdown').Props, 'source'>} extra options for SvelteMarkdown. */
+  export let options = {}
 </script>
 
 <section>

--- a/apps/web/src/components/PageFooter.svelte
+++ b/apps/web/src/components/PageFooter.svelte
@@ -1,7 +1,9 @@
 <script>
+  // @ts-check
   import { _, locale } from 'svelte-intl'
 
   import Button from './Button.svelte'
+
   const year = new Date().getFullYear()
 
   function scrollToTop() {

--- a/apps/web/src/components/Pane.svelte
+++ b/apps/web/src/components/Pane.svelte
@@ -1,6 +1,11 @@
 <script>
+  // @ts-check
+
+  /** @type {?string} this pane's title. */
   export let title = null
+  /** @type {number} HTML heading level used (defaults to 2). */
   export let heading = 2
+  /** @type {'base'|'primary'|'secondary'} color scheme used (defaults to 'base'). */
   export let backgroundColor = 'base'
 </script>
 

--- a/apps/web/src/components/PlayerThumbnail.svelte
+++ b/apps/web/src/components/PlayerThumbnail.svelte
@@ -1,12 +1,20 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/graphql').PlayerFragment} PlayerFragment
+   * @typedef {import('@src/utils').ScreenPosition} ScreenPosition
+   */
   import { abbreviate } from '../utils'
 
-  export let player = {}
+  /** @type {PlayerFragment & { color?: string }} displayed player. */
+  export let player = { id: '', username: '' }
+  /** @type {number} size for this thumbnail. */
   export let dimension = 60
+  /** @type {?ScreenPosition} optional screen position, relative to the absolute parent. */
   export let screenPosition = null
 
   $: isShort = dimension < 60
-  $: hasImage = player?.avatar
+  $: hasImage = Boolean(player?.avatar)
   $: caption = isShort ? abbreviate(player?.username) : player?.username
   $: style = formatVariables()
 

--- a/apps/web/src/components/Progress.svelte
+++ b/apps/web/src/components/Progress.svelte
@@ -1,4 +1,7 @@
 <script>
+  // @ts-check
+
+  /** @type {number} size of this circular progress. */
   export let radius = 35
 </script>
 

--- a/apps/web/src/components/QuantityButton.svelte
+++ b/apps/web/src/components/QuantityButton.svelte
@@ -1,13 +1,19 @@
 <script>
+  // @ts-check
   import { createEventDispatcher } from 'svelte'
 
   import Button from './Button.svelte'
 
+  /** @type {boolean} whether this button is primary or base. */
   export let primary = false
+  /** @type {boolean} whether this button is disabled. */
   export let disabled = false
+  /** @type {number} the current quantity displayed. */
   export let quantity = 1
+  /** @type {number} maximum quantity allowed. */
   export let max = 1000
 
+  /** @type {import('svelte').EventDispatcher<{ click: { quantity: number } }>} */
   const dispatch = createEventDispatcher()
 
   function stepUp() {
@@ -26,17 +32,17 @@
     }
   }
 
-  function handleUp(event) {
+  function handleUp(/** @type {MouseEvent} */ event) {
     event.stopPropagation()
     stepUp()
   }
 
-  function handleDown(event) {
+  function handleDown(/** @type {MouseEvent} */ event) {
     event.stopPropagation()
     stepDown()
   }
 
-  function handleKeys(event) {
+  function handleKeys(/** @type {KeyboardEvent} */ event) {
     switch (event.code) {
       case 'ArrowUp':
       case 'ArrowRight':
@@ -55,7 +61,7 @@
     }
   }
 
-  function handleClick(event) {
+  function handleClick(/** @type {MouseEvent} */ event) {
     event.stopPropagation()
     dispatch('click', { quantity })
   }

--- a/apps/web/src/components/RuleViewer.svelte
+++ b/apps/web/src/components/RuleViewer.svelte
@@ -1,38 +1,51 @@
 <script>
+  // @ts-check
   import { gameAssetsUrl } from '@src/utils'
   import { createEventDispatcher } from 'svelte'
   import { _, locale } from 'svelte-intl'
 
   import Button from './Button.svelte'
 
+  /** @type {number} current page index (0-based). */
   export let page = 0
+  /** @type {number} number of pages displayed. */
   export let lastPage = 0
   export let game = ''
+  /** @type {number} maximum viewport zoom allowed. */
   export let maxZoom = 1.5
+  /** @type {number} minimum viewport zoom allowed. */
   export let minZoom = 0.3
 
+  /** @type {import('svelte').EventDispatcher<{ change: { page: number } }>} */
   const dispatch = createEventDispatcher()
+  /** @type {{ width: number, height: number }} viewport dimension */
   let dimension = { width: 0, height: 0 }
+  /** @type {number} current zoom. */
   let zoom = minZoom
+  /** @type {?{ x: number, y: number, top: number, left: number }} current position in the viewport. */
   let pos = null
-  let container = null
-  let image = null
+  /** @type {HTMLDivElement} */
+  let container
+  /** @type {HTMLImageElement} */
+  let image
 
   function handleNavigate(previous = false) {
     page += previous ? -1 : 1
     dispatch('change', { page })
   }
 
-  function handleImageLoaded({ target }) {
+  function handleImageLoaded(
+    /** @type {Event & { currentTarget: Element }} */ { currentTarget }
+  ) {
     container.scrollTop = 0
     container.scrollLeft = 0
     setImageZoom(null)
-    const { width, height } = target.getBoundingClientRect()
+    const { width, height } = currentTarget.getBoundingClientRect()
     dimension = { width, height }
     setImageZoom(zoom)
   }
 
-  function handleDragStart({ clientX, clientY }) {
+  function handleDragStart(/** @type {MouseEvent} */ { clientX, clientY }) {
     pos = {
       left: container.scrollLeft,
       top: container.scrollTop,
@@ -43,7 +56,7 @@
     window.addEventListener('pointerup', handleDragStop)
   }
 
-  function handleDrag({ clientX, clientY }) {
+  function handleDrag(/** @type {MouseEvent} */ { clientX, clientY }) {
     if (!pos) {
       return
     }
@@ -60,16 +73,16 @@
     window.removeEventListener('pointerup', handleDragStop)
   }
 
-  function handleZoom({ deltaY }) {
+  function handleZoom(/** @type {WheelEvent} */ { deltaY }) {
     zoom = capZoom(zoom + (deltaY < 0 ? 0.1 : -0.1))
     setImageZoom(zoom)
   }
 
-  function capZoom(zoom) {
+  function capZoom(/** @type {number} */ zoom) {
     return zoom < minZoom ? minZoom : zoom > maxZoom ? maxZoom : zoom
   }
 
-  function setImageZoom(zoom) {
+  function setImageZoom(/** @type {?number} */ zoom) {
     image.style.width = zoom ? `${dimension.width * zoom}px` : ''
     image.style.height = zoom ? `${dimension.height * zoom}px` : ''
   }

--- a/apps/web/src/components/Skeleton.svelte
+++ b/apps/web/src/components/Skeleton.svelte
@@ -1,12 +1,19 @@
 <script>
+  // ts-check
+
+  /** @typedef {import('@src/utils').CssColorVariables} CssColorVariables*/
+
+  /** @type {string} component's width (css style). **/
   export let width = '100%'
+  /** @type {string} component's height (css style). **/
   export let height = '100%'
+  /** @type {CssColorVariables} css variable used as background color. **/
   export let tone = 'base-dark'
 
   $: background = `var(--${tone})`
   $: light = `var(--${computeLight(tone)})`
 
-  function computeLight(color) {
+  function computeLight(/** @type {CssColorVariables} */ color) {
     const [name, shade] = color.split('-')
     const newShade =
       shade === 'darkest'

--- a/apps/web/src/components/Skeleton.svelte
+++ b/apps/web/src/components/Skeleton.svelte
@@ -38,7 +38,7 @@
   style:--light={light}
 />
 
-<style type="postcss">
+<style lang="postcss">
   span {
     @apply inline-block rounded-xl;
     background-color: var(--background);

--- a/apps/web/src/components/SoundMeter.svelte
+++ b/apps/web/src/components/SoundMeter.svelte
@@ -1,10 +1,12 @@
 <script>
+  // @ts-check
   import { BehaviorSubject } from 'rxjs'
   import { onDestroy } from 'svelte'
 
+  /** @type {?MediaStream} monitored media stream. */
   export let mediaStream = null
 
-  const levelDb = new BehaviorSubject()
+  const levelDb = new BehaviorSubject(0)
   const audioContext = new AudioContext()
   const refreshDelayMs = 250
 
@@ -12,8 +14,10 @@
   analyser.fftSize = 512
   const samples = new Float32Array(analyser.fftSize)
 
-  let input = null
-  let timer = null
+  /** @type {MediaStreamAudioSourceNode} */
+  let input
+  /** @type {ReturnType<typeof setTimeout>} */
+  let timer
 
   $: if (mediaStream) {
     clearSoundMeter()

--- a/apps/web/src/components/TermsOfService.svelte
+++ b/apps/web/src/components/TermsOfService.svelte
@@ -1,8 +1,10 @@
 <script>
+  // @ts-check
   import { _ } from 'svelte-intl'
 
   import Markdown from './Markdown.svelte'
 
+  /** @type {boolean} whether to show the page title. */
   export let withTitle = true
 </script>
 

--- a/apps/web/src/components/Toaster/Container.svelte
+++ b/apps/web/src/components/Toaster/Container.svelte
@@ -30,7 +30,6 @@
 </script>
 
 <div>
-  <!-- eslint-disable-next-line no-unused-vars : we remove timeout since Message doesn't need it -->
   {#each messages as { id, ...toast } (id)}
     <Message {toast} on:close={() => removeMessage(id)} />
   {/each}

--- a/apps/web/src/components/Toaster/Container.svelte
+++ b/apps/web/src/components/Toaster/Container.svelte
@@ -1,25 +1,27 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/stores').Toast} Toast */
+
   import Message from './Message.svelte'
+
+  /** @type {?Toast} displayed toast message. */
   export let message = null
 
+  /** @type {(Toast & { id: string })[]} queue of displayed messages. */
   let messages = []
 
   $: if (message) {
     const added = {
-      ...message,
       id: `${Date.now()}_${Math.floor(Math.random() * 1000)}`,
       duration: message.duration || 4,
       ...message
     }
-    added.timeout = setTimeout(
-      () => removeMessage(added.id),
-      added.duration * 1000
-    )
+    setTimeout(() => removeMessage(added.id), added.duration * 1000)
     messages = [...messages, added]
     message = null
   }
 
-  function removeMessage(id) {
+  function removeMessage(/** @type {string} */ id) {
     const index = messages.findIndex(candidate => candidate.id === id)
     if (index >= 0) {
       messages = [...messages.slice(0, index), ...messages.slice(index + 1)]
@@ -28,8 +30,9 @@
 </script>
 
 <div>
-  {#each messages as { timeout, id, ...message } (id)}
-    <Message {...message} on:close={() => removeMessage(id)} />
+  <!-- eslint-disable-next-line no-unused-vars : we remove timeout since Message doesn't need it -->
+  {#each messages as { id, ...toast } (id)}
+    <Message {toast} on:close={() => removeMessage(id)} />
   {/each}
 </div>
 

--- a/apps/web/src/components/Toaster/Message.svelte
+++ b/apps/web/src/components/Toaster/Message.svelte
@@ -1,17 +1,19 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/stores').Toast} Toast */
+
   import { onMount } from 'svelte'
 
   import Button from '../Button.svelte'
 
-  export let icon = ''
-  export let content = ''
-  export let duration = defaultDuration
-  export let color = defaultColor
+  /** @type {Toast} message content. */
+  export let toast
 
   const defaultColor = '#fcfcfc'
   const defaultDuration = 5
 
   let hide = false
+  /** @type {?HTMLDivElement} */
   let node
   // use absolute positioning to avoid multiple notification glitch:
   // when previous message is removed, next messages "jump" upward because
@@ -21,9 +23,9 @@
   onMount(() => {
     // find nearest visible sibling and position current message bellow
     for (
-      let previous = node.previousElementSibling;
+      let previous = /** @type {?HTMLElement} */ (node?.previousElementSibling);
       previous;
-      previous = previous.previousElementSibling
+      previous = /** @type {?HTMLElement} */ (previous.previousElementSibling)
     ) {
       const styles = getComputedStyle(previous)
       if (styles.opacity !== '0') {
@@ -38,12 +40,13 @@
 <div
   class:hide
   bind:this={node}
-  style="--top:{top}px; --bg-color:{color ||
-    defaultColor}; --duration:{duration ||
-    defaultDuration}s; --close-duration:{duration / 10}s"
+  style="--top:{top}px; --bg-color:{toast.color ??
+    defaultColor}; --duration:{toast.duration ??
+    defaultDuration}s; --close-duration:{(toast.duration ?? defaultDuration) /
+    10}s"
 >
-  <span class="material-icons">{icon}</span>
-  <strong>{content}</strong>
+  {#if toast.icon}<span class="material-icons">{toast.icon}</span>{/if}
+  <strong>{toast.content}</strong>
   <Button transparent={true} icon="close" on:click={() => (hide = true)} />
 </div>
 

--- a/apps/web/src/components/Toaster/index.js
+++ b/apps/web/src/components/Toaster/index.js
@@ -1,2 +1,3 @@
+// @ts-check
 import Container from './Container.svelte'
 export default Container

--- a/apps/web/src/components/Typeahead.svelte
+++ b/apps/web/src/components/Typeahead.svelte
@@ -1,20 +1,31 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/components').LabelMenuOption} LabelMenuOption */
+
   import { tick } from 'svelte'
 
   import Input from './Input.svelte'
   import Menu from './Menu.svelte'
 
-  export let value = null
+  /** @typedef {(Record<string, ?> & string)|LabelMenuOption} MenuOption */
+
+  /** @type {MenuOption[]} options displayed in the drop down menu. */
   export let options
+  /** @type {?MenuOption} currently active option. */
+  export let value = null
+  /** @type {?HTMLInputElement} reference to the input text field. */
   export let ref = null
+  /** @type {?HTMLSpanElement } reference to the button's wrapper. */
   let anchor
-  let open
+  let open = false
+  /** @type {?HTMLUListElement } reference to the menu. */
   let menu
+  /** @type {string} text displayed in the field, based on input or selected option. */
   let text
 
   $: if (value) {
     // updates text based on current option
-    text = value?.label ?? value
+    text = typeof value === 'string' ? value : value.label
   } else {
     text = ''
   }
@@ -24,13 +35,13 @@
     open = true
   }
 
-  async function handleKeyUp(evt) {
+  async function handleKeyUp(/** @type {KeyboardEvent} */ evt) {
     if (!open || !menu) {
       return
     }
     if (evt.key === 'ArrowDown' || evt.key === 'ArrowUp') {
       // set menu's direction when looking for focusable
-      menu.dataset.focusNext = evt.key === 'ArrowDown'
+      menu.dataset.focusNext = `${evt.key === 'ArrowDown'}`
       menu.focus()
       evt.preventDefault()
     } else if (evt.key === 'ArrowRight' || evt.key === 'Enter') {
@@ -41,12 +52,14 @@
       }
     } else {
       // matches possible option with current text
-      const text = evt.currentTarget.value
+      const text = /** @type {HTMLInputElement} */ (evt.target).value
       await tick()
-      value = options?.find(
-        option =>
-          option?.label === text || (option === text && !option?.disabled)
-      )
+      value =
+        options?.find(option =>
+          typeof option === 'string'
+            ? option === text
+            : !option.disabled && option.label === text
+        ) ?? null
     }
   }
 </script>

--- a/apps/web/src/components/UsernameSearchability.svelte
+++ b/apps/web/src/components/UsernameSearchability.svelte
@@ -1,9 +1,11 @@
 <script>
+  // @ts-check
   import { setUsernameSearchability } from '@src/stores'
   import { _ } from 'svelte-intl'
-  
+
   import { invalidate } from '$app/navigation'
 
+  /** @type {boolean} whether player's username is searchable. */
   export let searchable = false
 
   async function handleToggle() {

--- a/apps/web/src/components/index.js
+++ b/apps/web/src/components/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 export { default as Aside } from './Aside/index.js'
 export { default as Breadcrumb } from './Breadcrumb.svelte'
 export { default as Button } from './Button.svelte'

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -225,8 +225,8 @@ mutation invite($gameId: ID!, $playerIds: [ID!]!) {
   }
 }
 
-mutation kick($gameId: ID!, $kickedId: ID!) {
-  kick(gameId: $gameId, playerId: $kickedId) {
+mutation kick($gameId: ID!, $playerId: ID!) {
+  kick(gameId: $gameId, playerId: $playerId) {
     id
   }
 }

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -1,4 +1,4 @@
-fragment lightPlayer on Player {
+fragment lightPlayer on GamePlayer {
   id
   username
   avatar

--- a/apps/web/src/graphql/players.graphql
+++ b/apps/web/src/graphql/players.graphql
@@ -4,14 +4,18 @@ fragment player on Player {
   avatar
 }
 
+fragment authenticatedPlayer on Player {
+  ...player
+  provider
+  email
+  termsAccepted
+  usernameSearchable
+}
+
 fragment authentication on PlayerWithTurnCredentials {
   token
   player {
-    ...player
-    provider
-    email
-    termsAccepted
-    usernameSearchable
+    ...authenticatedPlayer
   }
   turnCredentials {
     username
@@ -39,8 +43,7 @@ query searchPlayers($search: String!) {
 
 mutation acceptTerms {
   acceptTerms {
-    ...player
-    termsAccepted
+    ...authenticatedPlayer
   }
 }
 

--- a/apps/web/src/hooks.server.js
+++ b/apps/web/src/hooks.server.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { pick } from 'accept-language-parser'
 import cookie from 'cookie'
 
@@ -34,10 +35,21 @@ export async function handle({ event, resolve }) {
   return setCookie(await resolve(event), locals.session?.token)
 }
 
+/**
+ * Extract authentication token from cookie.
+ * @param {Request} request - analyzed request.
+ * @returns {?string|undefined} extracted token, if any.
+ */
 function extractToken(request) {
-  return cookie.parse(request.headers.get('cookie') || '').token
+  return /** @type {?} */ (cookie.parse(request.headers.get('cookie') || ''))
+    .token
 }
 
+/**
+ * Logs out and redirect to (localized) home page.
+ * @param {string} [lang] - locale used, if any.
+ * @returns {Response} - 307 redirection.
+ */
 function logOutAndRedirect(lang) {
   return setCookie(
     new Response(null, {
@@ -47,6 +59,13 @@ function logOutAndRedirect(lang) {
   )
 }
 
+/**
+ * Analyze the accept-language request header and redirects to the
+ * localized version of the specified url.
+ * @param {URL} url - desired url.
+ * @param {?string} languageHeader - requested language, if any.
+ * @returns {Response} - 303 redirection.
+ */
 function redirectBasedOnLanguage(url, languageHeader) {
   const lang =
     pick(supportedLanguages, languageHeader, {
@@ -60,6 +79,12 @@ function redirectBasedOnLanguage(url, languageHeader) {
   })
 }
 
+/**
+ * Extracts token and redirect query parameters (both optional)
+ * to set authentication cookie and redirect to the specified url.
+ * @param {URL} url - desired url.
+ * @returns {Response} - 303 redirection.
+ */
 function extractTokenAndRedirect(url) {
   const token = url.searchParams.get('token')
   const redirect = url.searchParams.get('redirect')
@@ -75,7 +100,14 @@ function extractTokenAndRedirect(url) {
   )
 }
 
+/**
+ * Sets or unsets the authentication cookie on a given response.
+ * @param {Response} response - enriched response.
+ * @param {?string} [token] - authentication token.
+ * @returns {Response} - 303 redirection.
+ */
 function setCookie(response, token) {
+  /** @type {?} */
   const cookieOptions = {
     path: '/',
     secure: true,

--- a/apps/web/src/params/lang.js
+++ b/apps/web/src/params/lang.js
@@ -1,9 +1,16 @@
+// @ts-check
 /**
- * @type {string[]} supported language codes (default comes first).
+ * @typedef {import('@src/common').Locale} Locale
+ */
+
+/**
+ * @type {Locale[]} supported language codes (default comes first).
  */
 export const supportedLanguages = ['fr', 'en']
 
 /** @type {import('@sveltejs/kit').ParamMatcher} */
 export function match(param) {
-  return param === '' || supportedLanguages.includes(param)
+  return (
+    param === '' || supportedLanguages.includes(/** @type {Locale} */ (param))
+  )
 }

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/+layout.server.js
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/+layout.server.js
@@ -1,14 +1,9 @@
+// @ts-check
 import { redirect } from '@sveltejs/kit'
 
-import { load as defaultLoad } from '../+layout.server'
-
 /** @type {import('./$types').LayoutServerLoad} */
-export async function load(args) {
-  const data = await defaultLoad(args)
-  const {
-    url,
-    params: { lang }
-  } = args
+export async function load({ url, params: { lang }, parent }) {
+  const data = await parent()
   if (!data.session) {
     throw redirect(
       307,

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/account/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/account/+page.svelte
@@ -37,7 +37,7 @@
   /** @type {?Error} */
   let usernameError = null
   let openAvatarDialogue = false
-  let avatar = user?.avatar
+  let avatar = user.avatar
 
   const saveSubscription = username$
     .pipe(
@@ -95,7 +95,7 @@
         <span class="with-progress">
           <Input
             name="username"
-            value={user?.username}
+            value={user.username}
             disabled={isSaving}
             on:input={handleSave}
           />

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/account/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/account/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/graphql').FullPlayer} Player */
+
   import {
     Button,
     Header,
@@ -20,14 +23,21 @@
   import AvatarDialogue from './AvatarDialogue.svelte'
 
   /** @type {import('./$types').PageData} */
-  export let data = {}
+  export let data
 
+  /** @type {Subject<string>} */
   const username$ = new Subject()
-  let user = data.session.player
+  /** @type {Player} */
+  let user = data.session?.player ?? {
+    username: '',
+    id: '',
+    currentGameId: null
+  }
   let isSaving = false
+  /** @type {?Error} */
   let usernameError = null
   let openAvatarDialogue = false
-  let avatar = user.avatar
+  let avatar = user?.avatar
 
   const saveSubscription = username$
     .pipe(
@@ -48,11 +58,13 @@
 
   onDestroy(() => saveSubscription.unsubscribe())
 
-  function handleSave({ target }) {
-    username$.next(target.value)
+  function handleSave(/** @type {Event} */ { target }) {
+    username$.next(/** @type {HTMLInputElement} */ (target).value)
   }
 
-  async function handleCloseAvatarDialogue({ detail: confirmed }) {
+  async function handleCloseAvatarDialogue(
+    /** @type {CustomEvent<boolean>} */ { detail: confirmed }
+  ) {
     if (confirmed) {
       user.avatar = (await updateCurrentPlayer(user.username, avatar)).avatar
     }
@@ -83,7 +95,7 @@
         <span class="with-progress">
           <Input
             name="username"
-            value={user.username}
+            value={user?.username}
             disabled={isSaving}
             on:input={handleSave}
           />

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/account/AvatarDialogue.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/account/AvatarDialogue.svelte
@@ -1,14 +1,17 @@
 <script>
+  // @ts-check
   import { ConfirmDialogue, Input } from '@src/components'
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
+  /** @type {boolean} whether this dialogue is opened. */
   export let open
+  /** @type {string | undefined} entered avatar value. */
   export let avatar
 
   const dispatch = createEventDispatcher()
 
-  function handleKey(event) {
+  function handleKey(/** @type {KeyboardEvent} */ event) {
     if (event.key === 'Enter') {
       dispatch('close', true)
       open = false

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/+page.svelte
@@ -1,10 +1,11 @@
 <script>
+  // @ts-check
   import { _ } from 'svelte-intl'
 
   import Loading from './LoadingScreen'
 
   /** @type {import('./$types').PageData} */
-  export let data = {}
+  export let data
 </script>
 
 <svelte:head>

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/CameraSwitch.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/CameraSwitch.svelte
@@ -1,28 +1,43 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+   */
+
   import { Button } from '@src/components'
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
+  /** @type {?CameraPosition} current camera position. */
   export let current = null
+  /** @type {CameraPosition[]} all saved camera positions. */
   export let saves = []
+  /** @type {number} maximum number of saveable positions. */
   export let maxCount = 9
+  /** @type {number} number of milliseconds to hold pointer down before it is considered as long. */
   export let longTapDelay = 250
 
+  /** @type {Map<number, number>} */
   const timeByPointerId = new Map()
+  /** @type {ReturnType<setTimeout>} */
   let deferLong
 
   $: saveCount = saves.length
 
   $: isSaved = Boolean(saves.find(({ hash }) => hash === current?.hash))
 
+  /** @type {import('svelte').EventDispatcher<{ restore: { index: number }, save: { index: number }, longTap: PointerEvent }>}*/
   const dispatch = createEventDispatcher()
 
-  function handleDown(pointerId) {
-    timeByPointerId.set(pointerId, Date.now())
-    deferLong = setTimeout(() => dispatch('longTap'), longTapDelay)
+  function handleDown(/** @type {PointerEvent} */ event) {
+    timeByPointerId.set(event.pointerId, Date.now())
+    deferLong = setTimeout(() => dispatch('longTap', event), longTapDelay)
   }
 
-  function handleUp(pointerId, index) {
+  function handleUp(
+    /** @type {number} */ pointerId,
+    /** @type {number} */ index
+  ) {
     clearTimeout(deferLong)
     const start = timeByPointerId.get(pointerId)
     if (start) {
@@ -43,7 +58,7 @@
     title={$_('tooltips.save-restore-camera', { index })}
     disabled={save.hash === current?.hash}
     transparent
-    on:pointerdown={({ pointerId }) => handleDown(pointerId)}
+    on:pointerdown={event => handleDown(event)}
     on:pointerup={({ pointerId }) => handleUp(pointerId, index)}
   />{' '}
 {/each}

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/CursorInfo.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/CursorInfo.svelte
@@ -1,10 +1,23 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/3d/managers/input').LongData} LongData
+   * @typedef {import('@src/utils').ScreenPosition} ScreenPosition
+   * @typedef {import('rxjs').Subject<?>} Subject
+   * @typedef {import('rxjs').Subscription} Subscription
+   */
+
   import { onDestroy } from 'svelte'
 
+  /** @type {Subject } subject emitting when halo must be shown. */
   export let halos
+
+  /** @type {?HTMLDivElement} reference to the current halo. */
   let halo
-  let position
-  let haloSubscription
+  /** @type {?ScreenPosition} current halo's absolute position. */
+  let position = null
+  /** @type {?Subscription} */
+  let haloSubscription = null
 
   $: {
     haloSubscription?.unsubscribe()

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/FPSViewer.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/FPSViewer.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { fps } from '@src/stores/game-engine'
   import { _ } from 'svelte-intl'
 </script>

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Feedback.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Feedback.svelte
@@ -1,12 +1,20 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/utils').ScreenPosition} ScreenPosition */
+
+  /** @type {string} feedback icon. */
   export let icon = ''
+  /** @type {string} feedback content. */
   export let content = ''
-  export let color = '#ffffff'
+  /** @type {string|undefined} color hex string or name. */
+  export let color = undefined
+  /** @type {ScreenPosition} absolute screen position. */
   export let screenPosition = { x: 0, y: 0 }
 </script>
 
 <div
-  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color}"
+  style="top: {screenPosition.y}px; left: {screenPosition.x}px; --color:{color ??
+    '#ffffff'}"
 >
   <span class="material-icons">{icon}</span>{content}
 </div>

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/GameHand.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/GameHand.svelte
@@ -1,12 +1,20 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@tabulous/server/src/graphql/types').Mesh} Mesh */
+
   import { MinimizableSection } from '@src/components'
   import { beforeUpdate } from 'svelte'
   import { _ } from 'svelte-intl'
 
+  /** @type {boolean} whether the hand is visible. */
   export let visible = false
+  /** @type {Mesh[]|undefined} list of meshes in hand. */
   export let meshes = []
+  /** @type {?HTMLDivElement} reference to the hand container. */
   export let node
+  /** @type {boolean} whether the hand should be highlighted. */
   export let highlight = false
+  /** @type {string} highlight color: hex string or color name. */
   export let color = '#00ff00'
 
   let meshCount = meshes?.length ?? 0
@@ -31,7 +39,7 @@
 >
   <MinimizableSection
     placement="bottom"
-    tabs={[{ icon: 'front_hand', key: $_('shortcuts.hand') }]}
+    tabs={[{ icon: 'front_hand', key: $_('shortcuts.hand'), id: 'hand' }]}
     dimension="25vh"
     {minimized}><div class="hand" bind:this={node} /></MinimizableSection
   >

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/GameMenu.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/GameMenu.svelte
@@ -1,4 +1,10 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/components').LabelMenuOption} LabelMenuOption
+   * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+   */
+
   import { Dropdown } from '@src/components'
   import { isFullscreen, toggleFullscreen } from '@src/stores'
   import {
@@ -20,13 +26,19 @@
 
   import CameraSwitch from './CameraSwitch.svelte'
 
+  /** @type {number} number of milliseconds to hold pointer down before it is considered as long. */
   export let longTapDelay
   const homeAction = 'home'
   const fullscreenAction = 'fullscreen'
   const indicatorsAction = 'indicators'
-  const corner = buildCornerClipPath({ placement: 'top', inverted: true })
+  const [cornerId, corner] = buildCornerClipPath({
+    placement: 'top',
+    inverted: true
+  })
+  /** @type {?LabelMenuOption|undefined} */
   let value = null
 
+  /** @type {LabelMenuOption[]} */
   $: options = [
     { icon: 'home', label: $_('actions.quit-game'), id: homeAction },
     {
@@ -62,7 +74,7 @@
   }
 </script>
 
-<aside style="--corner: url(#{corner.id});">
+<aside style="--corner: url(#{cornerId});">
   <Dropdown
     title={$_('tooltips.game-menu')}
     withArrow={false}
@@ -75,18 +87,14 @@
     {longTapDelay}
     current={$currentCamera}
     saves={$cameraSaves}
-    on:longTap={() => longInputs.next()}
+    on:longTap={({ detail: event }) => longInputs.next(event)}
     on:restore={({ detail: { index } }) => restoreCamera(index)}
     on:save={({ detail: { index } }) => saveCamera(index)}
   />
 </aside>
 <svg style="width:0px; height:0px">
-  <clipPath id={corner.id} clipPathUnits="objectBoundingBox">
-    <path
-      d={corner.d}
-      transform-origin="0.5 0.5"
-      transform={corner.transform}
-    />
+  <clipPath id={cornerId} clipPathUnits="objectBoundingBox">
+    <path {...corner} />
   </clipPath>
 </svg>
 

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Indicators.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Indicators.svelte
@@ -1,16 +1,37 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+   * @typedef {import('@src/stores/game-manager').Player} Player
+   * @typedef {import('@src/stores/indicators').VisibleIndicator} VisibleIndicator
+   * @typedef {import('@src/stores/indicators').VisibleFeedback} VisibleFeedback
+   */
+
   import { actionNames } from '@src/3d/utils/actions'
   import { Label, PlayerThumbnail } from '@src/components'
 
   import Feedback from './Feedback.svelte'
+
+  /** @type {VisibleIndicator[]}*/
   export let items = []
+  /** @type {VisibleFeedback[]}*/
   export let feedbacks = []
 
-  function computeLabel(player, { size }) {
-    return player?.username ?? size
+  $: hashedItems = items.map(item => ({
+    ...item,
+    hash: `${item.id}-${item.screenPosition.x},${item.screenPosition.y}`
+  }))
+
+  function computeLabel(
+    /** @type {Player|undefined} */ player,
+    /** @type {number|undefined} */ size
+  ) {
+    return player?.username ?? size?.toString() ?? ''
   }
 
-  function computeFeedback({ action }) {
+  function computeFeedback(
+    /** @type {ActionName | 'unlock' | 'lock'} */ action
+  ) {
     return action === actionNames.push
       ? 'layers'
       : action === actionNames.pop
@@ -27,23 +48,23 @@
   }
 </script>
 
-{#each items as { screenPosition, id, mesh, player, onClick, hovered, ...rest } ({ id, screenPosition })}
-  {#if mesh}
+{#each hashedItems as { screenPosition, hash, player, onClick, hovered, ...item } (hash)}
+  {#if 'mesh' in item}
     <Label
       {screenPosition}
       {onClick}
       {hovered}
-      content={computeLabel(player, rest)}
+      content={computeLabel(player, 'size' in item ? item.size : undefined)}
       color={player?.color}
     />
   {:else}
     <PlayerThumbnail {screenPosition} {player} />
   {/if}
 {/each}
-{#each feedbacks as { screenPosition, id, player, ...rest } (id)}
+{#each feedbacks as { screenPosition, id, player, action } (id)}
   <Feedback
     {screenPosition}
-    icon={computeFeedback(rest)}
+    icon={computeFeedback(action)}
     content={player?.username ?? ''}
     color={player?.color}
   />

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/LoadingScreen/Screen.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/LoadingScreen/Screen.svelte
@@ -1,4 +1,10 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@tabulous/server/src/graphql/types').ActionSpec} ActionSpec
+   * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+   */
+
   import { buttonIds } from '@src/3d/utils/actions'
   import { HelpButton1, HelpButton2, HelpButton3 } from '@src/components'
   import { fade } from 'svelte/transition'
@@ -7,18 +13,22 @@
   import { default as Logo } from './babylon-logo.svg?component'
   import { default as Spinning } from './spinning.svg?component'
 
+  /** @type {boolean} whether the loading screen is visible; */
   export let visible = false
+
+  /** @type {Map<keyof ActionSpec, ActionName[]>} map of action names by a given button. */
   export let actionNamesByButton = new Map()
 
   $: button1Actions = actionNamesByButton?.get(buttonIds.button1)
   $: button2Actions = actionNamesByButton?.get(buttonIds.button2)
   $: button3Actions = actionNamesByButton?.get(buttonIds.button3)
 
-  function mapToLabels(actions) {
+  function mapToLabels(/** @type {ActionName[]} */ actions) {
     return actions.map(action => $_(`tooltips.${action}`)).join('<br/>')
   }
 </script>
 
+<!-- eslint-disable svelte/no-at-html-tags -->
 {#if visible}
   <div transition:fade class="overlay">
     <span>
@@ -48,7 +58,7 @@
   </div>
 {/if}
 
-<style type="postcss">
+<style lang="postcss">
   div {
     @apply flex-1 flex flex-col items-center overflow-hidden justify-center 
           z-10 bg-$base-darkest text-$ink-dark transition-colors;

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/LoadingScreen/index.js
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/LoadingScreen/index.js
@@ -1,2 +1,3 @@
+// @ts-check
 import Screen from './Screen.svelte'
 export default Screen

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/MeshDetails.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/MeshDetails.svelte
@@ -1,12 +1,18 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/3d/managers/control').MeshDetails['data']} MeshDetails */
+
   import { gameAssetsUrl, injectLocale } from '@src/utils'
   import { afterUpdate, createEventDispatcher } from 'svelte'
   import { locale } from 'svelte-intl'
 
+  /** @type {?MeshDetails} */
   export let mesh = null
 
+  /** @type {import('svelte').EventDispatcher<{ close: void, open: void }>} */
   const dispatch = createEventDispatcher()
-  let previous
+  /** @type {?MeshDetails} */
+  let previous = null
   let isListeningKey = false
   $: open = Boolean(mesh)
   $: if (open) {
@@ -43,7 +49,11 @@
     on:pointerdown|stopPropagation
   >
     <img
-      src="{gameAssetsUrl}{injectLocale(mesh?.image, 'images', $locale)}"
+      src="{gameAssetsUrl}{injectLocale(
+        /** @type {MeshDetails} */ (mesh).image,
+        'images',
+        $locale
+      )}"
       alt=""
     />
   </button>

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/Container.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/Container.svelte
@@ -1,4 +1,10 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@tabulous/server/src/utils').Schema} Schema
+   * @typedef {import('@src/types').JSONValue} JSONValue
+   */
+
   import { Button, Pane } from '@src/components'
   import { createEventDispatcher } from 'svelte'
   import { fly } from 'svelte/transition'
@@ -6,11 +12,14 @@
 
   import { buildComponents } from './utils'
 
-  export let schema = {}
+  /** @type {Schema} enforced JSON Schema object */
+  export let schema
 
+  /** @type {JSONValue} */
   let values = {}
   $: components = buildComponents(values, schema)
 
+  /** @type {import('svelte').EventDispatcher<{ submit: JSONValue }>} */
   const dispatch = createEventDispatcher()
   const duration = 300
 

--- a/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/index.js
+++ b/apps/web/src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/index.js
@@ -1,2 +1,3 @@
+// @ts-check
 import Parameters from './Container.svelte'
 export default Parameters

--- a/apps/web/src/routes/[[lang=lang]]/+layout.js
+++ b/apps/web/src/routes/[[lang=lang]]/+layout.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { initLocale } from '@src/common'
 import { initGraphQlClient } from '@src/stores'
 import { graphQlUrl } from '@src/utils'

--- a/apps/web/src/routes/[[lang=lang]]/+layout.server.js
+++ b/apps/web/src/routes/[[lang=lang]]/+layout.server.js
@@ -1,3 +1,6 @@
+// @ts-check
+/** @typedef {import('@src/common').Locale} Locale */
+
 import { redirect } from '@sveltejs/kit'
 
 const termsUrl = '/accept-terms'
@@ -18,5 +21,5 @@ export function load({ url, locals, params: { lang }, depends }) {
     )
   }
   depends('data:session')
-  return { bearer, session, timeZone, lang }
+  return { bearer, session, timeZone, lang: /** @type {Locale} */ (lang) }
 }

--- a/apps/web/src/routes/[[lang=lang]]/+layout.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { Toaster } from '@src/components'
   import { lastToast } from '@src/stores'
 </script>

--- a/apps/web/src/routes/[[lang=lang]]/+page.js
+++ b/apps/web/src/routes/[[lang=lang]]/+page.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { redirect } from '@sveltejs/kit'
 
 /** @type {import('./$types').PageLoad} */

--- a/apps/web/src/routes/[[lang=lang]]/accept-terms/+page.server.js
+++ b/apps/web/src/routes/[[lang=lang]]/accept-terms/+page.server.js
@@ -1,17 +1,26 @@
+// @ts-check
+/** @typedef {import('@src/graphql').PlayerWithTurnCredentials} PlayerWithTurnCredentials */
+/**
+ * @template T
+ * @typedef {import('@src/types').DeepRequired<T>} DeepRequired
+ */
+
 import { initGraphQlClient } from '@src/stores/graphql-client'
 import { acceptTerms } from '@src/stores/players'
 import { graphQlUrl } from '@src/utils/env'
 import { fail, redirect } from '@sveltejs/kit'
 
+/** @type {import('./$types').Actions} */
 export const actions = {
-  /** @type {import('./$types').Action} */
   default: async ({ request, locals, fetch, params: { lang } }) => {
     const form = await request.formData()
     const {
       age,
       accept,
       redirect: location
-    } = Object.fromEntries(form.entries())
+    } = /** @type {Record<string, string>} */ (
+      Object.fromEntries(form.entries())
+    )
     if (
       location &&
       (location.startsWith('http') || !location.startsWith('/'))
@@ -36,7 +45,12 @@ export const actions = {
       bearer: locals.bearer,
       subscriptionSupport: false
     })
-    locals.session.player = await acceptTerms()
+    if (locals.session) {
+      locals.session.player =
+        /** @type {DeepRequired<PlayerWithTurnCredentials>['player']} */ (
+          await acceptTerms()
+        )
+    }
     throw redirect(303, location || (lang ? `/${lang}/home` : '/home'))
   }
 }

--- a/apps/web/src/routes/[[lang=lang]]/accept-terms/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/accept-terms/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { Header, PageFooter } from '@src/components'
   import { _ } from 'svelte-intl'
 
@@ -8,7 +9,7 @@
   import ScrollableTerms from './ScrollableTerms.svelte'
 
   /** @type {import('./$types').PageData} */
-  export let data = {}
+  export let data
 
   const redirect = $page.url?.searchParams.get('redirect')
 

--- a/apps/web/src/routes/[[lang=lang]]/accept-terms/Form.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/accept-terms/Form.svelte
@@ -1,11 +1,16 @@
 <script>
+  // @ts-check
   import { Button } from '@src/components'
   import { _ } from 'svelte-intl'
 
+  /** @type {boolean} whether this form is disabled. */
   export let disabled = true
-  export let redirect = ''
+  /** @type {?string} optional url to redirect to. */
+  export let redirect = null
 
+  /** @type {?HTMLInputElement} */
   let acceptInput
+  /** @type {?HTMLInputElement} */
   let ageInput
   let submitDisabled = true
 

--- a/apps/web/src/routes/[[lang=lang]]/accept-terms/ScrollableTerms.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/accept-terms/ScrollableTerms.svelte
@@ -1,19 +1,25 @@
 <script>
+  // @ts-check
   import { TermsOfService } from '@src/components'
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
 
+  /** @type {import('svelte').EventDispatcher<{ end: void }>} */
   const dispatch = createEventDispatcher()
+  /** @type {?HTMLElement } */
   let delimiter
+  /** @type {?IntersectionObserver} */
   let intersectionObserver = null
 
   onMount(() => {
-    intersectionObserver = new IntersectionObserver(function (entries) {
-      if (entries[0].intersectionRatio > 0) {
-        dispatch('end')
-        unwireObserver()
-      }
-    })
-    intersectionObserver.observe(delimiter)
+    if (delimiter) {
+      intersectionObserver = new IntersectionObserver(function (entries) {
+        if (entries[0].intersectionRatio > 0) {
+          dispatch('end')
+          unwireObserver()
+        }
+      })
+      intersectionObserver.observe(delimiter)
+    }
   })
 
   onDestroy(unwireObserver)

--- a/apps/web/src/routes/[[lang=lang]]/home/+page.js
+++ b/apps/web/src/routes/[[lang=lang]]/home/+page.js
@@ -1,3 +1,6 @@
+// @ts-check
+/** @typedef {import('@src/graphql').Game} Game */
+
 import { createGame, listCatalog, listGames } from '@src/stores'
 import { redirect } from '@sveltejs/kit'
 
@@ -9,14 +12,16 @@ export async function load({ parent, url, params: { lang } }) {
     listCatalog(),
     hasPlayer ? listGames() : Promise.resolve(null)
   ])
+  /** @type {?Error} */
   let creationError = null
   const name = url.searchParams.get('game-name')
   if (name && hasPlayer) {
-    let gameId
+    /** @type {?Game['id']} */
+    let gameId = null
     try {
       gameId = (await createGame(name)).id
     } catch (err) {
-      creationError = err
+      creationError = /** @type {Error} */ (err)
     }
     if (gameId) {
       throw redirect(307, `${lang ? `/${lang}` : ''}/game/${gameId}`)

--- a/apps/web/src/routes/[[lang=lang]]/home/CatalogItem.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/home/CatalogItem.svelte
@@ -1,18 +1,27 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/graphql').CatalogItem} CatalogItem */
+
   import { gameAssetsUrl } from '@src/utils'
   import { createEventDispatcher } from 'svelte'
   import { _, locale } from 'svelte-intl'
 
+  /** @type {CatalogItem} displayed catalog item. */
   export let game
 
+  /** @type {import('svelte').EventDispatcher<{ select: CatalogItem & { title: string } }>}*/
   const dispatch = createEventDispatcher()
   $: title = game?.locales?.[$locale]?.title
   $: seatsHidden = !game?.maxSeats && !game?.minSeats
   $: timeHidden = !game?.minTime
   $: ageHidden = !game?.minAge
 
-  function formatCopyright(field) {
-    return game?.copyright?.[field].map(({ name }) => name).join(', ')
+  function formatCopyright(/** @type {string} */ field) {
+    return /** @type {Record<string, { name: string }[]>} */ (
+      game?.copyright
+    )?.[field]
+      .map(({ name }) => name)
+      .join(', ')
   }
 
   function formatSeats() {
@@ -76,7 +85,9 @@
   button {
     @apply relative inline-flex flex-col justify-center items-stretch h-64 flex-1 text-left rounded;
     background: var(--card-light) var(--base-lighter);
-    transition: transform var(--short), box-shadow var(--short),
+    transition:
+      transform var(--short),
+      box-shadow var(--short),
       background-position var(--long);
     box-shadow: 0px 3px 10px var(--shadow-color);
 
@@ -111,7 +122,9 @@
   legend {
     @apply inline-grid grid-rows-[min-content,1fr] grid-cols-[auto,min-content] gap-1 p-4 -m-2
            h-0 opacity-0 bg-$base-darker text-$ink-dark overflow-hidden z-1 rounded;
-    transition: opacity var(--long) var(--medium), height var(--long);
+    transition:
+      opacity var(--long) var(--medium),
+      height var(--long);
   }
 
   h3 {

--- a/apps/web/src/routes/[[lang=lang]]/home/CreateLobby.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/home/CreateLobby.svelte
@@ -1,7 +1,9 @@
 <script>
+  // @ts-check
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
 
+  /** @type {import('svelte').EventDispatcher<{ select: void }>}*/
   const dispatch = createEventDispatcher()
 
   function handleClick() {

--- a/apps/web/src/routes/[[lang=lang]]/home/GameLink.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/home/GameLink.svelte
@@ -1,30 +1,37 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/graphql').LightGame} LightGame */
+
   import { Button } from '@src/components'
   import { gameAssetsUrl, isLobby } from '@src/utils'
   import { createEventDispatcher } from 'svelte'
   import { _, locale } from 'svelte-intl'
 
+  /** @type {LightGame} displayed game or lobby. */
   export let game
+  /** @type {string} authenticated user id to determine ownership. */
   export let playerId
+  /** @type {boolean} whether this link points to the curent game/lobby. */
   export let isCurrent = false
 
+  /** @type {import('svelte').EventDispatcher<{ close: LightGame, delete: LightGame, select: LightGame }>}*/
   const dispatch = createEventDispatcher()
-  const owned = game.players.find(player => player?.isOwner)?.id === playerId
+  const owned = game.players?.find(player => player?.isOwner)?.id === playerId
   $: isALobby = isLobby(game)
   $: peerNames = game.players
-    .filter(player => player && !player.isGuest && player.id !== playerId)
+    ?.filter(player => player && !player.isGuest && player.id !== playerId)
     .map(({ username }) => username)
   $: guestNames = game.players
-    .filter(player => player && player.isGuest && player.id !== playerId)
+    ?.filter(player => player && player.isGuest && player.id !== playerId)
     .map(({ username }) => username)
   $: title = isALobby
     ? $_('titles.lobby')
-    : game.locales?.[$locale]?.title || game.locales?.fr?.title
+    : game?.locales?.[$locale]?.title || game?.locales?.fr?.title
   $: coverImage = game.kind
     ? `${gameAssetsUrl}/${game.kind}/catalog/${$locale}/cover.webp`
     : ''
 
-  function handleDelete(event) {
+  function handleDelete(/** @type {MouseEvent} */ event) {
     dispatch('delete', game)
     event.stopPropagation()
   }
@@ -33,7 +40,7 @@
     dispatch('select', game)
   }
 
-  function handleClose(event) {
+  function handleClose(/** @type {MouseEvent} */ event) {
     dispatch('close', game)
     event.stopPropagation()
   }
@@ -49,10 +56,10 @@
       <h3>{title}</h3>
     </span>
     <span class="created">{$_('{ created, date, short-date }', game)}</span>
-    {#if peerNames.length}
+    {#if peerNames?.length}
       <span>{$_('labels.peer-players', { names: peerNames.join(', ') })}</span>
     {/if}
-    {#if guestNames.length}
+    {#if guestNames?.length}
       <span class="guests"
         >{$_('labels.peer-guests', { names: guestNames.join(', ') })}</span
       >
@@ -74,8 +81,11 @@
 <style lang="postcss">
   article {
     @apply relative inline-block m-2 flex bg-$base-lighter rounded overflow-hidden;
-    transition: background-color var(--long), color var(--medium),
-      transform var(--short), box-shadow var(--short);
+    transition:
+      background-color var(--long),
+      color var(--medium),
+      transform var(--short),
+      box-shadow var(--short);
     box-shadow: 0px 3px 10px var(--shadow-color);
 
     &::before {

--- a/apps/web/src/routes/[[lang=lang]]/login/+page.server.js
+++ b/apps/web/src/routes/[[lang=lang]]/login/+page.server.js
@@ -1,25 +1,27 @@
+// @ts-check
 import { initGraphQlClient } from '@src/stores/graphql-client'
 import { logIn } from '@src/stores/players'
 import { graphQlUrl } from '@src/utils/env'
 import { fail, redirect } from '@sveltejs/kit'
 
-/** @type {import('./$types').ServerLoad} */
+/** @type {import('./$types').PageServerLoad} */
 export function load({ locals, params: { lang } }) {
   const { session = null } = locals
   if (session && session.player) {
     throw redirect(303, lang ? `/${lang}/home` : '/home')
   }
 }
-
+/** @type {import('./$types').Actions} */
 export const actions = {
-  /** @type {import('./$types').Action} */
   default: async ({ request, locals, fetch, params: { lang } }) => {
     const form = await request.formData()
     const {
       id,
       password,
       redirect: location
-    } = Object.fromEntries(form.entries())
+    } = /** @type {Record<string, string>} */ (
+      Object.fromEntries(form.entries())
+    )
     if (
       location &&
       (location.startsWith('http') || !location.startsWith('/'))
@@ -32,7 +34,7 @@ export const actions = {
       initGraphQlClient({ graphQlUrl, fetch, subscriptionSupport: false })
       locals.session = await logIn(id, password)
     } catch (error) {
-      return fail(401, { message: error.message })
+      return fail(401, { message: /** @type {Error} */ (error).message })
     }
     throw redirect(303, location || (lang ? `/${lang}/home` : '/home'))
   }

--- a/apps/web/src/routes/[[lang=lang]]/login/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/login/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  // @ts-check
   import { Header, PageFooter } from '@src/components'
   import { flags } from '@src/stores'
   import { _ } from 'svelte-intl'
@@ -10,6 +11,7 @@
   /** @type {import('./$types').ActionData} */
   export let form = null
 
+  /** @type {?HTMLInputElement} */
   let inputRef = null
   const redirect = $page.url?.searchParams.get('redirect')
 

--- a/apps/web/src/routes/[[lang=lang]]/login/Form.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/login/Form.svelte
@@ -1,22 +1,31 @@
 <script>
+  // @ts-check
   import { Button, Input, Pane } from '@src/components'
   import GithubLogo from '@src/svg/github-logo.svg?component'
   import GoogleLogo from '@src/svg/google-logo.svg?component'
   import { authUrl } from '@src/utils'
   import { _, locale } from 'svelte-intl'
 
+  /** @type {string} username identifier. */
   export let id = ''
+  /** @type {string} username password. */
   export let password = ''
+  /** @type {?string} optional url to redirect to. */
   export let redirect = null
+  /** @type {?HTMLInputElement} reference to the username input field for focusing. */
   export let inputRef = null
+  /** @type {?string} optional authentication error string. */
   export let error = null
+  /** @type {boolean} whether to display the "connect with Google" button. */
   export let withGoogle = false
+  /** @type {boolean} whether to display the "connect with Github" button. */
   export let withGithub = false
 
   $: hasProviders = withGoogle || withGithub
   $: disabled =
     !id || id.trim().length === 0 || !password || password.trim().length <= 3
 
+  /** @type {?HTMLDetailsElement} */
   let details
   let isPasswordOpen = !!error
 
@@ -24,7 +33,7 @@
     error = null
   }
 
-  function handleConnectWith(provider) {
+  function handleConnectWith(/** @type {string} */ provider) {
     let url = `${authUrl}/${provider}/connect?${new URLSearchParams({
       redirect: window.location.origin + (redirect || `/${$locale}/home`)
     }).toString()}`
@@ -32,7 +41,7 @@
   }
 
   function handleTogglePassword() {
-    isPasswordOpen = details.open
+    isPasswordOpen = Boolean(details?.open)
     if (!isPasswordOpen) {
       resetError()
     }

--- a/apps/web/src/routes/[[lang=lang]]/terms-of-service/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/terms-of-service/+page.svelte
@@ -1,9 +1,10 @@
 <script>
+  // @ts-check
   import { Header, Markdown, PageFooter, TermsOfService } from '@src/components'
   import { _ } from 'svelte-intl'
 
   /** @type {import('./$types').PageData} */
-  export let data = {}
+  export let data
 </script>
 
 <svelte:head>

--- a/apps/web/src/stores/catalog.js
+++ b/apps/web/src/stores/catalog.js
@@ -1,16 +1,16 @@
+// @ts-check
+/**
+ * @typedef {import('@tabulous/server/src/graphql/types').CatalogItem} CatalogItem
+ */
+
+import * as graphQL from '@src/graphql'
 import { get } from 'svelte/store'
 
-import * as graphQL from '../graphql'
 import { makeLogger } from '../utils'
 import { runQuery } from './graphql-client'
 import { buildLocaleComparator } from './locale'
 
 const logger = makeLogger('players')
-
-/**
- * @typedef {object} CatalogItem a catalog item
- * @property {string} name - item unique name.
- */
 
 /**
  * List all catalog items.

--- a/apps/web/src/stores/configuration.js
+++ b/apps/web/src/stores/configuration.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { BehaviorSubject } from 'rxjs'
 
 /**

--- a/apps/web/src/stores/fullscreen.js
+++ b/apps/web/src/stores/fullscreen.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { BehaviorSubject } from 'rxjs'
 
 import { browser } from '$app/environment'
@@ -12,13 +13,11 @@ const fullscreen$ = new BehaviorSubject(
 
 /**
  * Emits whenever the application enters or leaves the fullscreen mode
- * @type {Observable<boolean>}
  */
 export const isFullscreen = fullscreen$.asObservable()
 
 /**
  * Enters fullscreen mode.
- * @returns {Promise<void>}
  */
 export async function enterFullscreen() {
   if (!fullscreen$.value) {
@@ -26,14 +25,16 @@ export async function enterFullscreen() {
       await document.documentElement?.requestFullscreen()
       fullscreen$.next(true)
     } catch (error) {
-      logger.warn({ error }, `failed to enter fullscreen: ${error.message}`)
+      logger.warn(
+        { error },
+        `failed to enter fullscreen: ${/** @type {Error} */ (error).message}`
+      )
     }
   }
 }
 
 /**
  * Leaves fullscreen mode.
- * @returns {Promise<void>}
  */
 export async function leaveFullscreen() {
   if (fullscreen$.value) {
@@ -41,14 +42,16 @@ export async function leaveFullscreen() {
       document.exitFullscreen?.()
       fullscreen$.next(false)
     } catch (error) {
-      logger.warn({ error }, `failed to leave fullscreen: ${error.message}`)
+      logger.warn(
+        { error },
+        `failed to leave fullscreen: ${/** @type {Error} */ (error).message}`
+      )
     }
   }
 }
 
 /**
  * Enters or leaves fullscreen mode, updating the relevant store.
- * @returns {Promise<void>}
  */
 export async function toggleFullscreen() {
   if (fullscreen$.value) {

--- a/apps/web/src/stores/game-manager.js
+++ b/apps/web/src/stores/game-manager.js
@@ -135,13 +135,12 @@ export const gamePlayerById = merge(hostId$, playingIds$, currentGame$).pipe(
     playerById = new Map()
     const game = currentGame$.value
     if (game) {
-      for (const { id, ...player } of game.players ?? []) {
-        playerById.set(id, {
-          id,
+      for (const player of game.players ?? []) {
+        playerById.set(player.id, {
           ...player,
-          ...findPlayerPreferences(game, id),
-          playing: playingIds$.value.includes(id),
-          isHost: isCurrentHost(id)
+          ...findPlayerPreferences(game, player.id),
+          playing: playingIds$.value.includes(player.id),
+          isHost: isCurrentHost(player.id)
         })
       }
     }

--- a/apps/web/src/stores/game-manager.js
+++ b/apps/web/src/stores/game-manager.js
@@ -1,3 +1,25 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@src/3d/engine').PlayerSelection} PlayerSelection
+ * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+ * @typedef {import('@src/graphql').LightGame} LightGame
+ * @typedef {import('@src/graphql').LightPlayer} LightPlayer
+ * @typedef {import('@src/graphql').Game} Game
+ * @typedef {import('@src/graphql').GameOrGameParameters} GameOrGameParameters
+ * @typedef {import('@src/types').JSONValue} JSONValue
+ * @typedef {import('@tabulous/server/src/graphql/types').CameraPosition} SharedCameraPosition
+ * @typedef {import('@tabulous/server/src/graphql/types').Hand} Hand
+ * @typedef {import('@tabulous/server/src/graphql/types').Mesh} Mesh
+ * @typedef {import('@tabulous/server/src/graphql/types').TurnCredentials} TurnCredentials
+ * @typedef {import('rxjs').Subscription} Subscription
+ */
+/**
+ * @template T
+ * @typedef {import('rxjs').Observable<T>} Observable
+ */
+
+import * as graphQL from '@src/graphql'
 import {
   BehaviorSubject,
   combineLatest,
@@ -8,7 +30,6 @@ import {
 } from 'rxjs'
 import { get } from 'svelte/store'
 
-import * as graphQL from '../graphql'
 import {
   buildPlayerColors,
   findPlayerColor,
@@ -34,34 +55,66 @@ import { toastInfo } from './toaster'
 // dynamically import ./game-engine which depends on
 // This allows splitting production chunks and keep Babylonjs (1.6Mb uncompressed) on its own.
 
-/** @typedef {import('../graphql').lightPlayer} Player */
-/** @typedef {import('../graphql').gameData} Game */
+/**
+ * @typedef {object} _Player
+ * @property {boolean} playing - whether this player is currently playing.
+ * @property {boolean} isHost - whether this player is hosting the current game.
+ *
+ * @typedef {LightPlayer & ReturnType<typeof findPlayerPreferences> & _Player} Player
+ */
+
+/** @typedef {Game & { selections?: PlayerSelection[] }} GameWithSelections */
+
+/**
+ * @typedef {object} JoinGameArgs
+ * @property {string} gameId - the loaded game id.
+ * @property {LightPlayer} player - the current authenticated user.
+ * @property {TurnCredentials} turnCredentials - credentials used to log onto the TURN server.
+ * @property {JSONValue} [parameters] - user chosen parameters, if any.
+ * @property {(game: ?Game) => void} [onDeletion] - optional callback invoked when current game is deleted on server side.
+ * @property {(game: Game) => void} [onPromotion] - optional callback invoked when current lobby is promoted to full game.
+ */
+
+/**
+ * @typedef {object} JoinGameContext
+ * @property {import('@src/stores/game-engine')} gameEngine - lazy-loaded game engine store.
+ * @property {string} gameId - joined game id.
+ * @property {string} currentPlayerId - joining player id.
+ * @property {JoinGameArgs['onDeletion']} onDeletion - optional callback invoked when current game is deleted on server side.
+ * @property {JoinGameArgs['onPromotion']} onPromotion - optional callback invoked when current lobby is promoted to full game.
+ */
 
 const logger = makeLogger('game-manager')
-const currentGame$ = new BehaviorSubject()
-const hostId$ = new BehaviorSubject(null)
-const playingIds$ = new BehaviorSubject([])
+const currentGame$ = new BehaviorSubject(
+  /** @type {?GameOrGameParameters} */ (null)
+)
+const hostId$ = new BehaviorSubject(/** @type {?string} */ (null))
+const playingIds$ = new BehaviorSubject(/** @type {string[]} */ ([]))
+/** @type {Subscription[]} */
 const currentGameSubscriptions = []
+/** @type {?Subscription} */
 let listGamesSubscription = null
 let delayOnLoad = () => {}
+/** @type {Map<string, Player>} */
 let playerById = new Map()
 // cameras for all players
+/** @type {SharedCameraPosition[]} */
 let cameras = []
 // hands for all players
+/** @type {Hand[]} */
 let hands = []
 // active selections for all players
+/** @type {PlayerSelection[]} */
 let selections = []
 
 /**
  * Emits the player current game, or undefined.
- * @type {Observable<object>} TODO
  */
 export const currentGame = currentGame$.asObservable()
 
 /**
  * Indicates whether a given game is different from the current game.
- * @param {string} gameId? - id of the tested game.
- * @returns {boolean} true when the two games have the same id.
+ * @param {?string} [gameId] - id of the tested game.
  */
 export function isDifferentGame(gameId) {
   return currentGame$.value?.id !== gameId
@@ -69,7 +122,6 @@ export function isDifferentGame(gameId) {
 
 /**
  * Emits the player current color.
- * @type {Observable<string>}
  */
 export const playerColor = combineLatest([currentGame$, playingIds$]).pipe(
   map(([game, playingIds]) => findPlayerColor(game, playingIds[0]))
@@ -77,16 +129,13 @@ export const playerColor = combineLatest([currentGame$, playingIds$]).pipe(
 
 /**
  * Emits a map of player in current game.
- * @type {Observable<Map<string, Player>>}
  */
 export const gamePlayerById = merge(hostId$, playingIds$, currentGame$).pipe(
   map(() => {
     playerById = new Map()
     const game = currentGame$.value
     if (game) {
-      // we don't want currentGameId in gamePlayerById map
-      // eslint-disable-next-line no-unused-vars
-      for (const { id, currentGameId, ...player } of game.players) {
+      for (const { id, ...player } of game.players ?? []) {
         playerById.set(id, {
           id,
           ...player,
@@ -102,7 +151,6 @@ export const gamePlayerById = merge(hostId$, playingIds$, currentGame$).pipe(
 
 /**
  * Lists all current games.
- * @returns {Promise<Game[]>} a list of current games for the authenticated user.
  */
 export async function listGames() {
   logger.info('list current games')
@@ -111,7 +159,7 @@ export async function listGames() {
 
 /**
  * Subscribes to current game list updates, to keep the list fresh.
- * @param {Game[]} currentGames - current game list.
+ * @param {LightGame[]} [currentGames] - current game list.
  * @returns {Observable<Game[]>} an observable containing up-to-date current games.
  */
 export function receiveGameListUpdates(currentGames) {
@@ -134,7 +182,7 @@ export function receiveGameListUpdates(currentGames) {
 /**
  * Creates a new game of a given kind on server, registering current player in it,
  * and receiving its id.
- * @param {string} kind - created game kind.
+ * @param {string} [kind] - created game kind (omit to create a lobby).
  * @returns {Promise<Game>} the created game data.
  */
 export async function createGame(kind) {
@@ -181,14 +229,13 @@ export async function kick(gameId, kickedId) {
     { gameId, kickedId },
     `kick guest/player ${kickedId} from lobby/game ${gameId}`
   )
-  await runMutation(graphQL.kick, { gameId, kickedId })
+  await runMutation(graphQL.kick, { gameId, playerId: kickedId })
 }
 
 /**
  * Promotes a lobby into a full game,
  * @param {string} gameId - the promoted game id.
  * @param {string} kind - promoted game kind.
- * @returns {Promise<Game>} the created game id.
  */
 export async function promoteGame(gameId, kind) {
   logger.info(
@@ -199,16 +246,6 @@ export async function promoteGame(gameId, kind) {
 }
 
 /**
- * @typedef {object} joinGameArgs
- * @property {string} gameId - the loaded game id.
- * @property {object} player - the session details.
- * @property {object} turnCredentials - credentials used to log onto the TURN server.
- * @property {object} parameters? - user chosen parameters, if any.
- * @property {(game: Game) => void} onDeletion? - optional callback invoked when current game is deleted on server side.
- * @property {(game: Game) => void} onPromotion? - optional callback invoked when current lobby is promoted to full game.
- */
-
-/**
  * Joins an existing game, loading it from the server.
  * If server returns required paremters, navigates to the relevant page.
  * Otherwise, loads the data into the provided 3D engine.
@@ -216,8 +253,7 @@ export async function promoteGame(gameId, kind) {
  * the game and sharing it with new players.
  * If other players are connected, waits at most 30s to receive the game data from game host.
  * Resolves when the game data has been received (either as host or regular peer).
- * @param {joinGameArgs} args - operation arguments.
- * @returns {Promise<Game>} - game parameters or game data
+ * @param {JoinGameArgs} args - operation arguments.
  */
 export async function joinGame({
   gameId,
@@ -247,7 +283,7 @@ export async function joinGame({
           console.warn(
             'Since there are multiple connected players, HMR is slightly delayed to let host reconnect'
           )
-          sessionStorage.setItem(delayKey, 3000)
+          sessionStorage.setItem(delayKey, '3000')
         }
       }
     })
@@ -278,7 +314,7 @@ export async function joinGame({
   }
 
   const gameEngine = await import('./game-engine')
-  const engine = get(gameEngine.engine)
+  const engine = /** @type {Engine} */ (get(gameEngine.engine))
 
   currentGame$.next(game)
   currentGameSubscriptions.push(
@@ -292,7 +328,7 @@ export async function joinGame({
   )
 
   if (needPeerConnection) {
-    const peers = game.players.filter(
+    const peers = (game.players ?? []).filter(
       ({ id, currentGameId }) =>
         id !== currentPlayerId && currentGameId === game.id
     )
@@ -337,14 +373,16 @@ export async function joinGame({
  * Leaves current game, trigering a last save when current player is the host.
  * Shuts down peer channels.
  * Does nothing without any current game.
- * @param {object} player - the current player details.
+ * @param {Pick<Player, 'id'>} player - the current player details.
  */
 export async function leaveGame({ id: currentPlayerId }) {
   const game = currentGame$.value
   if (!game) {
     return
   }
-  const engine = get((await import('./game-engine')).engine)
+  const engine = /** @type {Engine} */ (
+    get((await import('./game-engine')).engine)
+  )
   const { id: gameId } = game
   if (isCurrentHost(currentPlayerId)) {
     logger.info({ gameId, currentPlayerId }, `persisting game before leaving`)
@@ -363,13 +401,21 @@ export async function leaveGame({ id: currentPlayerId }) {
   clearThread()
 }
 
-async function load(engine, game, playerId, firstLoad) {
+async function load(
+  /** @type {Engine} */ engine,
+  /** @type {GameOrGameParameters} */ game,
+  /** @type {string} */ playerId,
+  /** @type {boolean} */ firstLoad
+) {
   const { loadCameraSaves } = await import('./game-engine')
   currentGame$.next(game)
-  hands = game.hands ?? []
-  cameras = game.cameras ?? []
-  selections = game.selections ?? []
-  if (game.messages) {
+  hands = ('hands' in game ? game.hands : null) ?? []
+  cameras = ('cameras' in game ? game.cameras : null) ?? []
+  selections =
+    ('selections' in game
+      ? /** @type {GameWithSelections} */ (game).selections
+      : null) ?? []
+  if ('messages' in game && game.messages) {
     loadThread(game.messages)
   }
   if (cameras.length && firstLoad) {
@@ -382,10 +428,10 @@ async function load(engine, game, playerId, firstLoad) {
   }
   if (
     engine &&
-    game.players.find(({ id }) => id === playerId)?.isGuest === false
+    (game.players ?? []).find(({ id }) => id === playerId)?.isGuest === false
   ) {
     await engine.load(
-      game,
+      /** @type {Game} */ (game),
       {
         playerId,
         preferences: findPlayerPreferences(game, playerId),
@@ -396,7 +442,12 @@ async function load(engine, game, playerId, firstLoad) {
   }
 }
 
-function mergeCameras({ playerId, cameras: playerCameras }) {
+function mergeCameras(
+  /** @type {{ playerId: string, cameras: CameraPosition[] }} */ {
+    playerId,
+    cameras: playerCameras
+  }
+) {
   logger.info(
     { playerId, cameras, playerCameras },
     `merging cameras for ${playerId}`
@@ -409,12 +460,14 @@ function mergeCameras({ playerId, cameras: playerCameras }) {
   ]
 }
 
-function saveCameras(gameId) {
+function saveCameras(/** @type {string} */ gameId) {
   logger.info({ gameId, cameras }, `persisting game cameras`)
   runMutation(graphQL.saveGame, { game: { id: gameId, cameras } })
 }
 
-function mergeHands({ playerId, meshes = [] }) {
+function mergeHands(
+  /** @type {{ playerId: String, meshes?: Mesh[] }} */ { playerId, meshes = [] }
+) {
   hands = [
     ...hands.filter(hand => hand.playerId !== playerId),
     { playerId, meshes }
@@ -422,12 +475,14 @@ function mergeHands({ playerId, meshes = [] }) {
   return hands
 }
 
-function saveHands(gameId) {
+function saveHands(/** @type {string} */ gameId) {
   logger.info({ gameId, hands }, `persisting player hands`)
   runMutation(graphQL.saveGame, { game: { id: gameId, hands } })
 }
 
-function mergeSelections({ playerId, selectedIds }) {
+function mergeSelections(
+  /** @type {PlayerSelection} */ { playerId, selectedIds }
+) {
   selections = [
     ...selections.filter(selection => selection.playerId !== playerId),
     { playerId, selectedIds }
@@ -436,6 +491,7 @@ function mergeSelections({ playerId, selectedIds }) {
 }
 
 function takeHostRole(
+  /** @type {import('@src/stores/game-engine')} */
   {
     engine: engine$,
     action,
@@ -444,12 +500,12 @@ function takeHostRole(
     remoteSelection,
     selectedMeshes
   },
-  gameId,
-  currentPlayerId,
+  /** @type {string} */ gameId,
+  /** @type {string} */ currentPlayerId,
   shouldShareGame = true
 ) {
   const game = currentGame$.value
-  const engine = get(engine$)
+  const engine = /** @type {Engine} */ (get(engine$))
   logger.info({ gameId, game }, `taking game host role`)
   hostId$.next(currentPlayerId)
   if (shouldShareGame && !isLobby(game)) {
@@ -487,10 +543,14 @@ function takeHostRole(
       handMeshes.pipe(
         map(meshes => ({ data: { playerId: currentPlayerId, meshes } }))
       )
-    ).subscribe(({ data }) => {
-      mergeHands(data)
-      saveHands(gameId)
-    }),
+    ).subscribe(
+      (
+        /** @type {{ data: { playerId: string, meshes?: Mesh[]} }} */ { data }
+      ) => {
+        mergeHands(data)
+        saveHands(gameId)
+      }
+    ),
     // save camera positions
     merge(
       lastMessageReceived.pipe(
@@ -516,7 +576,9 @@ function takeHostRole(
   ]
 }
 
-function subscribePeerStatusesAndGameUpdates(params) {
+function subscribePeerStatusesAndGameUpdates(
+  /** @type {JoinGameContext} */ params
+) {
   const { gameId } = params
   return [
     runSubscription(graphQL.receiveGameUpdates, { gameId }).subscribe(
@@ -527,35 +589,46 @@ function subscribePeerStatusesAndGameUpdates(params) {
   ]
 }
 
-function handleServerUpdate({
-  gameEngine,
-  currentPlayerId,
-  onDeletion,
-  onPromotion
-}) {
-  return async function (game) {
-    const wasLobby = isLobby(currentGame$.value)
+function handleServerUpdate(
+  /** @type {JoinGameContext} */ {
+    gameEngine,
+    currentPlayerId,
+    onDeletion,
+    onPromotion
+  }
+) {
+  return async function (/** @type {GameOrGameParameters} */ game) {
+    const currentGame = /** @type {?Game} */ (currentGame$.value)
+    const wasLobby = isLobby(currentGame)
     if (!game) {
       await leaveGame({ id: currentPlayerId })
-      onDeletion?.()
+      onDeletion?.(currentGame)
     } else {
       logger.debug(
         { gameId: game.id, currentPlayerId, wasLobby, game },
         'loading game update from server'
       )
-      await load(get(gameEngine.engine), game, currentPlayerId, false)
+      await load(
+        /** @type {Engine} */ (get(gameEngine.engine)),
+        game,
+        currentPlayerId,
+        false
+      )
       if (wasLobby && !isLobby(game)) {
-        onPromotion?.(game)
+        onPromotion?.(/** @type {Game} */ (game))
       }
     }
   }
 }
 
-function serializeGame(engine, currentPlayerId) {
+function serializeGame(
+  /** @type {Engine} */ engine,
+  /** @type {string} */ currentPlayerId
+) {
   const { meshes, handMeshes } =
-    (!isLobby(currentGame$.value) && engine?.serialize()) ?? {}
+    (isLobby(currentGame$.value) ? null : engine?.serialize()) ?? {}
   return {
-    id: currentGame$.value.id,
+    id: /** @type {GameOrGameParameters} */ (currentGame$.value).id,
     meshes,
     hands: mergeHands({ playerId: currentPlayerId, meshes: handMeshes }),
     messages: serializeThread(),
@@ -563,8 +636,14 @@ function serializeGame(engine, currentPlayerId) {
   }
 }
 
-function shareGame(engine, currentPlayerId, peerId) {
-  const { id: gameId, ...otherGameData } = currentGame$.value
+function shareGame(
+  /** @type {Engine} */ engine,
+  /** @type {string} */ currentPlayerId,
+  /** @type {string} */ peerId
+) {
+  const { id: gameId, ...otherGameData } = /** @type {Game} */ (
+    currentGame$.value
+  )
   logger.info(
     { gameId },
     `sending game data ${gameId} to peer${peerId ? ` ${peerId}` : 's'}`
@@ -582,16 +661,22 @@ function unsubscribeCurrentGame() {
   currentGameSubscriptions.splice(0, currentGameSubscriptions.length)
 }
 
-function handlePeerConnection({ gameEngine, currentPlayerId }) {
-  return async function (playerId) {
+function handlePeerConnection(
+  /** @type {JoinGameContext} */ { gameEngine, currentPlayerId }
+) {
+  return async function (/** @type {string} */ playerId) {
     playingIds$.next([...playingIds$.value, playerId])
-    const game = currentGame$.value
-    if (!game.players.some(({ id }) => id === playerId)) {
+    const game = /** @type {GameOrGameParameters} */ (currentGame$.value)
+    if (!(game.players ?? []).some(({ id }) => id === playerId)) {
       const { players } = await runMutation(graphQL.getGamePlayers, game)
       currentGame$.next({ ...game, players })
     }
     if (isCurrentHost(currentPlayerId)) {
-      shareGame(get(gameEngine.engine), currentPlayerId, playerId)
+      shareGame(
+        /** @type {Engine} */ (get(gameEngine.engine)),
+        currentPlayerId,
+        playerId
+      )
     }
     toastInfo({
       icon: 'person_add_alt_1',
@@ -603,10 +688,10 @@ function handlePeerConnection({ gameEngine, currentPlayerId }) {
   }
 }
 
-function handlePeerDisconnection(params) {
+function handlePeerDisconnection(/** @type {JoinGameContext} */ params) {
   const { currentPlayerId, gameEngine } = params
-  return function (playerId) {
-    const game = currentGame$.value
+  return function (/** @type {string} */ playerId) {
+    const game = /** @type {GameOrGameParameters} */ (currentGame$.value)
     toastInfo({
       icon: 'person_remove',
       contentKey: isLobby(game)
@@ -620,28 +705,33 @@ function handlePeerDisconnection(params) {
       unsubscribeCurrentGame()
       currentGameSubscriptions.push(
         ...subscribePeerStatusesAndGameUpdates(params),
-        ...takeHostRole(gameEngine, currentGame$.value.id, currentPlayerId)
+        ...takeHostRole(gameEngine, game.id, currentPlayerId)
       )
     }
   }
 }
 
-function shareCameras(currentPlayerId) {
-  return function (cameras) {
+function shareCameras(/** @type {string} */ currentPlayerId) {
+  return function (/** @type {CameraPosition[]} */ cameras) {
     logger.info({ cameras }, `sharing camera saves with peers`)
     send({ type: 'saveCameras', cameras, playerId: currentPlayerId })
   }
 }
 
-function shareHand(currentPlayerId) {
-  return function (meshes) {
+function shareHand(/** @type {string} */ currentPlayerId) {
+  return function (/** @type {Mesh[]|undefined} */ meshes) {
     logger.info({ meshes }, `sharing hand with peers`)
     send({ type: 'saveHand', meshes, playerId: currentPlayerId })
   }
 }
 
-function isNextHost(playerId, connectedIds) {
-  const { id, players } = currentGame$.value
+function isNextHost(
+  /** @type {string} */ playerId,
+  /** @type {string[]} */ connectedIds
+) {
+  const { id, players } = /** @type {Required<Pick<Game, 'id'|'players'>>} */ (
+    currentGame$.value
+  )
   const connectedPlayers = players
     .filter(({ isGuest }) => !isGuest)
     .map(player => ({
@@ -658,10 +748,10 @@ function isNextHost(playerId, connectedIds) {
   )
 }
 
-function isCurrentHost(playerId) {
+function isCurrentHost(/** @type {string} */ playerId) {
   return playerId === hostId$.value
 }
 
-function isGameParameter(game) {
-  return Boolean(game.schemaString)
+function isGameParameter(/** @type {GameOrGameParameters} */ game) {
+  return 'schemaString' in game && Boolean(game.schemaString)
 }

--- a/apps/web/src/stores/locale.js
+++ b/apps/web/src/stores/locale.js
@@ -1,10 +1,19 @@
+// @ts-check
+/**
+ * @typedef {import('@src/common').Locale} Locale
+ */
+
 import { getValue } from '@src/utils'
 import { derived } from 'svelte/store'
 import { locale } from 'svelte-intl'
 
+/** @type {Locale} */
 const defaultLocale = 'fr'
 /* c8 ignore start */
-const locale$ = derived(locale, value => value || defaultLocale)
+const locale$ = derived(
+  locale,
+  value => /** @type {Locale} */ (value) || defaultLocale
+)
 /* c8 ignore stop */
 
 /**
@@ -18,7 +27,7 @@ export const comparator$ = derived(
 /**
  * Builds a readable store containing a function for sorting arrays, based on locale collator.
  * It can dive into compared object properties to find a comparable value.
- * @param {string} propertyPath - the path to property used for comparison.
+ * @param {string} [propertyPath] - the path to property used for comparison.
  * Use . to dive into sub-object (or array index). You can use $locale as a placeholder for a propety named after the current locale:
  * `locales.$locale.titles`
  * @returns {import('svelte/store').Readable<<T>(a: T, b: T) => number>}
@@ -26,7 +35,7 @@ export const comparator$ = derived(
 export function buildLocaleComparator(propertyPath) {
   return derived([comparator$, locale$], ([comparator, locale]) => {
     const path = propertyPath?.replace('$locale', locale).split('.') ?? []
-    return (itemA, itemB) =>
+    return (/** @type {?} */ itemA, /** @type {?} */ itemB) =>
       comparator.compare(getValue(itemA, path), getValue(itemB, path))
   })
 }

--- a/apps/web/src/stores/notifications.js
+++ b/apps/web/src/stores/notifications.js
@@ -1,8 +1,13 @@
+// @ts-check
+/**
+ * @typedef {import('@src/types').Translate} Translate
+ */
 import { _ } from 'svelte-intl'
 
 import { browser } from '$app/environment'
 
 let isActive = true
+/** @type {Translate} */
 let translate
 _.subscribe(value => (translate = value))
 
@@ -16,7 +21,7 @@ if (browser) {
 /**
  * @typedef {object} Notification
  * @property {string} contentKey - i18n key used for content.
- * @property {...any} [args] - other argument passed to i18n formatMessage().
+ * @property {Parameters<Translate>[1]} [args] - object argument passed to i18n formatMessage()
  */
 
 /**

--- a/apps/web/src/stores/peer-channels.js
+++ b/apps/web/src/stores/peer-channels.js
@@ -53,6 +53,7 @@ let current = null
 let messageId = 1
 /** @type {Stream} */
 let local
+resetLocalState()
 
 unorderedMessages$
   .pipe(

--- a/apps/web/src/stores/players.js
+++ b/apps/web/src/stores/players.js
@@ -1,23 +1,32 @@
 // @ts-check
+/**
+ * @typedef {import('@src/graphql').PlayerFragment} PlayerFragment
+ * @typedef {import('@src/graphql').PlayerWithSearchable} PlayerWithSearchable
+ * @typedef {import('@src/graphql').PlayerWithTurnCredentials} PlayerWithTurnCredentials
+ * @typedef {import('@urql/core').ClientOptions} ClientOptions
+ */
+/**
+ * @template T
+ * @typedef {import('@src/types').DeepRequired<T>} DeepRequired
+ */
+
+import * as graphQL from '@src/graphql'
+
 import { goto } from '$app/navigation'
 
-import * as graphQL from '../graphql'
 import { graphQlUrl, makeLogger } from '../utils'
 import { initGraphQlClient, runMutation, runQuery } from './graphql-client'
-
-/** @typedef {import('@tabulous/server/src/services/players.js').Player} BasePlayer */
-/** @typedef {import('@tabulous/server/src/graphql/players-resolver').PlayerWithTurnCredentials} PlayerWithTurnCredentials */
-/** @typedef {Pick<BasePlayer, 'id'|'username'|'avatar'} Player */
 
 const logger = makeLogger('players')
 
 /**
  * Recovers previous session by calling server.
- * @param {function} fetch - the fetch implementation used to initialize GraphQL client.
+ * @param {ClientOptions['fetch']} fetch - the fetch implementation used to initialize GraphQL client.
  * @param {string} bearer - the Bearer authorization value used to recover session.
- * @returns {Promise<?PlayerWithTurnCredentials>} the recovered session in case of success, or null.
+ * @returns {Promise<?DeepRequired<PlayerWithTurnCredentials>>} the recovered session in case of success, or null.
  */
 export async function recoverSession(fetch, bearer) {
+  /** @type {?DeepRequired<PlayerWithTurnCredentials>} */
   let session = null
   try {
     logger.info(`recovering previous session`)
@@ -27,7 +36,9 @@ export async function recoverSession(fetch, bearer) {
       bearer,
       subscriptionSupport: false
     })
-    session = await runQuery(/** @type {?} */ (graphQL).getCurrentPlayer)
+    session = /** @type {DeepRequired<PlayerWithTurnCredentials>} */ (
+      await runQuery(graphQL.getCurrentPlayer)
+    )
   } catch (error) {
     logger.debug(
       { error },
@@ -42,15 +53,17 @@ export async function recoverSession(fetch, bearer) {
  * Logs a player in with id/password method.
  * @param {string} id - the authenticating player id.
  * @param {string} password - clear password.
- * @returns {Promise<PlayerWithTurnCredentials>}
+ * @returns {Promise<DeepRequired<PlayerWithTurnCredentials>>}
  * @throws {Error} when authentication was rejected
  */
 export async function logIn(id, password) {
   try {
-    const session = await runMutation(/** @type {?} */ (graphQL).logIn, {
-      id,
-      password
-    })
+    const session = /** @type {DeepRequired<PlayerWithTurnCredentials>} */ (
+      await runMutation(graphQL.logIn, {
+        id,
+        password
+      })
+    )
     logger.info({ session }, `authenticating ${id}`)
     return session
   } catch (error) {
@@ -74,29 +87,29 @@ export async function logOut() {
 /**
  * Searches for player whom username contains the searched text.
  * @param {string} search - searched text.
- * @returns {Promise<Player[]>} a list (possibly empty) of matching candidates.
+ * @returns {Promise<PlayerFragment[]>} a list (possibly empty) of matching candidates.
  */
 export async function searchPlayers(search) {
   logger.info({ search }, `searches for ${search}`)
-  return runQuery(/** @type {?} */ (graphQL).searchPlayers, { search })
+  return runQuery(graphQL.searchPlayers, { search })
 }
 
 /**
  * Accept terms for the current player.
- * @returns {Promise<Player & Pick<BasePlayer, 'termsAccepted'>>} the current player, updated.
+ * @returns {Promise<PlayerFragment & { termsAccepted?: boolean }>} the current player, updated.
  */
 export async function acceptTerms() {
-  return runMutation(/** @type {?} */ (graphQL).acceptTerms)
+  return runMutation(graphQL.acceptTerms)
 }
 
 /**
  * Updates user details for the current player.
  * @param {string} username - the desired username, if any.
- * @param {string} avatar - the desired avatar, if any.
- * @returns {Promise<Player & Pick<BasePlayer, 'usernameSearchable'>>} the current player, updated.
+ * @param {string} [avatar] - the desired avatar, if any.
+ * @returns {Promise<PlayerWithSearchable>} the current player, updated.
  */
 export async function updateCurrentPlayer(username, avatar) {
-  return runMutation(/** @type {?} */ (graphQL).updateCurrentPlayer, {
+  return runMutation(graphQL.updateCurrentPlayer, {
     username,
     avatar
   })
@@ -105,10 +118,10 @@ export async function updateCurrentPlayer(username, avatar) {
 /**
  * Sets whether current player could be found by username
  * @param {boolean} searchable - whether player could be found by username.
- * @returns {Promise<Player & Pick<BasePlayer, 'usernameSearchable'>>} the current player, updated.
+ * @returns {Promise<PlayerWithSearchable>} the current player, updated.
  */
 export async function setUsernameSearchability(searchable) {
-  return runMutation(/** @type {?} */ (graphQL).setUsernameSearchability, {
+  return runMutation(graphQL.setUsernameSearchability, {
     searchable
   })
 }

--- a/apps/web/src/stores/players.js
+++ b/apps/web/src/stores/players.js
@@ -36,9 +36,7 @@ export async function recoverSession(fetch, bearer) {
       bearer,
       subscriptionSupport: false
     })
-    session = /** @type {DeepRequired<PlayerWithTurnCredentials>} */ (
-      await runQuery(graphQL.getCurrentPlayer)
-    )
+    session = await runQuery(graphQL.getCurrentPlayer)
   } catch (error) {
     logger.debug(
       { error },
@@ -58,12 +56,10 @@ export async function recoverSession(fetch, bearer) {
  */
 export async function logIn(id, password) {
   try {
-    const session = /** @type {DeepRequired<PlayerWithTurnCredentials>} */ (
-      await runMutation(graphQL.logIn, {
-        id,
-        password
-      })
-    )
+    const session = await runMutation(graphQL.logIn, {
+      id,
+      password
+    })
     logger.info({ session }, `authenticating ${id}`)
     return session
   } catch (error) {

--- a/apps/web/src/stores/toaster.js
+++ b/apps/web/src/stores/toaster.js
@@ -1,29 +1,42 @@
+// @ts-check
+/**
+ * @typedef {import('@src/types').Translate} Translate
+ */
+
 import { Subject } from 'rxjs'
 import { _ } from 'svelte-intl'
 
+/** @type {Subject<Toast>} */
 const lastToast$ = new Subject()
+/** @type {Translate} */
 let translate
 _.subscribe(value => (translate = value))
 
 /**
- * @typedef {object} ToastInfo
- * @property {string} contentKey - i18n key used for content.
- * @property {string} content - already translated content.
- * @property {icon} [icon] - optional icon name used.
- * @property {color} [color] - optional background color used.
- * @property {...any} [args] - other argument passed to i18n formatMessage().
+ * @typedef {object} _CommonToastInfo
+ * @property {string} [icon] - optional icon name used.
+ * @property {string} [color] - optional background color used.
+ *
+ * @typedef {object} _ToastInfo
+ * @property {?string} contentKey - i18n key used for content.
+ * @property {Parameters<Translate>[1]} [args] - object argument passed to i18n formatMessage()
+ *
+ * @typedef {object} _TranslatedToastInfo
+ * @property {?string} content - already translated content.
+ *
+ * @typedef {(Record<string, ?> & _CommonToastInfo & _ToastInfo) | (Record<string, ?> & _CommonToastInfo & _TranslatedToastInfo)} ToastInfo
  */
 
 /**
  * @typedef {object} Toast
  * @property {string} content - toasted message
- * @property {icon} [icon] - optional icon name used.
- * @property {color} [color] - optional background color used.
+ * @property {string} [icon] - optional icon name used.
+ * @property {string} [color] - optional background color used.
+ * @property {number} [duration] - how long this toast is displayed in seconds (defaults to 4)?.
  */
 
 /**
  * Emits with the last toast message desired.
- * @type {import('rxjs').Observable<Toast>}
  */
 export const lastToast = lastToast$.asObservable()
 

--- a/apps/web/src/style.postcss
+++ b/apps/web/src/style.postcss
@@ -100,8 +100,7 @@
 }
 
 html,
-body,
-#svelte-container {
+body {
   @apply font-sans h-full m-0 text-$ink font-300;
   font-family: var(--font-base);
   background: var(--page-bg);

--- a/apps/web/src/style.postcss
+++ b/apps/web/src/style.postcss
@@ -100,7 +100,8 @@
 }
 
 html,
-body {
+body,
+#svelte-container {
   @apply font-sans h-full m-0 text-$ink font-300;
   font-family: var(--font-base);
   background: var(--page-bg);

--- a/apps/web/src/svg/help/index.js
+++ b/apps/web/src/svg/help/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 export { default as Arrows } from './arrows.svg?component'
 export { default as CtrlArrows } from './ctrl+arrows.svg?component'
 export { default as CtrlNumbers } from './ctrl+numbers.svg?component'

--- a/apps/web/src/types/@babylonjs.d.ts
+++ b/apps/web/src/types/@babylonjs.d.ts
@@ -1,0 +1,111 @@
+/* eslint-disable no-unused-vars */
+import type { Mesh, Observable } from '@babylonjs/core'
+import type {
+  AnchorBehavior,
+  AnimateBehavior,
+  DetailBehavior,
+  DrawBehavior,
+  FlipBehavior,
+  LockBehavior,
+  MoveBehavior,
+  QuantityBehavior,
+  RandomBehavior,
+  RotateBehavior,
+  StackBehavior,
+  TargetBehavior
+} from '@src/3d/behaviors'
+import type { Behavior } from '@src/3d/utils'
+import type { Game } from '@src/graphql'
+import type { GameWithSelections } from '@src/stores'
+import type { MeshMetadata } from '@src/types'
+import type {
+  ActionName,
+  ButtonName,
+  Mesh as SerializedMesh,
+  PlayerPreference
+} from '@tabulous/server/src/graphql/types'
+
+interface LoadPlayerData {
+  /** current player id (to determine their hand)). */
+  playerId: string
+  /** current player's preferences. */
+  preferences: Omit<PlayerPreference, 'playerId'>
+  /** map of hexadecimal color string for each player Id. */
+  colorByPlayerId: Map<string, string>
+}
+
+declare module '@babylonjs/core' {
+  interface Engine {
+    /** indicates whether the engine is still loading data and materials. */
+    isLoading: boolean
+    /** a map of action ids by (localized) keystroke. */
+    actionNamesByKey: Map<string, ActionName[]>
+    /** a map of action ids by(mouse / finger) button. */
+    actionNamesByButton: Map<ButtonName, ActionName[]>
+    /** emits while data and materials are being loaded. */
+    onLoadingObservable: Observable<boolean>
+    /** emits just before disposing the engien, to allow synchronous access to its content. */
+    onBeforeDisposeObservable: Observable<void>
+    /** starts the renderig loop. */
+    start(): void
+    /**
+     * loads all meshes into the game engine
+     * - shows and hides Babylon's loading UI while loading assets (initial loading only)
+     * - loads data into the main scene
+     * - if needed, loads data into player's hand scene
+     * @param game - serialized game data.
+     * @param playerData - players data.
+     * @param inital - set to true to show Babylon's loading UI while loading assets.
+     */
+    load(
+      game: GameWithSelections,
+      playerData: LoadPlayerData,
+      inital?: boolean
+    ): Promise<void>
+    /**
+     * serializes all meshes rendered in the game engines.
+     */
+    serialize(): { meshes: SerializedMesh[]; handMeshes: SerializedMesh[] }
+  }
+
+  interface AbstractMesh {
+    /** indicates a cylindric mesh like a round token. */
+    isCylindric?: boolean
+    /** indicates whether this mesh could be hit by a ray. */
+    isHittable?: boolean
+    /** indicates an mesh used for animation purpose that should not be serialized nor hitted. */
+    isPhantom?: boolean
+    /** this mesh's attached behaviors. */
+    behaviors: Behavior[]
+    getBehaviorByName(name: 'anchorable'): ?AnchorBehavior
+    getBehaviorByName(name: 'animatable'): ?AnimateBehavior
+    getBehaviorByName(name: 'detailable'): ?DetailBehavior
+    getBehaviorByName(name: 'drawable'): ?DrawBehavior
+    getBehaviorByName(name: 'flippable'): ?FlipBehavior
+    getBehaviorByName(name: 'lockable'): ?LockBehavior
+    getBehaviorByName(name: 'movable'): ?MoveBehavior
+    getBehaviorByName(name: 'quantifiable'): ?QuantityBehavior
+    getBehaviorByName(name: 'randomizable'): ?RandomBehavior
+    getBehaviorByName(name: 'rotable'): ?RotateBehavior
+    getBehaviorByName(name: 'stackable'): ?StackBehavior
+    getBehaviorByName(name: 'targetable'): ?TargetBehavior
+    /** metadata used to extend a mesh's state. */
+    metadata: MeshMetadata
+  }
+
+  interface Scene {
+    meshes: Mesh[]
+    getMeshById(id: string): Mesh?
+  }
+}
+
+declare global {
+  interface Window {
+    /**
+     * Displays or hide Babylon.js debugger for a given scene.
+     * @param main - whether to display main scene debugger.
+     * @param hand - whether to display hand scene debugger.
+     */
+    toggleDebugger(main = true, hand = false): Promise<void>
+  }
+}

--- a/apps/web/src/types/graphql.d.ts
+++ b/apps/web/src/types/graphql.d.ts
@@ -1,0 +1,158 @@
+/* eslint-disable no-unused-vars */
+import type {
+  AwaitSignalArgs,
+  CatalogItem as FullCatalogItem,
+  CreateGameArgs,
+  DeleteGameArgs,
+  Friendship as FullFriendship,
+  FriendshipUpdate as FullFriendshipUpdate,
+  Game as FullGame,
+  GameParameters,
+  GamePlayer,
+  InviteArgs,
+  JoinGameArgs,
+  KickArgs,
+  LogInArgs,
+  Player,
+  PlayerWithTurnCredentials as FullPlayerWithTurnCredentials,
+  PromoteGameArgs,
+  ReceiveGameUpdatesArgs,
+  SaveGameArgs,
+  SearchPlayersArgs,
+  SendSignalArgs,
+  Signal,
+  TargetedPlayerArgs,
+  UpdateCurrentPlayerArgs
+} from '@tabulous/server/src/graphql/types'
+import type { TypedDocumentNode } from '@urql/core'
+
+declare module '@src/graphql' {
+  // catalog.graphql
+  type CatalogItem = Omit<FullCatalogItem, 'maxAge'>
+  const listCatalog: TypedDocumentNode<{
+    listCatalog: CatalogItem[]
+  }>
+
+  // games.graphql
+  type LightPlayer = Pick<
+    GamePlayer,
+    'id' | 'username' | 'avatar' | 'currentGameId' | 'isGuest' | 'isOwner'
+  >
+  type Game = Omit<FullGame, 'players'> & { players?: LightPlayer[] }
+  type LightGame = Pick<Game, 'id' | 'created' | 'kind' | 'players' | 'locales'>
+  type GameOrGameParameters =
+    | Game
+    | (Pick<
+        GameParameters,
+        | 'schemaString'
+        | 'error'
+        | 'id'
+        | 'kind'
+        | 'preferences'
+        | 'rulesBookPageCount'
+        | 'availableSeats'
+        | 'colors'
+      > & { players?: LightPlayer[] })
+  const createGame: TypedDocumentNode<{ createGame: LightGame }, CreateGameArgs>
+  const deleteGame: TypedDocumentNode<
+    { deleteGame: Pick<Game, 'id'> },
+    DeleteGameArgs
+  >
+  const invite: TypedDocumentNode<{ invite: Pick<Game, 'id'> }, InviteArgs>
+  const kick: TypedDocumentNode<{ kick: Pick<Game, 'id'> }, KickArgs>
+  const listGames: TypedDocumentNode<{ listGames: LightGame[] }>
+  const receiveGameListUpdates: TypedDocumentNode<{
+    receiveGameListUpdates: LightGame[]
+  }>
+  const receiveGameUpdates: TypedDocumentNode<
+    {
+      receiveGameUpdates: Game
+    },
+    ReceiveGameUpdatesArgs
+  >
+  const promoteGame: TypedDocumentNode<
+    {
+      promoteGame: GameOrGameParameters
+    },
+    PromoteGameArgs
+  >
+  const joinGame: TypedDocumentNode<
+    {
+      joinGame: GameOrGameParameters
+    },
+    JoinGameArgs
+  >
+  const getGamePlayers: TypedDocumentNode<
+    {
+      joinGame: { players: LightPlayer[] }
+    },
+    { id: JoinGameArgs['gameId'] }
+  >
+  const saveGame: TypedDocumentNode<
+    {
+      saveGame: Pick<Game, 'id'>
+    },
+    SaveGameArgs
+  >
+
+  // players.graphql
+  type PlayerFragment = Pick<Player, 'id' | 'username' | 'avatar'>
+  type PlayerWithSearchable = PlayerFragment &
+    Pick<Player, 'usernameSearchable'>
+  type PlayerWithTurnCredentials = FullPlayerWithTurnCredentials
+  type FullPlayer = Player
+  type Friendship = { player: PlayerFragment } & Pick<
+    FullFriendship,
+    'isProposal' | 'isRequest'
+  >
+  type FriendshipUpdate = { from: PlayerFragment } & Pick<
+    FullFriendshipUpdate,
+    'accepted' | 'declined' | 'proposed' | 'requested'
+  >
+
+  const acceptFriendship: TypedDocumentNode<
+    { acceptFriendship: void },
+    TargetedPlayerArgs
+  >
+  const acceptTerms: TypedDocumentNode<{
+    acceptTerms: PlayerWithTurnCredentials['player']
+  }>
+  const endFriendship: TypedDocumentNode<
+    { endFriendship: void },
+    TargetedPlayerArgs
+  >
+  const getCurrentPlayer: TypedDocumentNode<{
+    getCurrentPlayer: PlayerWithTurnCredentials
+  }>
+  const listFriends: TypedDocumentNode<{ listFriends: Friendship[] }>
+  const logIn: TypedDocumentNode<
+    { logIn: PlayerWithTurnCredentials },
+    LogInArgs
+  >
+  const receiveFriendshipUpdates: TypedDocumentNode<{
+    receiveFriendshipUpdates: FriendshipUpdate
+  }>
+  const requestFriendship: TypedDocumentNode<
+    { requestFriendship: void },
+    TargetedPlayerArgs
+  >
+  const searchPlayers: TypedDocumentNode<
+    { searchPlayers: PlayerFragment[] },
+    Pick<SearchPlayersArgs, 'search'>
+  >
+  const setUsernameSearchability: TypedDocumentNode<
+    { setUsernameSearchability: PlayerWithSearchable },
+    { searchable: boolean }
+  >
+  const updateCurrentPlayer: TypedDocumentNode<
+    { updateCurrentPlayer: PlayerWithSearchable },
+    Pick<UpdateCurrentPlayerArgs, 'avatar' | 'username'>
+  >
+
+  // signals.graphql
+  const awaitSignal: TypedDocumentNode<{ awaitSignal: Signal }, AwaitSignalArgs>
+  const sendSignal: TypedDocumentNode<
+    { sendSignal: Pick<Signal, 'from'> },
+    SendSignalArgs
+  >
+}

--- a/apps/web/src/types/graphql.d.ts
+++ b/apps/web/src/types/graphql.d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+import type { DeepRequired } from '@src/types'
 import type {
   AwaitSignalArgs,
   CatalogItem as FullCatalogItem,
@@ -122,11 +123,11 @@ declare module '@src/graphql' {
     TargetedPlayerArgs
   >
   const getCurrentPlayer: TypedDocumentNode<{
-    getCurrentPlayer: PlayerWithTurnCredentials
+    getCurrentPlayer: DeepRequired<PlayerWithTurnCredentials>
   }>
   const listFriends: TypedDocumentNode<{ listFriends: Friendship[] }>
   const logIn: TypedDocumentNode<
-    { logIn: PlayerWithTurnCredentials },
+    { logIn: DeepRequired<PlayerWithTurnCredentials> },
     LogInArgs
   >
   const receiveFriendshipUpdates: TypedDocumentNode<{

--- a/apps/web/src/types/index.d.ts
+++ b/apps/web/src/types/index.d.ts
@@ -1,0 +1,152 @@
+/* eslint-disable no-unused-vars */
+import type { Observable, Observer } from '@babylonjs/core'
+import type {
+  AnchorableState,
+  AnchorBehavior,
+  DetailableState,
+  DetailBehavior,
+  DrawBehavior,
+  FlipBehavior,
+  FlippableState,
+  LockableState,
+  LockBehavior,
+  MovableState,
+  QuantifiableState,
+  QuantityBehavior,
+  RandomBehavior,
+  RandomizableState,
+  RotableState,
+  RotateBehavior,
+  StackBehavior
+} from '@src/3d/behaviors'
+import type { Mesh as SerializedMesh } from '@tabulous/server/src/graphql/types'
+import type { Observable as RxObservable, Subject } from 'rxjs'
+import type { ComponentType } from 'svelte'
+
+declare module '@src/types' {
+  type Translate = (
+    msg: string,
+    args?: object,
+    locales?: string | string[]
+  ) => string
+
+  type DeepRequired<T> = {
+    [K in keyof T]: Required<DeepRequired<T[K]>>
+  }
+
+  type JSONValue =
+    | string
+    | number
+    | boolean
+    | Record<string, JSONValue>
+    | Array<JSONValue>
+    | undefined
+
+  type BabylonToRxMapping = {
+    observable: Observable<?>
+    subject: Subject<?>
+    observer: ?Observer<?>
+  }
+
+  type Observed<T> = T extends RxObservable<infer U> ? U : T
+  type ArrayItem<T> = T extends Array<infer U> ? U : T
+
+  type MeshActions = {
+    snap: AnchorBehavior['snap']
+    unsnap: AnchorBehavior['unsnap']
+    unsnapAll: AnchorBehavior['unsnapAll']
+    detail: DetailBehavior['detail']
+    draw: DrawBehavior['draw']
+    flip: FlipBehavior['flip']
+    toggleLock: LockBehavior['toggleLock']
+    increment: QuantityBehavior['increment']
+    decrement: QuantityBehavior['decrement']
+    random: RandomBehavior['random']
+    setFace: RandomBehavior['setFace']
+    rotate: RotateBehavior['rotate']
+    push: StackBehavior['push']
+    pop: StackBehavior['pop']
+    reorder: StackBehavior['reorder']
+    flipAll: StackBehavior['flipAll']
+  }
+
+  type MeshMetadata = Record<string, ?> & {
+    serialize: () => SerializedMesh
+
+    anchors?: AnchorableState['anchors']
+    snap?: AnchorBehavior['snap']
+    unsnap?: AnchorBehavior['unsnap']
+    unsnapAll?: AnchorBehavior['unsnapAll']
+
+    frontImage?: DetailableState['frontImage']
+    backImage?: DetailableState['backImage']
+    detail?: DetailBehavior['detail']
+
+    draw?: DrawBehavior['draw']
+
+    isFlipped?: FlippableState['isFlipped']
+    flip?: FlipBehavior['flip']
+
+    isLocked?: LockableState['isLocked']
+    toggleLock?: LockBehavior['toggleLock']
+
+    partCenters?: MovableState['partCenters']
+
+    quantity?: QuantifiableState['quantity']
+    increment?: QuantityBehavior['increment']
+    decrement?: QuantityBehavior['decrement']
+    canIncrement?: QuantityBehavior['canIncrement']
+
+    face?: RandomizableState['face']
+    maxFace?: RandomizableState['max']
+    random?: RandomBehavior['random']
+    setFace?: RandomBehavior['setFace']
+
+    angle?: RotableState['angle']
+    rotate?: RotateBehavior['rotate']
+
+    stack?: StackBehavior['stack']
+    push?: StackBehavior['push']
+    pop?: StackBehavior['pop']
+    reorder?: StackBehavior['reorder']
+    flipAll?: StackBehavior['flipAll']
+    canPush?: StackBehavior['canPush']
+  }
+}
+
+interface OptionProps {
+  focus?: boolean // whether this option is focused.
+  open?: boolean // whether this option is opened (for nested menus).
+}
+
+type CommonMenuOption = Record<string, ?> & {
+  props?: Record<string, ?> & OptionProps // properties passed to the svelte component, and updated on hover.
+  icon?: string // optional icon.
+  disabled?: boolean // whether this option is disabled.
+}
+
+declare module '@src/components' {
+  interface ComponentMenuOption extends CommonMenuOption {
+    Component: ComponentType // Svelte component for this option.
+  }
+
+  interface LabelMenuOption extends CommonMenuOption {
+    label: string // text displayed.
+  }
+
+  interface ColorMenuOption extends CommonMenuOption {
+    color: string // color displayed (hexcode or color name).
+  }
+
+  type MenuOption =
+    | (Record<string, ?> & string)
+    | ComponentMenuOption
+    | LabelMenuOption
+    | ColorMenuOption
+
+  interface SectionTab {
+    id: string // mandatory id used to identify tabs.
+    icon: string // icon displayed.
+    key?: string // shortcut key assigned, if any.
+  }
+}

--- a/apps/web/src/types/svelte.d.ts
+++ b/apps/web/src/types/svelte.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-unused-vars */
+import type { Observable } from 'rxjs'
+
+declare module 'svelte/store' {
+  function get<T>(observable: Observable<T>): T
+}

--- a/apps/web/src/types/vitest.d.ts
+++ b/apps/web/src/types/vitest.d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-vars */
+import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+
+interface CustomMatchers<R = unknown> {
+  toEqualWithAngle<E extends { angle: number }>(expected: E): R
+}
+
+declare module 'vitest' {
+  interface Assertion<T = ?> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/apps/web/src/utils/collections.js
+++ b/apps/web/src/utils/collections.js
@@ -1,8 +1,10 @@
+// @ts-check
 /**
  * Shuffle an array, several times, using Fisher–Yates algorithm.
- * @param {any[]} source - source array.
+ * @template T
+ * @param {T[]|null} source - source array.
  * @param {number} [iterations=3] - how many times the array is shuffled.
- * @returns {any[]} a randomized copy of the source array.
+ * @returns {T[]} a randomized copy of the source array.
  * @see {@link https://bost.ocks.org/mike/shuffle/}
  */
 export function shuffle(source = [], iterations = 5) {

--- a/apps/web/src/utils/dom.js
+++ b/apps/web/src/utils/dom.js
@@ -1,14 +1,18 @@
+// @ts-check
 import { auditTime, map, Subject } from 'rxjs'
 
 import { browser } from '$app/environment'
 
+/** @typedef {'base-darkest'|'base-darker'|'base-dark'|'base'|'base-light'|'base-lighter'|'base-lightest'|'primary-darkest'|'primary-darker'|'primary-dark'|'primary'|'primary-light'|'primary-lighter'|'primary-lightest'|'secondary-darkest'|'secondary-darker'|'secondary-dark'|'secondary'|'secondary-light'|'secondary-lighter'|'secondary-lightest'} CssColorVariables **/
+
 /**
  * @typedef {object} Dimension the dimension of a HTML element.
- * @param {number} height - height, in pixel.
+ * @property {number} height - height, in pixel.
+ * @property {number} width - width, in pixel.
  */
 
 /**
- * Computes the height, in pixel, or a displayed HTML element.
+ * Computes the height and width, in pixel, of a displayed HTML element.
  * @param {HTMLElement} element - the sized element.
  * @returns {Dimension} its dimension in pixel.
  */
@@ -19,8 +23,8 @@ export function getPixelDimension(element) {
 
 /**
  * @typedef {object} SizeObserver
- * @param {import('rxjs').Observable<Dimension>} dimension$ - emit an element size, in pixels.
- * @param {function} disconnect - function to release the observer and stop the observable.
+ * @property {import('rxjs').Observable<Dimension>} dimension$ - emit an element size, in pixels.
+ * @property {() => void} disconnect - function to release the observer and stop the observable.
  */
 
 /**
@@ -31,7 +35,7 @@ export function getPixelDimension(element) {
  */
 export function observeDimension(element, buffer = 10) {
   const subject$ = new Subject()
-  const observer = new ResizeObserver(() => subject$.next())
+  const observer = new ResizeObserver(() => subject$.next(void 0))
   observer.observe(element)
   return {
     dimension$: subject$.pipe(
@@ -45,7 +49,7 @@ export function observeDimension(element, buffer = 10) {
 /**
  * Defines new css variables on a given element, returning any existing values.
  * @param {HTMLElement} element - element to set variables on.
- * @param {object} variables - hash of Css variables (without the -- prefix).
+ * @param {Record<string, ?string|undefined>} variables - hash of Css variables (without the -- prefix).
  */
 export function setCssVariables(element, variables) {
   for (const [name, value] of Object.entries(variables)) {
@@ -56,22 +60,45 @@ export function setCssVariables(element, variables) {
 }
 
 /**
- * TODOC
+ * @typedef {object} CornerClipPath
+ * @property {string} d - the d attribute of the SVG path.
+ * @property {string} transform - transform to apply to the SVG path.
+ * @property {string} transform-origin - transform origin for the SVG path.
+ */
+
+/**
+ * Computes a SVG clip path for a rounded tab.
+ * The returned properties must be applied like this:
+ * <svg style="width:0px; height:0px">
+ *   <clipPath id={id} clipPathUnits="objectBoundingBox">
+ *    <path {...corner} />
+ *   </clipPath>
+ * </svg>
+ * and then referenced in a clip-path css property: `clip-path: var(--id);`
+ *
+ * @param {object} args - generated clip path arguments:
+ * @param {number} [args.curve=0.5] - percentage for the curve (between 0 and 1)
+ * @param {boolean} [args.inverted=false] - whether to invert the curve.
+ * @param {'top'|'bottom'|'left'|'right'} [args.placement='top'] - tab placement.
+ * @returns {[string, CornerClipPath]} the generated clip path
  */
 export function buildCornerClipPath({
   curve = 0.5,
   inverted = false,
   placement = 'top'
 } = {}) {
-  return {
-    id: `clip-path-${Math.floor(Math.random() * 100000)}`,
-    transform: `rotate(${
-      placement === 'right' || placement === 'left' ? 90 : 0
-    }) scale(1, ${placement === 'right' || placement === 'top' ? -1 : 1})`,
-    d: inverted
-      ? `M 0 0 C ${curve} 0 ${1 - curve} 1 1 1 H 0 Z`
-      : `M 0 1 C ${curve} 1 ${1 - curve} 0 1 0 V 1 Z`
-  }
+  return [
+    `clip-path-${Math.floor(Math.random() * 100000)}`,
+    {
+      transform: `rotate(${
+        placement === 'right' || placement === 'left' ? 90 : 0
+      }) scale(1, ${placement === 'right' || placement === 'top' ? -1 : 1})`,
+      d: inverted
+        ? `M 0 0 C ${curve} 0 ${1 - curve} 1 1 1 H 0 Z`
+        : `M 0 1 C ${curve} 1 ${1 - curve} 0 1 0 V 1 Z`,
+      'transform-origin': '0.5 0.5'
+    }
+  ]
 }
 
 /**

--- a/apps/web/src/utils/env.js
+++ b/apps/web/src/utils/env.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Base URL for game assets (with no traling slash).
  * @type {string}

--- a/apps/web/src/utils/index.js
+++ b/apps/web/src/utils/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Do not include any store that imports anything from @src/3d (like game-interfaction)
 // This would bloat production chunks with Babylonjs (1.6Mb uncompressed)
 // @src/3d/utils/actions and @src/3d/behavior/names are safe

--- a/apps/web/src/utils/logger.js
+++ b/apps/web/src/utils/logger.js
@@ -39,7 +39,7 @@ const levels = {
   selection: 'warn',
   'scene-loader': 'warn',
   stackable: 'warn',
-  stream: 'debug',
+  stream: 'warn',
   target: 'warn'
 }
 

--- a/apps/web/src/utils/math.js
+++ b/apps/web/src/utils/math.js
@@ -1,12 +1,19 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Vector3} Vector3
+ * @typedef {import('@babylonjs/core').BoundingBox} BoundingBox
+ * @typedef {import('@src/3d/utils').ScreenPosition} ScreenPosition
+ */
+
 /**
  * @typedef {object} Rectangle A 2D rectangle defined by its minimum and maximum points.
- * @property {import('../3d/utils').ScreenPosition} min - a 2D point representing the lowest corner of this rectangle.
- * @property {import('../3d/utils').ScreenPosition} max - a 2D point representing the highest corner of this rectangle.
+ * @property {ScreenPosition} min - a 2D point representing the lowest corner of this rectangle.
+ * @property {ScreenPosition} max - a 2D point representing the highest corner of this rectangle.
  */
 
 /**
  * @typedef {object} Circle A 2D circle defined by its center point and radius.
- * @property {import('../3d/utils').ScreenPosition} center - a 2D point representing center.
+ * @property {ScreenPosition} center - a 2D point representing center.
  * @property {number} radius - a radius distance.
  */
 
@@ -45,8 +52,8 @@ export function normalize(value, maxInput, min, max) {
 
 /**
  * Computes Euclidean distance between two (screen coordinates) points.
- * @param {import('../3d/utils').ScreenPosition} first - first screen position.
- * @param {import('../3d/utils').ScreenPosition} second - second screen position.
+ * @param {ScreenPosition} first - first screen position.
+ * @param {ScreenPosition} second - second screen position.
  */
 export function distance(first, second) {
   return Math.sqrt(
@@ -56,8 +63,8 @@ export function distance(first, second) {
 
 /**
  * Projects a point in 3D space to the ground plane.
- * @param {import('@babylonjs/core').Vector3} vector - a 3D vector object with x, y, and z coordinates.
- * @returns {import('@babylonjs/core').Vector2} the equivalent 2D vector, where x is unchanged and resulting y is z.
+ * @param {Partial<Vector3>} [vector] - a 3D vector object with x, y, and z coordinates.
+ * @returns {ScreenPosition} the equivalent 2D vector, where x is unchanged and resulting y is z.
  */
 export function projectToGround({ x = 0, z = 0 } = {}) {
   return { x, y: z }
@@ -65,7 +72,7 @@ export function projectToGround({ x = 0, z = 0 } = {}) {
 
 /**
  * Projects a 3D bounding box to the ground plane and return the corresponding rectangle.
- * @param {import('@babylonjs/core').BoundingBox} box - a 3D bounding box, with its minimumWorld and maximumWorld 3D points.
+ * @param {Partial<BoundingBox>} [box] - a 3D bounding box, with its minimumWorld and maximumWorld 3D points.
  * @returns {Rectangle} the corresponding rectangle projected to the ground plane.
  */
 export function buildGroundRectangle({ minimumWorld, maximumWorld } = {}) {
@@ -77,7 +84,7 @@ export function buildGroundRectangle({ minimumWorld, maximumWorld } = {}) {
 
 /**
  * Returns the biggest circle fully enclosed within the provided rectangle.
- * @param {Rectangle} rectangle - a given 2D rectangle.
+ * @param {Partial<Rectangle>} [rectangle] - a given 2D rectangle.
  * @returns {Circle} the enclosed 2D circle.
  */
 export function buildEnclosedCircle({ min, max } = {}) {

--- a/apps/web/src/utils/object.js
+++ b/apps/web/src/utils/object.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * Returns a (deeply nested) property of an object.
+ * Supports objects and arrays.
+ * @param {?} object  - root object.
+ * @param {(string|number)[]} path - array of segments to the desired property
+ * @returns {?} the property found, or undefined
+ */
 export function getValue(object, path) {
   for (let index = 0; index < path.length; index++) {
     if (!object) {

--- a/apps/web/src/utils/string.js
+++ b/apps/web/src/utils/string.js
@@ -1,6 +1,7 @@
+// @ts-check
 /**
  * Turns a sentence in uppercase and only keeps its initials.
- * @param {string} value - abbreviated value.
+ * @param {?string} [value] - abbreviated value.
  * @returns {string} value's initials.
  */
 export function abbreviate(value) {
@@ -13,25 +14,25 @@ export function abbreviate(value) {
 
 /**
  * Translate errors from server into human-readable localized equivalent
- * @param {(key: string, options: object) => string} formatMessage - svelte-intl's format message function.
- * @param {Error} error - error to translate.
- * @return {string|null} the translate error message, if any
+ * @param {(key: string, options?: object) => string} formatMessage - svelte-intl's format message function.
+ * @param {?Error|string|undefined} error - error to translate.
+ * @return {?string} the translate error message, if any
  */
-export function translateError(svelteIntl, error) {
-  const message = error?.message || error
+export function translateError(formatMessage, error) {
+  const message = error instanceof Error ? error.message : error
   if (!message) {
     return null
   }
   if (/^Access to game/.test(message)) {
-    return svelteIntl('errors.restricted-game')
+    return formatMessage('errors.restricted-game')
   } else if (/^Username already used/.test(message)) {
-    return svelteIntl('errors.username-used')
+    return formatMessage('errors.username-used')
   } else if (/^Username too short/.test(message)) {
-    return svelteIntl('errors.username-too-short')
+    return formatMessage('errors.username-too-short')
   }
   const match = message.match(/^You own (\d+) games/)
   if (match) {
-    return svelteIntl('errors.too-many-games', { count: match[1] })
+    return formatMessage('errors.too-many-games', { count: match[1] })
   }
   return message
 }

--- a/apps/web/src/utils/time.js
+++ b/apps/web/src/utils/time.js
@@ -1,7 +1,8 @@
+// @ts-check
 /**
  * Awaits for some time.
- * @aync
- * @param {number} [duration=0] - number of milliseconds to wait for
+ * @param {number} [n=0] - number of milliseconds to wait for
+ * @returns {Promise<void>}
  */
 export async function sleep(n = 0) {
   await new Promise(resolve => setTimeout(resolve, n))

--- a/apps/web/src/utils/webrtc.js
+++ b/apps/web/src/utils/webrtc.js
@@ -1,8 +1,13 @@
+// @ts-check
+/**
+ * @typedef {object} Constraints
+ * @property {number} constraints.bitrate - maximum bitrate applied, in Kbps.
+ */
+
 /**
  * Builds a transform function to applies various customization to the WebRTC SDP payload, such as bitrate limitation.
- * @param {object} constraints - applied constraints, including:
- * @param {number} constraints.bitrate - maximum bitrate applied, in Kbps.
- * @returns {function} the transform function, that takes SDP payload as parameter and returns an altered version.
+ * @param {Constraints} constraints - applied constraints.
+ * @returns {(sdp: string) => string} the transform function, that takes SDP payload as parameter and returns an altered version.
  * @see https://webrtchacks.com/limit-webrtc-bandwidth-sdp/
  */
 export function buildSDPTransform(constraints) {
@@ -17,6 +22,10 @@ export function buildSDPTransform(constraints) {
   }
 }
 
+/**
+ * @param {?} context - contextual object
+ * @param {Constraints} constraints - applied constraints.
+ */
 function initContextForBitrate(context, { bitrate }) {
   const isFirefox = navigator.userAgent.toLowerCase().includes('firefox')
   // we can not modifiy JSDom useragent on the fly, so we only test the default case
@@ -27,6 +36,13 @@ function initContextForBitrate(context, { bitrate }) {
   context.inMedia = false
 }
 
+/**
+ * @param {object} args
+ * @param {string[]} args.claims - an array of SDP claims.
+ * @param {number} args.rank - current claim rank.
+ * @param {?} args.context - contextual data.
+ * @returns {number} rank of the analyzed claim.
+ */
 function applyBitrateLimit({ claims, rank, context }) {
   if (context.bitrateClaim) {
     const claim = claims[rank]

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,19 +1,17 @@
 import vercel from '@sveltejs/adapter-vercel'
+import { windi } from 'svelte-windicss-preprocess'
 
 // This file is used by
 // - "Svelte for VS Code" plugin
 // - svelte kit
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  onwarn(warning, defaultHandler) {
-    if (warning.code === 'a11y-autofocus') return
-    defaultHandler(warning)
-  },
   kit: {
     adapter: vercel({ runtime: 'edge' }),
     files: { assets: 'public' },
     output: { preloadStrategy: 'preload-mjs' }
-  }
+  },
+  preprocess: [windi()]
 }
 
 export default config

--- a/apps/web/tests/3d/behaviors/anchorable.test.js
+++ b/apps/web/tests/3d/behaviors/anchorable.test.js
@@ -493,7 +493,7 @@ describe('AnchorBehavior', () => {
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
 
-    it('can reset snapped mesh rotationwhen hydrating', () => {
+    it('can reset snapped mesh rotation when hydrating', () => {
       const snapped = meshes[0]
       snapped.addBehavior(new RotateBehavior({ angle: Math.PI * 0.5 }), true)
       expectRotated(snapped, Math.PI * 0.5)
@@ -683,10 +683,10 @@ describe('AnchorBehavior', () => {
         ]
       })
       expectSnapped(mesh, snapped, 0)
-      expectStacked([snapped, stacked])
+      expectStacked([snapped, stacked], true, mesh.id)
 
       await stacked.metadata.reorder?.([stacked.id, snapped.id])
-      expectStacked([stacked, snapped])
+      expectStacked([stacked, snapped], true, mesh.id)
       expectSnapped(mesh, stacked, 0)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -700,10 +700,10 @@ describe('AnchorBehavior', () => {
         ]
       })
       expectSnapped(mesh, snapped, 0)
-      expectStacked([snapped, stacked])
+      expectStacked([snapped, stacked], true, mesh.id)
 
       await stacked.metadata.flipAll?.()
-      expectStacked([stacked, snapped])
+      expectStacked([stacked, snapped], true, mesh.id)
       expectSnapped(mesh, stacked, 0)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })

--- a/apps/web/tests/3d/behaviors/animatable.test.js
+++ b/apps/web/tests/3d/behaviors/animatable.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import { AnimateBehavior, AnimateBehaviorName } from '@src/3d/behaviors'
@@ -14,7 +19,9 @@ describe('AnimateBehavior', () => {
 
   const animationEndReceived = vi.fn()
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   it('has initial state', () => {
     const behavior = new AnimateBehavior()
@@ -46,7 +53,9 @@ describe('AnimateBehavior', () => {
   })
 
   describe('given attached to a mesh', () => {
+    /** @type {Mesh} */
     let mesh
+    /** @type {AnimateBehavior} */
     let behavior
 
     beforeEach(() => {
@@ -55,6 +64,7 @@ describe('AnimateBehavior', () => {
       mesh.addBehavior(behavior, true)
       mesh.getScene()._pendingData = []
       behavior.onAnimationEndObservable.add(animationEndReceived)
+      // @ts-expect-error isLoading is not optional
       delete mesh.getEngine().isLoading
     })
 

--- a/apps/web/tests/3d/behaviors/detailable.test.js
+++ b/apps/web/tests/3d/behaviors/detailable.test.js
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Observer<?>} Observer
+ */
+
 import { faker } from '@faker-js/faker'
 import { DetailBehavior, DetailBehaviorName } from '@src/3d/behaviors'
 import { controlManager } from '@src/3d/managers'
@@ -16,15 +22,22 @@ import { configures3dTestEngine, createBox } from '../../test-utils'
 describe('DetailBehavior', () => {
   configures3dTestEngine()
 
-  const onDetailedObserver = vi.fn()
+  const onDetailsReceived = vi.fn()
+  /** @type {?Observer} */
+  let onDetailsObserver
 
-  beforeEach(vi.resetAllMocks)
-
-  beforeAll(() => {
-    controlManager.onDetailedObservable.add(onDetailedObserver)
+  beforeEach(() => {
+    vi.resetAllMocks()
   })
 
-  afterAll(() => controlManager.onDetailedObservable.remove(onDetailedObserver))
+  beforeAll(() => {
+    onDetailsObserver =
+      controlManager.onDetailedObservable.add(onDetailsReceived)
+  })
+
+  afterAll(() => {
+    controlManager.onDetailedObservable.remove(onDetailsObserver)
+  })
 
   it('has initial state', () => {
     const state = {
@@ -43,15 +56,15 @@ describe('DetailBehavior', () => {
   })
 
   it('can not restore state without mesh', () => {
-    expect(() => new DetailBehavior().fromState({ front: null })).toThrow(
+    expect(() => new DetailBehavior().fromState({ frontImage: '' })).toThrow(
       'Can not restore state without mesh'
     )
   })
 
   it('can not show details without mesh', () => {
     const behavior = new DetailBehavior()
-    behavior.detail()
-    expect(onDetailedObserver).not.toHaveBeenCalled()
+    behavior.detail?.()
+    expect(onDetailsReceived).not.toHaveBeenCalled()
   })
 
   it('can hydrate with default state', () => {
@@ -59,11 +72,11 @@ describe('DetailBehavior', () => {
     const mesh = createBox('box', {})
     mesh.addBehavior(behavior, true)
 
-    behavior.fromState()
-    expect(behavior.state).toEqual({ frontImage: null, backImage: null })
+    behavior.fromState({ frontImage: '' })
+    expect(behavior.state).toEqual({ frontImage: '' })
     expect(behavior.mesh).toEqual(mesh)
-    expect(mesh.metadata.frontImage).toBe(null)
-    expect(mesh.metadata.backImage).toBe(null)
+    expect(mesh.metadata.frontImage).toBe('')
+    expect(mesh.metadata.backImage).toBeUndefined()
   })
 
   describe.each([
@@ -78,10 +91,13 @@ describe('DetailBehavior', () => {
       backImage: null
     }
   ])('given attached to a mesh$title', ({ frontImage, backImage }) => {
+    /** @type {Mesh} */
     let mesh
+    /** @type {DetailBehavior} */
     let behavior
 
     beforeEach(() => {
+      // @ts-expect-error image types are different
       behavior = new DetailBehavior({ frontImage, backImage })
       mesh = createBox('box', {})
       mesh.addBehavior(behavior, true)
@@ -96,9 +112,9 @@ describe('DetailBehavior', () => {
     })
 
     it('can show front image', () => {
-      mesh.metadata.detail()
-      expect(onDetailedObserver).toHaveBeenCalledTimes(1)
-      expect(onDetailedObserver).toHaveBeenCalledWith(
+      mesh.metadata.detail?.()
+      expect(onDetailsReceived).toHaveBeenCalledTimes(1)
+      expect(onDetailsReceived).toHaveBeenCalledWith(
         { mesh, data: { image: frontImage } },
         expect.anything()
       )
@@ -106,9 +122,9 @@ describe('DetailBehavior', () => {
 
     it('can show back image', () => {
       mesh.metadata.isFlipped = true
-      mesh.metadata.detail()
-      expect(onDetailedObserver).toHaveBeenCalledTimes(1)
-      expect(onDetailedObserver).toHaveBeenCalledWith(
+      mesh.metadata.detail?.()
+      expect(onDetailsReceived).toHaveBeenCalledTimes(1)
+      expect(onDetailsReceived).toHaveBeenCalledWith(
         { mesh, data: { image: backImage } },
         expect.anything()
       )

--- a/apps/web/tests/3d/behaviors/movable.test.js
+++ b/apps/web/tests/3d/behaviors/movable.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { faker } from '@faker-js/faker'
 import { MoveBehavior, MoveBehaviorName } from '@src/3d/behaviors'
 import { moveManager } from '@src/3d/managers'
@@ -48,7 +53,9 @@ describe('MoveBehavior', () => {
   })
 
   describe('given attached to a mesh', () => {
+    /** @type {Mesh} */
     let mesh
+    /** @type {MoveBehavior} */
     let behavior
 
     beforeEach(() => {

--- a/apps/web/tests/3d/behaviors/rotable.test.js
+++ b/apps/web/tests/3d/behaviors/rotable.test.js
@@ -1,3 +1,14 @@
+// @ts-check
+/**
+ * @typedef {import('vitest').Mock<?, ?>} Mock
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@src/3d/behaviors').RotableState} RotableState
+ */
+/**
+ * @template {any[]} P, R
+ * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import {
@@ -21,7 +32,9 @@ import {
 describe('RotateBehavior', () => {
   configures3dTestEngine()
 
+  /** @type {SpyInstance<Parameters<typeof controlManager['record']>, void>} */
   let recordSpy
+  /** @type {Mock} */
   let animationEndReceived
 
   beforeEach(() => {
@@ -55,7 +68,7 @@ describe('RotateBehavior', () => {
 
   it('can not rotate without mesh', async () => {
     const behavior = new RotateBehavior()
-    await behavior.rotate()
+    await behavior.rotate?.()
     expect(recordSpy).not.toHaveBeenCalled()
   })
 
@@ -67,18 +80,20 @@ describe('RotateBehavior', () => {
       angle: 0,
       duration: 200
     })
-    expect(behavior.mesh.rotation.y).toEqual(0)
-    expect(behavior.mesh.metadata.angle).toEqual(0)
+    expect(behavior.mesh?.rotation.y).toEqual(0)
+    expect(behavior.mesh?.metadata.angle).toEqual(0)
     expect(recordSpy).not.toHaveBeenCalled()
   })
 
   describe('given attached to a mesh', () => {
+    /** @type {Mesh} */
     let mesh
+    /** @type {RotateBehavior} */
     let behavior
 
     beforeEach(() => {
       behavior = createAttachedRotable({ duration: 50 })
-      mesh = behavior.mesh
+      mesh = /** @type {Mesh} */ (behavior.mesh)
       behavior.onAnimationEndObservable.add(animationEndReceived)
     })
 
@@ -125,7 +140,7 @@ describe('RotateBehavior', () => {
       mesh.setAbsolutePosition(new Vector3(x, 10, z))
 
       expectRotated(mesh, 0)
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, Math.PI * 0.5)
       expectPosition(mesh, [x, 0.5, z])
       expect(animationEndReceived).toHaveBeenCalledOnce()
@@ -145,7 +160,7 @@ describe('RotateBehavior', () => {
       expectRotated(mesh, 0)
       expectFlipped(child, false)
       expectRotated(child, 0)
-      await child.metadata.rotate()
+      await child.metadata.rotate?.()
       expectFlipped(mesh, true)
       expectRotated(mesh, 0)
       expectFlipped(child, false)
@@ -162,7 +177,7 @@ describe('RotateBehavior', () => {
 
       expectRotated(mesh, 0)
       expectRotated(child, 0)
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, Math.PI * 0.5)
       expectPosition(mesh, [x, 0.5, z])
       expectRotated(child, Math.PI * 0.5)
@@ -172,7 +187,7 @@ describe('RotateBehavior', () => {
     it('makes mesh unpickable while rotating', async () => {
       expectPickable(mesh)
       expectRotated(mesh, 0)
-      const flipPromise = mesh.metadata.rotate()
+      const flipPromise = mesh.metadata.rotate?.()
       expectPickable(mesh, false)
       await flipPromise
 
@@ -183,7 +198,7 @@ describe('RotateBehavior', () => {
     it('can rotate mesh with any angle', async () => {
       const angle = faker.number.float(1) * Math.PI
       expectRotated(mesh, 0)
-      await mesh.metadata.rotate(angle)
+      await mesh.metadata.rotate?.(angle)
       expectRotated(mesh, angle)
       expect(animationEndReceived).toHaveBeenCalledOnce()
       expect(recordSpy).toHaveBeenCalledOnce()
@@ -198,7 +213,7 @@ describe('RotateBehavior', () => {
     it('records rotations to controlManager', async () => {
       expectRotated(mesh, 0)
       expect(recordSpy).toHaveBeenCalledTimes(0)
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expect(recordSpy).toHaveBeenCalledOnce()
       expect(recordSpy).toHaveBeenNthCalledWith(1, {
         mesh,
@@ -208,7 +223,7 @@ describe('RotateBehavior', () => {
       })
       expectRotated(mesh, Math.PI * 0.5)
 
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expect(recordSpy).toHaveBeenCalledTimes(2)
       expect(recordSpy).toHaveBeenNthCalledWith(2, {
         mesh,
@@ -222,11 +237,11 @@ describe('RotateBehavior', () => {
 
     it('keeps rotation within [0..2*Math.PI[', async () => {
       expectRotated(mesh, 0)
-      await mesh.metadata.rotate()
-      await mesh.metadata.rotate()
-      await mesh.metadata.rotate()
-      await mesh.metadata.rotate()
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
+      await mesh.metadata.rotate?.()
+      await mesh.metadata.rotate?.()
+      await mesh.metadata.rotate?.()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, Math.PI * 0.5)
       expect(animationEndReceived).toHaveBeenCalledTimes(5)
     })
@@ -234,9 +249,9 @@ describe('RotateBehavior', () => {
     it('can not rotate while animating', async () => {
       expectPickable(mesh)
       expectRotated(mesh, 0)
-      const promise = mesh.metadata.rotate()
+      const promise = mesh.metadata.rotate?.()
       expectPickable(mesh, false)
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       await promise
 
       expectPickable(mesh)
@@ -247,8 +262,8 @@ describe('RotateBehavior', () => {
 
     it('applies current rotation to added child', async () => {
       const angle = Math.PI
-      await mesh.metadata.rotate()
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, angle)
 
       const child = createAttachedRotable().mesh
@@ -260,9 +275,9 @@ describe('RotateBehavior', () => {
 
     it('applies current rotation to removed child', async () => {
       const angle = Math.PI * 0.5
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       const child = createAttachedRotable().mesh
-      await child.metadata.rotate()
+      await child.metadata.rotate?.()
       child.setParent(mesh)
       expectRotated(mesh, angle)
       expectRotated(child, angle)
@@ -274,7 +289,7 @@ describe('RotateBehavior', () => {
 
     it('does not compensate rotation for un-rotable child', async () => {
       const angle = Math.PI * 0.5
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, angle)
       const child = createBox('child', {})
       child.setParent(mesh)
@@ -288,16 +303,16 @@ describe('RotateBehavior', () => {
     it('can not rotate if locked', async () => {
       mesh.metadata.isLocked = true
       expectRotated(mesh, 0)
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectRotated(mesh, 0)
       expect(animationEndReceived).not.toHaveBeenCalled()
     })
   })
 })
 
-function createAttachedRotable(state) {
+function createAttachedRotable(/** @type {RotableState}*/ state) {
   const behavior = new RotateBehavior(state)
   const mesh = createBox('box', {})
   mesh.addBehavior(behavior, true)
-  return behavior
+  return /** @type {RotateBehavior & { mesh: Mesh }} */ (behavior)
 }

--- a/apps/web/tests/3d/behaviors/stackable.test.js
+++ b/apps/web/tests/3d/behaviors/stackable.test.js
@@ -1,3 +1,14 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Observer<?>} Observer
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+/**
+ * @template {any[]} P, R
+ * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import {
@@ -10,9 +21,9 @@ import {
   MoveBehaviorName,
   RotateBehavior,
   RotateBehaviorName,
-  StackBehavior,
   StackBehaviorName
 } from '@src/3d/behaviors'
+import { StackBehavior } from '@src/3d/behaviors/stackable'
 import {
   controlManager,
   handManager,
@@ -51,10 +62,14 @@ describe('StackBehavior', () => {
   configures3dTestEngine(created => (scene = created.scene))
 
   const moveRecorded = vi.fn()
-  let recordSpy
-  let registerFeedbackSpy
-  let moveObserver
+  /** @type {Scene} */
   let scene
+  /** @type {SpyInstance<Parameters<typeof controlManager['record']>, void>} */
+  let recordSpy
+  /** @type {SpyInstance<Parameters<typeof indicatorManager['registerFeedback']>, void>} */
+  let registerFeedbackSpy
+  /** @type {?Observer} */
+  let moveObserver
 
   beforeAll(() => {
     moveObserver = moveManager.onMoveObservable.add(moveRecorded)
@@ -65,12 +80,14 @@ describe('StackBehavior', () => {
     vi.clearAllMocks()
     recordSpy = vi.spyOn(controlManager, 'record')
     registerFeedbackSpy = vi.spyOn(indicatorManager, 'registerFeedback')
-    vi.spyOn(handManager, 'draw').mockImplementation(mesh =>
-      controlManager.record({ mesh, fn: 'draw' })
-    )
+    vi.spyOn(handManager, 'draw').mockImplementation(async mesh => {
+      controlManager.record({ mesh, fn: 'draw', args: [] })
+    })
   })
 
-  afterAll(() => moveManager.onMoveObservable.remove(moveObserver))
+  afterAll(() => {
+    moveManager.onMoveObservable.remove(moveObserver)
+  })
 
   it('has initial state', () => {
     const state = {
@@ -134,7 +151,15 @@ describe('StackBehavior', () => {
   })
 
   describe('given attached to a mesh', () => {
-    let mesh, box1, box2, box3
+    /** @type {Mesh} */
+    let mesh
+    /** @type {Mesh} */
+    let box1
+    /** @type {Mesh} */
+    let box2
+    /** @type {Mesh} */
+    let box3
+    /** @type {StackBehavior} */
     let behavior
 
     beforeEach(() => {
@@ -146,18 +171,27 @@ describe('StackBehavior', () => {
         box.addBehavior(new RotateBehavior({ duration: 100 }), true)
         box.addBehavior(new MoveBehavior(), true)
         box.addBehavior(
-          new AnchorBehavior({ anchors: [{ x: -0.5 }, { x: 0.5 }] })
+          new AnchorBehavior({
+            anchors: [
+              { id: '1', x: -0.5 },
+              { id: '2', x: 0.5 }
+            ]
+          })
         )
         box.addBehavior(new DrawBehavior(), true)
         controlManager.registerControlable(box)
         return box
       })
 
-      behavior = getTargetableBehavior(mesh)
+      behavior = /** @type {StackBehavior} */ (getTargetableBehavior(mesh))
     })
 
     it('attaches metadata to its mesh', () => {
-      expectZone(behavior, { extent: 2, enabled: true, ignoreParts: true })
+      expectZone(behavior, {
+        extent: 2,
+        enabled: true,
+        ignoreParts: true
+      })
       expectStacked([mesh])
       expect(behavior.state.duration).toEqual(10)
       expect(behavior.state.extent).toEqual(2)
@@ -262,7 +296,7 @@ describe('StackBehavior', () => {
       const stackIds = [box1.id, box3.id]
       box3
         .getBehaviorByName(RotateBehaviorName)
-        .fromState({ duration: 100, angle: baseAngle })
+        ?.fromState({ duration: 100, angle: baseAngle })
       expectRotated(box3, baseAngle)
 
       behavior.fromState({ stackIds, angle: 0 })
@@ -275,13 +309,13 @@ describe('StackBehavior', () => {
 
     it('rotates pushed mesh regardless of their parent when hydrating', async () => {
       const angle = Math.PI * 0.5
-      await mesh.getBehaviorByName(RotateBehaviorName).rotate()
+      await mesh.getBehaviorByName(RotateBehaviorName)?.rotate()
       behavior.fromState({ stackIds: [], angle: 0 })
       expectStacked([mesh])
       expectRotated(mesh, angle)
       expectRotated(box1, 0)
-      await mesh.metadata.push(box1.id)
-      await mesh.metadata.push(box3.id)
+      await mesh.metadata.push?.(box1.id)
+      await mesh.metadata.push?.(box3.id)
       expectStacked([mesh, box1, box3])
       expectRotated(mesh, angle)
       expectRotated(box1, angle)
@@ -334,7 +368,7 @@ describe('StackBehavior', () => {
       expectStacked([mesh])
       expect(box1.absolutePosition).toEqual(Vector3.FromArray([1, 1, 1]))
 
-      await mesh.metadata.push(box1.id)
+      await mesh.metadata.push?.(box1.id)
       expectStacked([mesh, box1])
       expectRotated(box1, 0)
       expect(recordSpy).toHaveBeenCalledTimes(1)
@@ -351,7 +385,7 @@ describe('StackBehavior', () => {
     it('can push on any stacked mesh', async () => {
       behavior.fromState({ stackIds: ['box2', 'box1'] })
 
-      await box2.metadata.push(box3.id)
+      await box2.metadata.push?.(box3.id)
       expectStacked([mesh, box2, box1, box3])
       expectRotated(box1, 0)
       expectRotated(box2, 0)
@@ -361,7 +395,7 @@ describe('StackBehavior', () => {
         fn: 'push',
         mesh,
         args: [box3.id, false],
-        duration: box2.getBehaviorByName(StackBehaviorName).state.duration
+        duration: box2.getBehaviorByName(StackBehaviorName)?.state.duration
       })
       expectMoveRecorded(moveRecorded, box3)
       expectMeshFeedback(registerFeedbackSpy, 'push', box3)
@@ -371,20 +405,20 @@ describe('StackBehavior', () => {
       const baseAngle = Math.PI * 0.5
       mesh
         .getBehaviorByName(RotateBehaviorName)
-        .fromState({ duration: 100, angle: baseAngle })
+        ?.fromState({ duration: 100, angle: baseAngle })
       expectRotated(mesh, baseAngle)
       const angle = Math.PI
       box1
         .getBehaviorByName(RotateBehaviorName)
-        .fromState({ duration: 100, angle: Math.PI * -0.5 })
+        ?.fromState({ duration: 100, angle: Math.PI * -0.5 })
       box1
         .getBehaviorByName(FlipBehaviorName)
-        .fromState({ duration: 100, isFlipped: true })
+        ?.fromState({ duration: 100, isFlipped: true })
       behavior.fromState({ angle })
       expectStacked([mesh])
       expect(box1.absolutePosition).toEqual(Vector3.FromArray([1, 1, 1]))
 
-      await mesh.metadata.push(box1.id)
+      await mesh.metadata.push?.(box1.id)
       expectRotated(box1, baseAngle - angle)
       expectFlipped(box1)
       expectStacked([mesh, box1])
@@ -405,7 +439,7 @@ describe('StackBehavior', () => {
       expectInteractible(mesh, true)
       expectInteractible(box1, true, false)
 
-      await mesh.metadata.push(box1.id)
+      await mesh.metadata.push?.(box1.id)
       expectStacked([mesh, box1], false)
       expect(recordSpy).toHaveBeenCalledTimes(1)
       expect(recordSpy).toHaveBeenCalledWith({
@@ -420,7 +454,9 @@ describe('StackBehavior', () => {
 
     it('pushes dropped meshes', async () => {
       behavior.fromState({ stackIds: ['box2'] })
-      const targetable = getTargetableBehavior(box2)
+      const targetable = /** @type {StackBehavior} */ (
+        getTargetableBehavior(box2)
+      )
 
       targetable.onDropObservable.notifyObservers({
         dropped: [box1, box3],
@@ -433,13 +469,13 @@ describe('StackBehavior', () => {
         fn: 'push',
         mesh,
         args: [box1.id, false],
-        duration: box2.getBehaviorByName(StackBehaviorName).state.duration
+        duration: box2.getBehaviorByName(StackBehaviorName)?.state.duration
       })
       expect(recordSpy).toHaveBeenNthCalledWith(2, {
         fn: 'push',
         mesh,
         args: [box3.id, false],
-        duration: box2.getBehaviorByName(StackBehaviorName).state.duration
+        duration: box2.getBehaviorByName(StackBehaviorName)?.state.duration
       })
       expectMoveRecorded(moveRecorded, box1, box3)
       expectMeshFeedback(registerFeedbackSpy, 'push', box1, box3)
@@ -451,10 +487,10 @@ describe('StackBehavior', () => {
 
       box2
         .getBehaviorByName(StackBehaviorName)
-        .fromState({ stackIds: ['box3'] })
+        ?.fromState({ stackIds: ['box3'] })
       expectStacked([box2, box3])
 
-      await mesh.metadata.push(box2.id)
+      await mesh.metadata.push?.(box2.id)
       expectStacked([mesh, box1, box2, box3])
       expect(recordSpy).toHaveBeenCalledTimes(1)
       expect(recordSpy).toHaveBeenCalledWith({
@@ -468,7 +504,7 @@ describe('StackBehavior', () => {
     })
 
     it('can not pop an empty stack', async () => {
-      expect(await mesh.metadata.pop()).toEqual([])
+      expect(await mesh.metadata.pop?.()).toEqual([])
       expectStacked([mesh])
       expect(recordSpy).not.toHaveBeenCalled()
       expectMoveRecorded(moveRecorded)
@@ -478,7 +514,7 @@ describe('StackBehavior', () => {
     it('pops last mesh from stack', async () => {
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
-      let [poped] = await mesh.metadata.pop()
+      let [poped] = await (mesh.metadata.pop ? mesh.metadata.pop() : [])
       expect(poped?.id).toBe('box3')
       expectInteractible(poped)
       expectStacked([mesh, box2, box1])
@@ -490,7 +526,7 @@ describe('StackBehavior', () => {
       })
       expectStackIndicator(poped)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
-      ;[poped] = await mesh.metadata.pop()
+      ;[poped] = await (mesh.metadata.pop ? mesh.metadata.pop() : [])
       expect(poped?.id).toBe('box1')
       expectInteractible(poped)
       expectStacked([mesh, box2])
@@ -502,7 +538,7 @@ describe('StackBehavior', () => {
       })
       expectStackIndicator(poped)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
-      ;[poped] = await mesh.metadata.pop()
+      ;[poped] = await (mesh.metadata.pop ? mesh.metadata.pop() : [])
       expect(poped?.id).toBe('box2')
       expectInteractible(poped)
       expectStacked([mesh])
@@ -521,7 +557,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
       const [[poped]] = await Promise.all([
-        mesh.metadata.pop(1, true),
+        mesh.metadata.pop ? mesh.metadata.pop(1, true) : [],
         expectAnimationEnd(getAnimatableBehavior(box3))
       ])
       expect(poped?.id).toBe('box3')
@@ -543,7 +579,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
       const [[poped1, poped2]] = await Promise.all([
-        mesh.metadata.pop(2, true),
+        mesh.metadata.pop ? mesh.metadata.pop(2, true) : [],
         expectAnimationEnd(getAnimatableBehavior(box1)),
         expectAnimationEnd(getAnimatableBehavior(box3))
       ])
@@ -568,7 +604,9 @@ describe('StackBehavior', () => {
     it('pops all meshes from a stack', async () => {
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
-      let [poped1, poped2, poped3, poped4] = await mesh.metadata.pop(4)
+      let [poped1, poped2, poped3, poped4] = await await (mesh.metadata.pop
+        ? mesh.metadata.pop(4)
+        : [])
       expect(poped1?.id).toBe('box3')
       expect(poped2?.id).toBe('box1')
       expect(poped3?.id).toBe('box2')
@@ -591,7 +629,7 @@ describe('StackBehavior', () => {
     it('can pop from any stacked mesh', async () => {
       behavior.fromState({ stackIds: ['box3', 'box1', 'box2'] })
 
-      const [poped] = await box3.metadata.pop()
+      const [poped] = await (box3.metadata.pop ? box3.metadata.pop() : [])
       expect(poped?.id).toBe('box2')
       expectInteractible(poped)
       expectStacked([mesh, box3, box1])
@@ -623,11 +661,15 @@ describe('StackBehavior', () => {
     it('pops last mesh when drawn', async () => {
       behavior.fromState({ stackIds: ['box3', 'box1', 'box2'] })
 
-      box2.metadata.draw()
+      box2.metadata.draw?.()
       expectInteractible(box2)
       expectStacked([mesh, box3, box1])
       expect(recordSpy).toHaveBeenCalledTimes(1)
-      expect(recordSpy).toHaveBeenCalledWith({ fn: 'draw', mesh: box2 })
+      expect(recordSpy).toHaveBeenCalledWith({
+        fn: 'draw',
+        mesh: box2,
+        args: []
+      })
       expectMoveRecorded(moveRecorded)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -636,11 +678,15 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box3', 'box1', 'box2'] })
 
       box3.isPickable = false
-      box3.metadata.draw()
+      box3.metadata.draw?.()
       expectInteractible(box3, false, false)
       expectStacked([mesh, box3, box1, box2])
       expect(recordSpy).toHaveBeenCalledTimes(1)
-      expect(recordSpy).toHaveBeenCalledWith({ fn: 'draw', mesh: box3 })
+      expect(recordSpy).toHaveBeenCalledWith({
+        fn: 'draw',
+        mesh: box3,
+        args: []
+      })
       expect(moveRecorded).not.toHaveBeenCalled()
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -650,7 +696,7 @@ describe('StackBehavior', () => {
       expectInteractible(box3, true, false)
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
-      let [poped] = await mesh.metadata.pop()
+      let [poped] = await (mesh.metadata.pop ? mesh.metadata.pop() : [])
       expect(poped?.id).toBe('box3')
       expectInteractible(poped, true, false)
       expectStacked([mesh, box2, box1])
@@ -668,7 +714,7 @@ describe('StackBehavior', () => {
     it('reorders stack to given order', async () => {
       behavior.fromState({ stackIds: ['box3', 'box2', 'box1'] })
 
-      await mesh.metadata.reorder(['box0', 'box1', 'box2', 'box3'], false)
+      await mesh.metadata.reorder?.(['box0', 'box1', 'box2', 'box3'], false)
 
       expectStacked([mesh, box1, box2, box3])
       expect(recordSpy).toHaveBeenCalledTimes(1)
@@ -684,7 +730,7 @@ describe('StackBehavior', () => {
     it('reorders with animation', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
-      await mesh.metadata.reorder(['box2', 'box0', 'box3', 'box1'])
+      await mesh.metadata.reorder?.(['box2', 'box0', 'box3', 'box1'])
 
       expectStacked([box2, mesh, box3, box1])
       expect(recordSpy).toHaveBeenCalledTimes(1)
@@ -700,13 +746,13 @@ describe('StackBehavior', () => {
     it('can not reorder while reordering', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
-      const firstReordering = mesh.metadata.reorder([
+      const firstReordering = mesh.metadata.reorder?.([
         'box2',
         'box0',
         'box3',
         'box1'
       ])
-      mesh.metadata.reorder(['box4', 'box3', 'box2', 'box1'])
+      mesh.metadata.reorder?.(['box4', 'box3', 'box2', 'box1'])
       await firstReordering
 
       expectStacked([box2, mesh, box3, box1])
@@ -722,7 +768,7 @@ describe('StackBehavior', () => {
     it('can reorder any stacked mesh', async () => {
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
-      box3.metadata.reorder(['box0', 'box1', 'box2', 'box3'], false)
+      box3.metadata.reorder?.(['box0', 'box1', 'box2', 'box3'], false)
 
       expectStacked([mesh, box1, box2, box3])
       expect(recordSpy).toHaveBeenCalledTimes(1)
@@ -737,7 +783,7 @@ describe('StackBehavior', () => {
     it('can move current mesh while reordering', async () => {
       behavior.fromState({ stackIds: ['box3', 'box2', 'box1'] })
 
-      mesh.metadata.reorder(['box3', 'box0', 'box2', 'box1'], false)
+      mesh.metadata.reorder?.(['box3', 'box0', 'box2', 'box1'], false)
 
       expectStacked([box3, mesh, box2, box1])
       expect(recordSpy).toHaveBeenCalledTimes(1)
@@ -752,28 +798,36 @@ describe('StackBehavior', () => {
     it('flips the entire stack', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
-      await mesh.metadata.flipAll()
+      await mesh.metadata.flipAll?.()
       expectStacked([box3, box2, box1, mesh])
       expect(recordSpy).toHaveBeenCalledTimes(6)
-      expect(recordSpy).toHaveBeenNthCalledWith(1, { fn: 'flipAll', mesh })
+      expect(recordSpy).toHaveBeenNthCalledWith(1, {
+        fn: 'flipAll',
+        mesh,
+        args: []
+      })
       expect(recordSpy).toHaveBeenNthCalledWith(2, {
         fn: 'flip',
         mesh,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(3, {
         fn: 'flip',
         mesh: box1,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(4, {
         fn: 'flip',
         mesh: box2,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(5, {
         fn: 'flip',
         mesh: box3,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(6, {
@@ -787,14 +841,18 @@ describe('StackBehavior', () => {
 
     it('flips an entire flipped stack', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      await mesh.metadata.flip()
+      await mesh.metadata.flip?.()
       expectFlipped(mesh, true)
       recordSpy.mockReset()
 
-      await mesh.metadata.flipAll()
+      await mesh.metadata.flipAll?.()
       expectStacked([box3, box2, box1, mesh])
       expect(recordSpy).toHaveBeenCalledTimes(6)
-      expect(recordSpy).toHaveBeenNthCalledWith(1, { fn: 'flipAll', mesh })
+      expect(recordSpy).toHaveBeenNthCalledWith(1, {
+        fn: 'flipAll',
+        mesh,
+        args: []
+      })
       expect(recordSpy).toHaveBeenNthCalledWith(2, {
         fn: 'reorder',
         mesh,
@@ -803,21 +861,25 @@ describe('StackBehavior', () => {
       expect(recordSpy).toHaveBeenNthCalledWith(3, {
         fn: 'flip',
         mesh: box3,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(4, {
         fn: 'flip',
         mesh: box2,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(5, {
         fn: 'flip',
         mesh: box1,
+        args: [],
         duration: 100
       })
       expect(recordSpy).toHaveBeenNthCalledWith(6, {
         fn: 'flip',
         mesh,
+        args: [],
         duration: 100
       })
       expectMoveRecorded(moveRecorded)
@@ -825,14 +887,19 @@ describe('StackBehavior', () => {
     })
 
     it('flips an entire stack of one', async () => {
-      await mesh.metadata.flipAll()
+      await mesh.metadata.flipAll?.()
       expectStacked([mesh])
       expectFlipped(mesh, true)
       expect(recordSpy).toHaveBeenCalledTimes(2)
-      expect(recordSpy).toHaveBeenNthCalledWith(1, { fn: 'flipAll', mesh })
+      expect(recordSpy).toHaveBeenNthCalledWith(1, {
+        fn: 'flipAll',
+        mesh,
+        args: []
+      })
       expect(recordSpy).toHaveBeenNthCalledWith(2, {
         fn: 'flip',
         mesh,
+        args: [],
         duration: 100
       })
       expectMoveRecorded(moveRecorded)
@@ -841,15 +908,17 @@ describe('StackBehavior', () => {
 
     it('flips the entire stack from peer', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      controlManager.apply({ fn: 'flipAll', meshId: mesh.id }, true)
-      controlManager.apply({ fn: 'flipAll', meshId: mesh.id }, true)
-      controlManager.apply({ fn: 'flip', meshId: mesh.id }, true)
-      controlManager.apply({ fn: 'flip', meshId: box1.id }, true)
-      controlManager.apply({ fn: 'flip', meshId: box2.id }, true)
-      controlManager.apply({ fn: 'flip', meshId: box3.id }, true)
+      const extras = { args: [], fromHand: false, pos: undefined }
+      controlManager.apply({ fn: 'flipAll', meshId: mesh.id, ...extras }, true)
+      controlManager.apply({ fn: 'flipAll', meshId: mesh.id, ...extras }, true)
+      controlManager.apply({ fn: 'flip', meshId: mesh.id, ...extras }, true)
+      controlManager.apply({ fn: 'flip', meshId: box1.id, ...extras }, true)
+      controlManager.apply({ fn: 'flip', meshId: box2.id, ...extras }, true)
+      controlManager.apply({ fn: 'flip', meshId: box3.id, ...extras }, true)
       controlManager.apply({
         fn: 'reorder',
         meshId: mesh.id,
+        ...extras,
         args: [['box3', 'box2', 'box1', 'box0'], false]
       })
 
@@ -862,7 +931,7 @@ describe('StackBehavior', () => {
     it('rotates the entire stack', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectStacked([mesh, box1, box2, box3])
       expect(recordSpy).toHaveBeenCalledTimes(1)
       expect(recordSpy).toHaveBeenNthCalledWith(1, {
@@ -876,7 +945,7 @@ describe('StackBehavior', () => {
     })
 
     it('rotates an entire stack of one', async () => {
-      await mesh.metadata.rotate()
+      await mesh.metadata.rotate?.()
       expectStacked([mesh])
       expect(recordSpy).toHaveBeenCalledTimes(1)
       expect(recordSpy).toHaveBeenCalledWith({
@@ -890,32 +959,43 @@ describe('StackBehavior', () => {
     })
 
     it('can not push no mesh', () => {
-      expect(mesh.metadata.canPush()).toBe(false)
-      expect(mesh.metadata.canPush(null)).toBe(false)
+      // @ts-expect-error no arguments
+      expect(mesh.metadata.canPush?.()).toBe(false)
+      // @ts-expect-error null is not acceptable
+      expect(mesh.metadata.canPush?.(null)).toBe(false)
     })
 
     it('can not push mesh with different kind', () => {
       behavior.fromState({ kinds: ['card'] })
-      box1.getBehaviorByName(MoveBehaviorName).state.kind = 'token'
-      expect(mesh.metadata.canPush(box1)).toBe(false)
-      expect(mesh.metadata.canPush(box2)).toBe(false)
+      const moveBehavior = /** @type {MoveBehavior} */ (
+        box1.getBehaviorByName(MoveBehaviorName)
+      )
+      moveBehavior.state.kind = 'token'
+      expect(mesh.metadata.canPush?.(box1)).toBe(false)
+      expect(mesh.metadata.canPush?.(box2)).toBe(false)
     })
 
     it('can push mesh with the same kind', () => {
       behavior.fromState({ kinds: ['card'] })
-      box1.getBehaviorByName(MoveBehaviorName).state.kind = 'card'
-      expect(mesh.metadata.canPush(box1)).toBe(true)
+      const moveBehavior = /** @type {MoveBehavior} */ (
+        box1.getBehaviorByName(MoveBehaviorName)
+      )
+      moveBehavior.state.kind = 'card'
+      expect(mesh.metadata.canPush?.(box1)).toBe(true)
     })
 
     it('can push mesh with kind on kindless zone', () => {
-      box1.getBehaviorByName(MoveBehaviorName).state.kind = 'card'
-      expect(mesh.metadata.canPush(box1)).toBe(true)
+      const moveBehavior = /** @type {MoveBehavior} */ (
+        box1.getBehaviorByName(MoveBehaviorName)
+      )
+      moveBehavior.state.kind = 'card'
+      expect(mesh.metadata.canPush?.(box1)).toBe(true)
     })
 
     it('can push on top of a stacked the entire stack', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2'] })
       expectStacked([mesh, box1, box2])
-      expect(mesh.metadata.canPush(box3)).toBe(true)
+      expect(mesh.metadata.canPush?.(box3)).toBe(true)
     })
   })
 })

--- a/apps/web/tests/3d/behaviors/targetable.test.js
+++ b/apps/web/tests/3d/behaviors/targetable.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { faker } from '@faker-js/faker'
 import { TargetBehavior, TargetBehaviorName } from '@src/3d/behaviors'
 import { indicatorManager, targetManager } from '@src/3d/managers'
@@ -8,15 +13,12 @@ import { configures3dTestEngine, createBox } from '../../test-utils'
 describe('TargetBehavior', () => {
   configures3dTestEngine()
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   it('has initial state', () => {
-    const state = {
-      isFlipped: faker.datatype.boolean(),
-      duration: faker.number.int(999),
-      ignoreParts: faker.datatype.boolean()
-    }
-    const behavior = new TargetBehavior(state)
+    const behavior = new TargetBehavior()
     const mesh = createBox('box', {})
 
     expect(behavior.name).toEqual(TargetBehaviorName)
@@ -76,7 +78,7 @@ describe('TargetBehavior', () => {
     expect(indicatorManager.isManaging({ id })).toBe(false)
     const behavior = new TargetBehavior()
     const mesh = createBox(meshId, {})
-    const zone = behavior.addZone(mesh, { playerId })
+    const zone = behavior.addZone(mesh, { playerId, extent: 1 })
     expect(behavior.zones).toEqual([zone])
     expect(zone).toEqual(
       expect.objectContaining({ mesh, enabled: true, priority: 0, playerId })
@@ -105,13 +107,17 @@ describe('TargetBehavior', () => {
       mesh,
       enabled: true,
       extent: 1,
+      priority: 0,
+      ignoreParts: true,
       targetable: behavior
     })
     expect(behavior.zones).toEqual([])
   })
 
   describe('given attached to a mesh', () => {
+    /** @type {Mesh} */
     let mesh
+    /** @type {TargetBehavior} */
     let behavior
 
     beforeEach(() => {

--- a/apps/web/tests/3d/managers/camera.test.js
+++ b/apps/web/tests/3d/managers/camera.test.js
@@ -1,3 +1,10 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').ArcRotateCamera} ArcRotateCamera
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
+ */
+
 import { faker } from '@faker-js/faker'
 import { cameraManager as manager } from '@src/3d/managers'
 import { createTable } from '@src/3d/utils'
@@ -6,7 +13,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { configures3dTestEngine } from '../../test-utils'
 
 describe('CameraManager', () => {
+  /** @type {Scene} */
+  let scene
+  /** @type {CameraPosition[]} */
   let states
+  /** @type {CameraPosition[][]} */
   let saveUpdates
   const defaults = {
     alpha: (3 * Math.PI) / 2,
@@ -17,11 +28,11 @@ describe('CameraManager', () => {
     target: [0, 0, 0]
   }
 
-  configures3dTestEngine()
+  configures3dTestEngine(created => (scene = created.scene))
 
   beforeEach(() => {
     vi.resetAllMocks()
-    createTable()
+    createTable(undefined, scene)
     states = []
     saveUpdates = []
   })
@@ -65,13 +76,13 @@ describe('CameraManager', () => {
   describe('init()', () => {
     it('creates a camera with defaults', () => {
       manager.init()
-      expect(manager.camera.upperBetaLimit).toEqual(Math.PI / 3)
-      expect(manager.camera.lowerRadiusLimit).toEqual(defaults.minY)
-      expect(manager.camera.upperRadiusLimit).toEqual(defaults.maxY)
-      expect(manager.camera.alpha).toEqual(defaults.alpha)
-      expect(manager.camera.beta).toEqual(defaults.beta)
-      expect(manager.camera.radius).toEqual(defaults.elevation)
-      expect(manager.camera.target.asArray()).toEqual(defaults.target)
+      expect(manager.camera?.upperBetaLimit).toEqual(Math.PI / 3)
+      expect(manager.camera?.lowerRadiusLimit).toEqual(defaults.minY)
+      expect(manager.camera?.upperRadiusLimit).toEqual(defaults.maxY)
+      expect(manager.camera?.alpha).toEqual(defaults.alpha)
+      expect(manager.camera?.beta).toEqual(defaults.beta)
+      expect(manager.camera?.radius).toEqual(defaults.elevation)
+      expect(manager.camera?.target.asArray()).toEqual(defaults.target)
       expectState(manager.saves[0])
     })
 
@@ -84,13 +95,13 @@ describe('CameraManager', () => {
       const maxY = 50
       const minAngle = Math.PI / 8
       manager.init({ beta, y: elevation, minY, maxY, minAngle })
-      expect(manager.camera.upperBetaLimit).toEqual(minAngle)
-      expect(manager.camera.lowerRadiusLimit).toEqual(minY)
-      expect(manager.camera.upperRadiusLimit).toEqual(maxY)
-      expect(manager.camera.alpha).toEqual(alpha)
-      expect(manager.camera.beta).toEqual(beta)
-      expect(manager.camera.radius).toEqual(elevation)
-      expect(manager.camera.target.asArray()).toEqual(target)
+      expect(manager.camera?.upperBetaLimit).toEqual(minAngle)
+      expect(manager.camera?.lowerRadiusLimit).toEqual(minY)
+      expect(manager.camera?.upperRadiusLimit).toEqual(maxY)
+      expect(manager.camera?.alpha).toEqual(alpha)
+      expect(manager.camera?.beta).toEqual(beta)
+      expect(manager.camera?.radius).toEqual(elevation)
+      expect(manager.camera?.target.asArray()).toEqual(target)
       expectState(manager.saves[0], { alpha, beta, elevation })
     })
   })
@@ -301,19 +312,19 @@ describe('CameraManager', () => {
     it('adjusts minimum main scene zoom', () => {
       const min = faker.number.int(999)
       manager.adjustZoomLevels({ min })
-      expect(manager.camera.lowerRadiusLimit).toEqual(min)
+      expect(manager.camera?.lowerRadiusLimit).toEqual(min)
     })
 
     it('adjusts maximum main scene zoom', () => {
       const max = faker.number.int(999)
       manager.adjustZoomLevels({ max })
-      expect(manager.camera.upperRadiusLimit).toEqual(max)
+      expect(manager.camera?.upperRadiusLimit).toEqual(max)
     })
 
     it('adjusts current hand scene zoom', () => {
       const hand = faker.number.int(999)
       manager.adjustZoomLevels({ hand })
-      expect(manager.handSceneCamera.position.y).toEqual(hand)
+      expect(manager.handSceneCamera?.position.y).toEqual(hand)
     })
 
     it('adjusts all level at once', () => {
@@ -321,13 +332,21 @@ describe('CameraManager', () => {
       const min = faker.number.int(999)
       const max = faker.number.int(999)
       manager.adjustZoomLevels({ min, max, hand })
-      expect(manager.camera.lowerRadiusLimit).toEqual(min)
-      expect(manager.camera.upperRadiusLimit).toEqual(max)
-      expect(manager.handSceneCamera.position.y).toEqual(hand)
+      expect(manager.camera?.lowerRadiusLimit).toEqual(min)
+      expect(manager.camera?.upperRadiusLimit).toEqual(max)
+      expect(manager.handSceneCamera?.position.y).toEqual(hand)
     })
   })
 
-  function expectState(state, { alpha, beta, elevation, target = [] } = {}) {
+  function expectState(
+    /** @type {CameraPosition} */ state,
+    /** @type {Partial<CameraPosition>} */ {
+      alpha,
+      beta,
+      elevation,
+      target = []
+    } = {}
+  ) {
     expect(state.alpha).toBeCloseTo(alpha ?? defaults.alpha)
     expect(state.beta).toBeCloseTo(beta ?? defaults.beta)
     expect(state.elevation).toEqual(elevation ?? defaults.elevation)

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -1418,7 +1418,7 @@ describe('HandManager', () => {
           expect(moveManager.isManaging(newMesh2)).toBe(true)
           await expectAnimationEnd(newMesh1.getBehaviorByName(DrawBehaviorName))
           expectSnapped(dropZone, newMesh1)
-          expectStacked([newMesh1, newMesh2])
+          expectStacked([newMesh1, newMesh2], true, dropZone.id)
         })
 
         it(`automatically moves mesh to player's drop zone when dragging mesh`, async () => {
@@ -1564,7 +1564,7 @@ describe('HandManager', () => {
           expect(controlManager.isManaging(newMesh2)).toBe(true)
           expect(moveManager.isManaging(newMesh2)).toBe(true)
           expectSnapped(dropZone, newMesh1)
-          expectStacked([newMesh1, newMesh2])
+          expectStacked([newMesh1, newMesh2], true, dropZone.id)
           expectCloseVector(
             extractDrawnState(),
             newMesh1.absolutePosition.asArray()

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -1,3 +1,18 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').ArcRotateCamera} ArcRotateCamera
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Observer<?>} Observer
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/behaviors').DrawBehavior} DrawBehavior
+ * @typedef {import('@tabulous/server/src/graphql/types').Mesh} SerializableMesh
+ */
+/**
+ * @template {any[]} P, R
+ * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import {
@@ -42,12 +57,19 @@ import {
 } from '../../test-utils'
 
 describe('HandManager', () => {
+  /** @type {Engine} */
   let engine
+  /** @type {Scene} */
   let scene
+  /** @type {ArcRotateCamera} */
   let camera
+  /** @type {Scene} */
   let handScene
+  /** @type {?Observer} */
   let actionObserver
+  /** @type {Vector3} */
   let savedCameraPosition
+  /** @type {SpyInstance<Parameters<typeof indicatorManager['registerFeedback']>, void>} */
   let registerFeedbackSpy
   const overlay = document.createElement('div')
 
@@ -76,9 +98,12 @@ describe('HandManager', () => {
   )
 
   beforeAll(() => {
-    vi.spyOn(window, 'getComputedStyle').mockImplementation(() => ({
-      height: `${renderHeight / 4}px`
-    }))
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(
+      () =>
+        /** @type {CSSStyleDeclaration} */ ({
+          height: `${renderHeight / 4}px`
+        })
+    )
     savedCameraPosition = camera.position.clone()
     targetManager.init({ scene, playerId, color: '#00ff00' })
     indicatorManager.init({ scene })
@@ -92,11 +117,13 @@ describe('HandManager', () => {
     createTable({}, scene)
   })
 
-  afterAll(() => controlManager.onActionObservable.remove(actionObserver))
+  afterAll(() => {
+    controlManager.onActionObservable.remove(actionObserver)
+  })
 
   it('has initial state', () => {
-    expect(manager.scene).toBeNull()
-    expect(manager.handScene).toBeNull()
+    expect(manager.scene).toBeUndefined()
+    expect(manager.handScene).toBeUndefined()
     expect(manager.gap).toEqual(0)
     expect(manager.horizontalPadding).toEqual(0)
     expect(manager.verticalPadding).toEqual(0)
@@ -107,7 +134,7 @@ describe('HandManager', () => {
   })
 
   it('can not draw mesh', async () => {
-    const mesh = createMesh({ id: 'box' }, scene)
+    const mesh = createMesh({ id: 'box', shape: 'box', texture: '' }, scene)
     await manager.draw(mesh)
     expect(actionRecorded).not.toHaveBeenCalled()
     expect(registerFeedbackSpy).not.toHaveBeenCalled()
@@ -115,7 +142,10 @@ describe('HandManager', () => {
 
   it('can not apply draw', async () => {
     const id = 'box'
-    await manager.applyDraw({ drawable: {}, id })
+    await manager.applyDraw(
+      { shape: 'box', texture: '', drawable: {}, id },
+      'player'
+    )
     expect(scene.getMeshById(id)?.id).toBeUndefined()
     expect(handScene.getMeshById(id)?.id).toBeUndefined()
     expect(registerFeedbackSpy).not.toHaveBeenCalled()
@@ -123,7 +153,9 @@ describe('HandManager', () => {
   })
 
   describe('init()', () => {
-    afterEach(() => engine.onDisposeObservable.notifyObservers())
+    afterEach(() => {
+      engine.onDisposeObservable.notifyObservers(engine)
+    })
 
     it('sets scenes', () => {
       const gap = faker.number.int(999)
@@ -164,11 +196,14 @@ describe('HandManager', () => {
           duration,
           transitionMargin
         })
+
         const cards = [
-          { id: 'box1', x: 1, y: 1, z: -1 },
-          { id: 'box2', x: 0, y: 0, z: 0 },
-          { id: 'box3', x: -5, y: 0, z: -2 }
-        ].map(state => createMesh(state, handScene))
+          { id: 'box1', shape: 'box', texture: '', x: 1, y: 1, z: -1 },
+          { id: 'box2', shape: 'box', texture: '', x: 0, y: 0, z: 0 },
+          { id: 'box3', shape: 'box', texture: '', x: -5, y: 0, z: -2 }
+        ].map(state =>
+          createMesh(/** @type {SerializableMesh} */ (state), handScene)
+        )
         await waitForLayout()
         const z = computeZ()
         expectPosition(cards[2], [-gap - cardWidth, 0.005, z])
@@ -182,8 +217,11 @@ describe('HandManager', () => {
   })
 
   describe('given an initialized manager', () => {
+    /** @type {Mesh[]} */
     let cards
+    /** @type {?Observer} */
     let changeObserver
+    /** @type {?Observer} */
     let draggableToHandObserver
     const changeReceived = vi.fn()
     const draggableToHandReceived = vi.fn()
@@ -203,7 +241,7 @@ describe('HandManager', () => {
         { id: 'box2', x: 0, y: 0, z: 0 },
         { id: 'box3', x: -5, y: 0, z: -10 },
         { id: 'box4', x: 5, y: 5, z: 5 }
-      ].map(state => createMesh(state, scene))
+      ].map(state => createMesh(/** @type {SerializableMesh} */ (state), scene))
     })
 
     afterEach(async () => {
@@ -222,6 +260,7 @@ describe('HandManager', () => {
       const card = createCard(
         {
           id: 'undrawable box',
+          texture: '',
           width: cardWidth,
           depth: cardDepth,
           rotable: {},
@@ -238,11 +277,11 @@ describe('HandManager', () => {
 
     it('moves drawn mesh to hand', async () => {
       const [, card] = cards
-      card.metadata.draw()
+      card.metadata.draw?.()
       await waitForLayout()
       await expectAnimationEnd(card.getBehaviorByName(DrawBehaviorName))
       expect(scene.getMeshById(card.id)?.id).toBeUndefined()
-      const newMesh = handScene.getMeshById(card.id)
+      const newMesh = getMeshById(handScene, card.id)
       expect(newMesh?.id).toBeDefined()
       expectPosition(newMesh, [0, 0, computeZ()])
       expect(changeReceived).toHaveBeenCalledTimes(1)
@@ -263,11 +302,11 @@ describe('HandManager', () => {
 
     it('unflips flipped mesh while drawing into hand', async () => {
       const [card] = cards
-      await card.metadata.flip()
+      await card.metadata.flip?.()
       actionRecorded.mockReset()
       expectFlipped(card, true)
-      card.metadata.draw()
-      const newMesh = handScene.getMeshById(card.id)
+      card.metadata.draw?.()
+      const newMesh = getMeshById(handScene, card.id)
       await Promise.all([
         expectAnimationEnd(newMesh.getBehaviorByName(FlipBehaviorName)),
         expectAnimationEnd(card.getBehaviorByName(DrawBehaviorName)),
@@ -284,7 +323,7 @@ describe('HandManager', () => {
         expect.anything()
       )
       expect(actionRecorded).toHaveBeenCalledWith(
-        { meshId: newMesh.id, fn: 'flip', fromHand: true, duration },
+        { meshId: newMesh.id, fn: 'flip', args: [], fromHand: true, duration },
         expect.anything()
       )
       expect(actionRecorded).toHaveBeenCalledTimes(2)
@@ -294,15 +333,15 @@ describe('HandManager', () => {
     it('can rotate mesh while drawing into hand', async () => {
       const [card] = cards
       const angle = Math.PI
-      card.getBehaviorByName(DrawBehaviorName).state.angleOnPick = angle
-      await card.metadata.rotate()
-      await card.metadata.rotate()
-      await card.metadata.rotate()
+      getDrawBehavior(card).state.angleOnPick = angle
+      await card.metadata.rotate?.()
+      await card.metadata.rotate?.()
+      await card.metadata.rotate?.()
       expectRotated(card, Math.PI * -0.5)
       actionRecorded.mockReset()
 
-      card.metadata.draw()
-      const newMesh = handScene.getMeshById(card.id)
+      card.metadata.draw?.()
+      const newMesh = getMeshById(handScene, card.id)
       await Promise.all([
         expectAnimationEnd(newMesh.getBehaviorByName(RotateBehaviorName)),
         expectAnimationEnd(card.getBehaviorByName(DrawBehaviorName)),
@@ -330,21 +369,21 @@ describe('HandManager', () => {
       )
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
-      expect(newMesh.getBehaviorByName(RotateBehaviorName).state.angle).toBe(
+      expect(newMesh.getBehaviorByName(RotateBehaviorName)?.state.angle).toBe(
         angle
       )
     })
 
     it('can keep flipped mesh while drawing into hand', async () => {
       const [card] = cards
-      card.getBehaviorByName(DrawBehaviorName).state.unflipOnPick = false
-      await card.metadata.flip()
+      getDrawBehavior(card).state.unflipOnPick = false
+      await card.metadata.flip?.()
       actionRecorded.mockReset()
       expectFlipped(card, true)
-      card.metadata.draw()
+      card.metadata.draw?.()
       await waitForLayout()
-      await expectAnimationEnd(card.getBehaviorByName(DrawBehaviorName))
-      const newMesh = handScene.getMeshById(card.id)
+      await expectAnimationEnd(getDrawBehavior(card))
+      const newMesh = getMeshById(handScene, card.id)
       expectFlipped(newMesh, true)
       expect(actionRecorded).toHaveBeenCalledWith(
         {
@@ -363,7 +402,7 @@ describe('HandManager', () => {
       const [, , card] = cards
       const playerId = faker.string.uuid()
       await manager.applyDraw(card.metadata.serialize(), playerId)
-      await expectAnimationEnd(card.getBehaviorByName(DrawBehaviorName))
+      await expectAnimationEnd(getDrawBehavior(card))
       expect(scene.getMeshById(card.id)?.id).toBeUndefined()
       expect(handScene.meshes.length).toEqual(0)
       expect(changeReceived).not.toHaveBeenCalled()
@@ -392,11 +431,13 @@ describe('HandManager', () => {
           { id: 'box17', x: 2, y: 0, z: 0 },
           { id: 'box18', x: 2, y: 0, z: 0 },
           { id: 'box19', x: 2, y: 0, z: 0 }
-        ].map(state => createMesh(state, scene))
+        ].map(state =>
+          createMesh(/** @type {SerializableMesh} */ (state), scene)
+        )
       )
 
       for (const card of cards) {
-        card.metadata.draw()
+        card.metadata.draw?.()
       }
       await waitForLayout()
       const z = computeZ()
@@ -412,6 +453,7 @@ describe('HandManager', () => {
     })
 
     describe('given some meshs in hand', () => {
+      /** @type {Mesh[]} */
       let handCards
 
       beforeEach(async () => {
@@ -419,7 +461,9 @@ describe('HandManager', () => {
           { id: 'box20', x: 1, y: 1, z: -1 },
           { id: 'box21', x: 0, y: 0, z: 0 },
           { id: 'box22', x: 2, y: 0, z: 0 }
-        ].map(state => createMesh(state, handScene))
+        ].map(state =>
+          createMesh(/** @type {SerializableMesh} */ (state), handScene)
+        )
         await waitForLayout()
         changeReceived.mockReset()
         camera.lockedTarget = new Vector3(0, 0, 0)
@@ -443,7 +487,7 @@ describe('HandManager', () => {
 
       it('lays out hand when drawing more mesh to hand', async () => {
         const [, card2] = cards
-        card2.metadata.draw()
+        card2.metadata.draw?.()
         await waitForLayout()
         const unitWidth = cardWidth + gap
         expectPosition(handScene.getMeshById(card2.id), [
@@ -457,9 +501,9 @@ describe('HandManager', () => {
       })
 
       it('lays out hand when resizing engine', async () => {
-        engine.onResizeObservable.notifyObservers()
-        engine.onResizeObservable.notifyObservers()
-        engine.onResizeObservable.notifyObservers()
+        engine.onResizeObservable.notifyObservers(engine)
+        engine.onResizeObservable.notifyObservers(engine)
+        engine.onResizeObservable.notifyObservers(engine)
         await waitForLayout()
         const unitWidth = cardWidth + gap
         expectPosition(handCards[1], [-unitWidth, 0.005, computeZ()])
@@ -468,7 +512,9 @@ describe('HandManager', () => {
       })
 
       it('lays out hand when resizing hand overlay', async () => {
+        // @ts-expect-error resizeObservers is a test fixture
         window.resizeObservers[0].notify()
+        // @ts-expect-error
         window.resizeObservers[0].notify()
         await waitForLayout()
         const unitWidth = cardWidth + gap
@@ -483,7 +529,7 @@ describe('HandManager', () => {
         expectPosition(handCards[1], [-unitWidth, 0.005, z])
         expectPosition(handCards[0], [0, 0.005, z])
         expectPosition(handCards[2], [unitWidth, 0.005, z])
-        handCards[0].metadata.rotate()
+        handCards[0].metadata.rotate?.()
         await waitForLayout()
         unitWidth = (cardWidth + cardDepth) / 2 + gap
         expectPosition(handCards[1], [-unitWidth, 0.005, z])
@@ -493,14 +539,14 @@ describe('HandManager', () => {
 
       it('lays out hand when flipping mesh in hand', async () => {
         const positions = getPositions(handCards)
-        handCards[0].metadata.flip()
+        handCards[0].metadata.flip?.()
         await waitForLayout()
         expect(getPositions(handCards)).toEqual(positions)
       })
 
       it('does not lay out hand when rotating mesh in main scene', async () => {
         const positions = getPositions(handCards)
-        cards[2].metadata.rotate()
+        cards[2].metadata.rotate?.()
         await expect(waitForLayout()).rejects.toThrow()
         expect(getPositions(handCards)).toEqual(positions)
       })
@@ -516,7 +562,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(getPositions(handCards)).toEqual([
@@ -536,7 +585,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'drag',
           mesh,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(getPositions(handCards)).toEqual([
@@ -556,7 +608,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
           mesh,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(getPositions(handCards)).toEqual([
@@ -582,7 +637,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh: mesh2,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(draggableToHandReceived).toHaveBeenCalledTimes(2)
@@ -600,7 +658,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'drag',
           mesh: mesh2,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(getPositions(handCards)).toEqual([
@@ -611,7 +672,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
           mesh: mesh1,
-          event: {}
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({})
         })
         await waitForLayout()
         expect(getPositions(handCards)).toEqual([
@@ -639,11 +703,14 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await waitForLayout()
         expect(handScene.getMeshById(mesh.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(mesh.id)
+        const newMesh = getMeshById(scene, mesh.id)
         expect(newMesh?.id).toBeDefined()
         expectPosition(newMesh, [6, 2.005, 0])
         const unitWidth = cardWidth + gap
@@ -669,7 +736,7 @@ describe('HandManager', () => {
 
       it('can flip mesh to main scene while dragging', async () => {
         const mesh = handCards[1]
-        mesh.getBehaviorByName(DrawBehaviorName).state.flipOnPlay = true
+        getDrawBehavior(mesh).state.flipOnPlay = true
         expectFlipped(mesh, false)
 
         let movedPosition = new Vector3(
@@ -681,11 +748,14 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await waitForLayout()
         expect(handScene.getMeshById(mesh.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(mesh.id)
+        const newMesh = getMeshById(scene, mesh.id)
         expect(newMesh?.id).toBeDefined()
         expectFlipped(newMesh, true)
         expectPosition(newMesh, [6, 2.005, 0])
@@ -725,11 +795,14 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await waitForLayout()
         expect(handScene.getMeshById(mesh.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(mesh.id)
+        const newMesh = getMeshById(scene, mesh.id)
         expect(newMesh?.id).toBeDefined()
         expectRotated(newMesh, angle)
         expectPosition(newMesh, [6, 2.005, 0])
@@ -764,13 +837,16 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await waitForLayout()
         expect(handScene.getMeshById(mesh.id)?.id).toBeUndefined()
         expect(selectionManager.meshes.has(mesh)).toBe(false)
 
-        const newMesh = scene.getMeshById(mesh.id)
+        const newMesh = getMeshById(scene, mesh.id)
         expect(newMesh?.id).toBeDefined()
         expect(selectionManager.meshes.has(newMesh)).toBe(true)
         expectPosition(newMesh, [6, 2.005, 0])
@@ -801,7 +877,10 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'dragStart',
             mesh,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
           expect(draggableToHandReceived).toHaveBeenCalledTimes(2)
           expect(draggableToHandReceived).toHaveBeenNthCalledWith(
@@ -813,7 +892,10 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'dragStop',
             mesh,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
           await waitForLayout()
           expect(draggableToHandReceived).toHaveBeenCalledTimes(3)
@@ -823,7 +905,7 @@ describe('HandManager', () => {
             expect.anything()
           )
           expect(scene.getMeshById(mesh.id)?.id).toBeUndefined()
-          const newMesh = handScene.getMeshById(mesh.id)
+          const newMesh = getMeshById(handScene, mesh.id)
           expect(newMesh?.id).toBeDefined()
           const unitWidth = cardWidth + gap
           expectPosition(handCards[1], [unitWidth * -1.5, 0.005, computeZ()])
@@ -848,7 +930,7 @@ describe('HandManager', () => {
 
       it('moves all selected meshes to hand by dragging', async () => {
         const [mesh1, mesh2, mesh3] = cards
-        mesh3.metadata.push(mesh2.id)
+        mesh3.metadata.push?.(mesh2.id)
         selectionManager.select([mesh1, mesh2, mesh3])
         actionRecorded.mockReset()
         const stopDrag = vi.spyOn(inputManager, 'stopDrag')
@@ -858,21 +940,27 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh: mesh1,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         expect(stopDrag).toHaveBeenCalledTimes(1)
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
           mesh: mesh1,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await waitForLayout()
         expect(scene.getMeshById(mesh1.id)?.id).toBeUndefined()
-        const newMesh1 = handScene.getMeshById(mesh1.id)
+        const newMesh1 = getMeshById(handScene, mesh1.id)
         expect(newMesh1?.id).toBeDefined()
-        const newMesh2 = handScene.getMeshById(mesh2.id)
+        const newMesh2 = getMeshById(handScene, mesh2.id)
         expect(newMesh2?.id).toBeDefined()
-        const newMesh3 = handScene.getMeshById(mesh3.id)
+        const newMesh3 = getMeshById(handScene, mesh3.id)
         expect(newMesh3?.id).toBeDefined()
         const unitWidth = cardWidth + gap
         expectPosition(newMesh3, [unitWidth * -2.5, 0.005, computeZ()])
@@ -919,7 +1007,7 @@ describe('HandManager', () => {
 
       it('unflips flipped mesh while dragging into hand', async () => {
         const [, , mesh] = cards
-        await mesh.metadata.flip()
+        await mesh.metadata.flip?.()
         actionRecorded.mockReset()
         expectFlipped(mesh, true)
         let movedPosition = new Vector3(1, 0, -19)
@@ -927,14 +1015,20 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
-        const newMesh = handScene.getMeshById(mesh.id)
+        const newMesh = getMeshById(handScene, mesh.id)
         await Promise.all([
           expectAnimationEnd(newMesh.getBehaviorByName(FlipBehaviorName)),
           waitForLayout()
@@ -950,7 +1044,13 @@ describe('HandManager', () => {
           expect.anything()
         )
         expect(actionRecorded).toHaveBeenCalledWith(
-          { meshId: newMesh.id, fn: 'flip', fromHand: true, duration },
+          {
+            meshId: newMesh.id,
+            fn: 'flip',
+            args: [],
+            fromHand: true,
+            duration
+          },
           expect.anything()
         )
         expect(actionRecorded).toHaveBeenCalledTimes(2)
@@ -960,7 +1060,11 @@ describe('HandManager', () => {
         const positions = getPositions(handCards)
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
-          event: { x: 289.7, y: 175 }
+          mesh: null,
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         expect(draggableToHandReceived).toHaveBeenCalledTimes(1)
         expect(draggableToHandReceived).toHaveBeenNthCalledWith(
@@ -970,7 +1074,11 @@ describe('HandManager', () => {
         )
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
-          event: { x: 289.7, y: 175 }
+          mesh: null,
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await expect(waitForLayout()).rejects.toThrow()
         expect(draggableToHandReceived).toHaveBeenCalledTimes(2)
@@ -985,12 +1093,15 @@ describe('HandManager', () => {
 
       it('ignores drag operations of non-drawable meshes', async () => {
         const [mesh] = cards
-        mesh.removeBehavior(mesh.getBehaviorByName(DrawBehaviorName))
+        mesh.removeBehavior(getDrawBehavior(mesh))
         const positions = getPositions(handCards)
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStart',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         expect(draggableToHandReceived).toHaveBeenCalledTimes(1)
         expect(draggableToHandReceived).toHaveBeenNthCalledWith(
@@ -1001,7 +1112,10 @@ describe('HandManager', () => {
         inputManager.onDragObservable.notifyObservers({
           type: 'dragStop',
           mesh,
-          event: { x: 289.7, y: 175 }
+          timestamp: Date.now(),
+          button: 1,
+          pointers: 1,
+          event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
         })
         await expect(waitForLayout()).rejects.toThrow()
         expect(draggableToHandReceived).toHaveBeenCalledTimes(2)
@@ -1016,10 +1130,10 @@ describe('HandManager', () => {
 
       it('moves mesh to main scene', async () => {
         const [, card] = handCards
-        card.metadata.draw()
+        card.metadata.draw?.()
         await waitForLayout()
         expect(handScene.getMeshById(card.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(card.id)
+        const newMesh = getMeshById(scene, card.id)
         expect(newMesh?.id).toBeDefined()
         await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
         expect(actionRecorded).toHaveBeenCalledWith(
@@ -1044,10 +1158,10 @@ describe('HandManager', () => {
         const [, card] = handCards
         const [base] = cards
         base.setAbsolutePosition(new Vector3(-3.89, 0, 0))
-        card.metadata.draw()
+        card.metadata.draw?.()
         await waitForLayout()
         expect(handScene.getMeshById(card.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(card.id)
+        const newMesh = getMeshById(scene, card.id)
         expect(newMesh?.id).toBeDefined()
         await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
         expect(actionRecorded).toHaveBeenNthCalledWith(
@@ -1088,12 +1202,12 @@ describe('HandManager', () => {
 
       it('can flip mesh prior to moving it to main scene', async () => {
         const [, card] = handCards
-        card.getBehaviorByName(DrawBehaviorName).state.flipOnPlay = true
+        getDrawBehavior(card).state.flipOnPlay = true
         expectFlipped(card, false)
-        card.metadata.draw()
+        card.metadata.draw?.()
         await waitForLayout()
         expect(handScene.getMeshById(card.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(card.id)
+        const newMesh = getMeshById(scene, card.id)
         expect(newMesh?.id).toBeDefined()
         await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
         expectFlipped(newMesh, true)
@@ -1127,6 +1241,7 @@ describe('HandManager', () => {
           {
             shape: 'card',
             id: meshId,
+            texture: '',
             rotable: {},
             drawable: {},
             movable: {},
@@ -1138,7 +1253,7 @@ describe('HandManager', () => {
         )
         expect(handScene.getMeshById(meshId)?.id).toBeUndefined()
         expect(getPositions(handCards)).toEqual(positions)
-        const newMesh = scene.getMeshById(meshId)
+        const newMesh = getMeshById(scene, meshId)
         expect(newMesh?.id).toBeDefined()
         await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
         expectPosition(newMesh, [10, 3, -20])
@@ -1155,10 +1270,10 @@ describe('HandManager', () => {
       it('positions mesh according to main camera angle', async () => {
         camera.lockedTarget = new Vector3(-17, 0, -6)
         const [, card] = handCards
-        card.metadata.draw()
+        card.metadata.draw?.()
         await waitForLayout()
         expect(handScene.getMeshById(card.id)?.id).toBeUndefined()
-        const newMesh = scene.getMeshById(card.id)
+        const newMesh = getMeshById(scene, card.id)
         expect(newMesh?.id).toBeDefined()
         await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
         expectPosition(newMesh, [-20.89, 0, -6])
@@ -1172,7 +1287,7 @@ describe('HandManager', () => {
       it('cancels playing mesh to main when position is not about above table', async () => {
         camera.setPosition(new Vector3(0, 0, 0))
         const [, card] = handCards
-        card.metadata.draw()
+        card.metadata.draw?.()
         await expect(waitForLayout()).rejects.toThrow
         expect(handScene.getMeshById(card.id)?.id).toBeDefined()
         expect(scene.getMeshById(card.id)?.id).toBeUndefined()
@@ -1181,6 +1296,7 @@ describe('HandManager', () => {
       })
 
       describe('given a player drop zone', () => {
+        /** @type {Mesh} */
         let dropZone
         let anchorDuration = 50
 
@@ -1188,11 +1304,15 @@ describe('HandManager', () => {
           dropZone = createCard(
             {
               id: `player-drop-zone`,
+              texture: '',
               x: 10,
               y: 5,
               z: -10,
               movable: {},
-              anchorable: { anchors: [{ playerId }], duration: anchorDuration }
+              anchorable: {
+                anchors: [{ id: '1', playerId }],
+                duration: anchorDuration
+              }
             },
             scene
           )
@@ -1200,10 +1320,10 @@ describe('HandManager', () => {
 
         it(`moves hand mesh to player's drop zone`, async () => {
           const [, card] = handCards
-          card.metadata.draw()
+          card.metadata.draw?.()
           await waitForLayout()
           expect(handScene.getMeshById(card.id)?.id).toBeUndefined()
-          const newMesh = scene.getMeshById(card.id)
+          const newMesh = getMeshById(scene, card.id)
           expect(newMesh?.id).toBeDefined()
           await expectAnimationEnd(newMesh.getBehaviorByName(DrawBehaviorName))
           expect(actionRecorded).toHaveBeenNthCalledWith(
@@ -1241,13 +1361,13 @@ describe('HandManager', () => {
         it(`moves multiple drawn meshes to player's drop zone`, async () => {
           const [mesh1, mesh2] = handCards
           selectionManager.select([mesh1, mesh2])
-          mesh2.metadata.draw()
+          mesh2.metadata.draw?.()
           await waitForLayout()
           expect(handScene.getMeshById(mesh1.id)?.id).toBeUndefined()
           expect(handScene.getMeshById(mesh2.id)?.id).toBeUndefined()
-          const newMesh1 = scene.getMeshById(mesh1.id)
+          const newMesh1 = getMeshById(scene, mesh1.id)
           expect(newMesh1?.id).toBeDefined()
-          const newMesh2 = scene.getMeshById(mesh2.id)
+          const newMesh2 = getMeshById(scene, mesh2.id)
           expect(newMesh2?.id).toBeDefined()
           expect(actionRecorded).toHaveBeenNthCalledWith(
             1,
@@ -1306,7 +1426,10 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'dragStart',
             mesh,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
           let movedPosition = new Vector3(
             mesh.absolutePosition.x,
@@ -1317,9 +1440,12 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'drag',
             mesh,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
-          const newMesh = scene.getMeshById(mesh.id)
+          const newMesh = getMeshById(scene, mesh.id)
           expect(newMesh?.id).toBeDefined()
           expectPosition(newMesh, [6, 0.005, 0])
           await waitForLayout()
@@ -1361,7 +1487,10 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'dragStart',
             mesh: mesh1,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
           let movedPosition = new Vector3(
             mesh1.absolutePosition.x,
@@ -1372,12 +1501,15 @@ describe('HandManager', () => {
           inputManager.onDragObservable.notifyObservers({
             type: 'drag',
             mesh: mesh1,
-            event: { x: 289.7, y: 175 }
+            timestamp: Date.now(),
+            button: 1,
+            pointers: 1,
+            event: /** @type {PointerEvent} */ ({ x: 289.7, y: 175 })
           })
           await sleep()
-          const newMesh1 = scene.getMeshById(mesh1.id)
+          const newMesh1 = getMeshById(scene, mesh1.id)
           expect(newMesh1?.id).toBeDefined()
-          const newMesh2 = scene.getMeshById(mesh2.id)
+          const newMesh2 = getMeshById(scene, mesh2.id)
           expect(newMesh2?.id).toBeDefined()
           expectPosition(newMesh1, [6, 0.005, 0])
           expectPosition(newMesh2, [6, 0.016, 0])
@@ -1452,7 +1584,10 @@ describe('HandManager', () => {
     return -13.144563674926758
   }
 
-  function createMesh(state, scene) {
+  function createMesh(
+    /** @type {SerializableMesh} */ state,
+    /** @type {Scene} */ scene
+  ) {
     return createCard(
       {
         width: cardWidth,
@@ -1468,9 +1603,15 @@ describe('HandManager', () => {
     )
   }
 
-  function getPositions(meshes) {
+  function getPositions(/** @type {Mesh[]} */ meshes) {
     return meshes
-      .map(({ absolutePosition, id }) => [id, ...absolutePosition.asArray()])
+      .map(
+        ({ absolutePosition, id }) =>
+          /** @type {[string, number, number, number]} */ ([
+            id,
+            ...absolutePosition.asArray()
+          ])
+      )
       .sort(([, a], [, b]) => a - b)
   }
 
@@ -1489,5 +1630,15 @@ describe('HandManager', () => {
 
   function extractDrawnState(position = 0) {
     return actionRecorded.mock.calls[position][0].args[0]
+  }
+
+  function getMeshById(/** @type {Scene} */ scene, /** @type {string} */ id) {
+    return /** @type {Mesh} */ (scene.getMeshById(id))
+  }
+
+  function getDrawBehavior(/** @type {Mesh} */ mesh) {
+    return /** @type {DrawBehavior} */ (
+      mesh.getBehaviorByName(DrawBehaviorName)
+    )
   }
 })

--- a/apps/web/tests/3d/managers/material.test.js
+++ b/apps/web/tests/3d/managers/material.test.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+
 import { DirectionalLight } from '@babylonjs/core/Lights/directionalLight'
 import { ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator'
 import { PBRSpecularGlossinessMaterial } from '@babylonjs/core/Materials/PBR/pbrSpecularGlossinessMaterial'
@@ -17,17 +25,22 @@ import {
 
 import { configures3dTestEngine, createBox } from '../../test-utils'
 
+/** @typedef {Material & { diffuseTexture: Texture }} MaterialWithTexture */
+
 describe('MaterialManager', () => {
+  /** @type {Scene} */
   let scene
+  /** @type {Scene} */
   let handScene
+  /** @type {Engine} */
   let engine
   const gameAssetsUrl = 'https://localhost:3000'
 
   configures3dTestEngine(created => ({ scene, handScene, engine } = created))
 
   it('has initial state', () => {
-    expect(manager.scene).toBeNull()
-    expect(manager.handScene).toBeNull()
+    expect(manager.scene).toBeUndefined()
+    expect(manager.handScene).toBeUndefined()
     expect(manager.gameAssetsUrl).toBe('')
   })
 
@@ -60,10 +73,24 @@ describe('MaterialManager', () => {
       manager.init(
         { scene, gameAssetsUrl },
         {
-          meshes: [{ texture: texture1 }, { texture: texture2 }],
+          id: 'whatever',
+          created: Date.now(),
+          meshes: [
+            { id: 'm1', shape: 'box', texture: texture1 },
+            { id: 'm2', shape: 'box', texture: texture2 }
+          ],
           hands: [
-            { meshes: [{ texture: texture3 }] },
-            { meshes: [{ texture: color1 }, { texture: color2 }] }
+            {
+              playerId: '1',
+              meshes: [{ id: 'm3', shape: 'box', texture: texture3 }]
+            },
+            {
+              playerId: '2',
+              meshes: [
+                { id: 'm4', shape: 'box', texture: color1 },
+                { id: 'm5', shape: 'box', texture: color2 }
+              ]
+            }
           ]
         }
       )
@@ -79,7 +106,9 @@ describe('MaterialManager', () => {
     const ktx2 = '/some/path/to/texture.ktx2'
     const webp = '/some/path/to/texture.gl1.webp'
 
+    /** @type {Mesh} */
     let box
+    /** @type {Mesh} */
     let handBox
 
     beforeAll(() => manager.init({ scene, handScene, gameAssetsUrl }))
@@ -130,11 +159,10 @@ describe('MaterialManager', () => {
         expect(manager.isManaging(texture)).toBe(true)
         manager.configure(handBox, color)
         expect(manager.isManaging(color)).toBe(true)
-        box.material.onDisposeObservable.addOnce(disposeBoxMaterial)
-        box.material.diffuseTexture.onDisposeObservable.addOnce(
-          disposeBoxTexture
-        )
-        handBox.material.onDisposeObservable.addOnce(disposeHandBoxMaterial)
+        const material = /** @type {Material} */ (box.material)
+        material.onDisposeObservable.addOnce(disposeBoxMaterial)
+        material.diffuseTexture?.onDisposeObservable.addOnce(disposeBoxTexture)
+        handBox.material?.onDisposeObservable.addOnce(disposeHandBoxMaterial)
 
         manager.clear()
         expect(manager.isManaging(texture)).toBe(false)
@@ -148,29 +176,32 @@ describe('MaterialManager', () => {
     describe('configure()', () => {
       it('creates a material with a color', () => {
         manager.configure(box, '#0066ff66')
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([
-          0, 0.1332085131842997, 1, 0.4
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseColor.asArray()).toEqual([
+          0, 0.1332085131842997, 1
         ])
-        expect(box.material.alpha).toEqual(0.4)
-        expect(box.material.diffuseTexture).toBeNull()
+        expect(material.alpha).toEqual(0.4)
+        expect(material.diffuseTexture).toBeNull()
       })
 
       it('creates a material with a texture', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseTexture).toBeInstanceOf(Texture)
       })
 
       it('reuses existing color material on the same scene', () => {
         const color = '#0066ff66'
         manager.configure(box, color)
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([
-          0, 0.1332085131842997, 1, 0.4
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1
         ])
-        expect(box.material.diffuseTexture).toBeNull()
+        expect(material.diffuseTexture).toBeNull()
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, color)
@@ -186,7 +217,9 @@ describe('MaterialManager', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
         expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
+        expect(
+          /** @type {Material} */ (box.material).diffuseTexture
+        ).toBeInstanceOf(Texture)
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, texture)
@@ -196,8 +229,11 @@ describe('MaterialManager', () => {
         manager.configure(handBox, texture)
         expect(handBox.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(handBox.material === box.material).toBe(false)
-        expect(handBox.material.diffuseTexture.url).toEqual(
-          box.material.diffuseTexture.url
+        expect(
+          /** @type {MaterialWithTexture} */ (handBox.material).diffuseTexture
+            .url
+        ).toEqual(
+          /** @type {MaterialWithTexture} */ (box.material).diffuseTexture.url
         )
       })
 
@@ -218,11 +254,14 @@ describe('MaterialManager', () => {
           result: undefined
         }
       ])('$text', ({ original, result }) => {
-        manager.configure(box, original ?? result)
-        expect(box.material.diffuseTexture.url).toEqual(result)
+        manager.configure(box, /** @type {string} */ (original ?? result))
+        expect(
+          /** @type {MaterialWithTexture} */ (box.material).diffuseTexture.url
+        ).toEqual(result)
       })
 
       describe('given an WebGL 2 engine', () => {
+        /** @type {number} */
         let version
 
         beforeEach(() => {
@@ -248,13 +287,17 @@ describe('MaterialManager', () => {
           { text: 'handles null texture', result: null },
           { text: 'handles undefined texture', result: undefined }
         ])('$text', ({ original, result }) => {
-          manager.configure(box, original ?? result)
-          expect(box.material.diffuseTexture.url).toEqual(result)
+          manager.configure(box, /** @type {string} */ (original ?? result))
+          expect(
+            /** @type {MaterialWithTexture} */ (box.material).diffuseTexture.url
+          ).toEqual(result)
         })
       })
 
       describe('given a texture material', () => {
+        /** @type {Material} */
         let material
+        /** @type {ShadowGenerator} */
         let shadowGenerator
 
         beforeAll(() => {
@@ -263,22 +306,25 @@ describe('MaterialManager', () => {
         })
 
         beforeEach(() => {
+          // @ts-expect-error: _filter is an internal field
           shadowGenerator._filter = ShadowGenerator.FILTER_PCF
           expect(shadowGenerator.usePercentageCloserFiltering).toBe(true)
           manager.configure(box, ktx2)
-          material = box.material
+          material = /** @type {Material} */ (box.material)
         })
 
         it('disables shadow generator on material shader error', () => {
           expect(material.onError).toBeInstanceOf(Function)
-          material.onError(null, ['FRAGMENT SHADER'])
+          // @ts-expect-error: null is not a valid Effect but it's ok
+          material.onError?.(null, ['FRAGMENT SHADER'])
           expect(shadowGenerator.usePercentageCloserFiltering).toBe(false)
           expect(shadowGenerator.useContactHardeningShadow).toBe(false)
         })
 
         it('ignores all other errors', () => {
           expect(material.onError).toBeInstanceOf(Function)
-          material.onError(null, ['OTHER', 'ERROR'])
+          // @ts-expect-error: null is not a valid Effect but it's ok
+          material.onError?.(null, ['OTHER', 'ERROR'])
           expect(shadowGenerator.usePercentageCloserFiltering).toBe(true)
           expect(shadowGenerator.useContactHardeningShadow).toBe(false)
         })
@@ -292,7 +338,7 @@ describe('MaterialManager', () => {
         const material = manager.buildOnDemand(texture, scene)
         expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
         expect(material.diffuseColor?.toGammaSpace().toHexString()).toEqual(
-          texture
+          texture.slice(0, -2)
         )
         expect(material.diffuseTexture).toBeNull()
         expect(manager.isManaging(texture)).toBe(true)
@@ -330,6 +376,7 @@ describe('MaterialManager', () => {
   })
 
   describe('given an initialized manager with no hand scene', () => {
+    /** @type {Mesh} */
     let box
 
     beforeAll(() => manager.init({ scene }))
@@ -366,10 +413,9 @@ describe('MaterialManager', () => {
         const color = '#ff6600ff'
         manager.configure(box, texture)
         expect(manager.isManaging(texture)).toBe(true)
-        box.material.onDisposeObservable.addOnce(disposeBoxMaterial)
-        box.material.diffuseTexture.onDisposeObservable.addOnce(
-          disposeBoxTexture
-        )
+        const material = /** @type {Material} */ (box.material)
+        material.onDisposeObservable.addOnce(disposeBoxMaterial)
+        material.diffuseTexture?.onDisposeObservable.addOnce(disposeBoxTexture)
 
         manager.clear()
         expect(manager.isManaging(texture)).toBe(false)
@@ -382,29 +428,33 @@ describe('MaterialManager', () => {
     describe('configure()', () => {
       it('creates a material with a color', () => {
         manager.configure(box, '#0066ff66')
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([
-          0, 0.1332085131842997, 1, 0.4
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1
         ])
-        expect(box.material.alpha).toEqual(0.4)
-        expect(box.material.diffuseTexture).toBeNull()
+        expect(material.alpha).toEqual(0.4)
+        expect(material.diffuseTexture).toBeNull()
       })
 
       it('creates a material with a texture', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseTexture).toBeInstanceOf(Texture)
       })
 
       it('reuses existing color material', () => {
-        const color = '#0066ff66'
+        const color = '#0066ff99'
         manager.configure(box, color)
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseColor?.asArray()).toEqual([
-          0, 0.1332085131842997, 1, 0.4
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseColor?.asArray()).toEqual([
+          0, 0.1332085131842997, 1
         ])
-        expect(box.material.diffuseTexture).toBeNull()
+        expect(material.alpha).toEqual(0.6)
+        expect(material.diffuseTexture).toBeNull()
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, color)
@@ -415,8 +465,9 @@ describe('MaterialManager', () => {
       it('reuses existing texture material', () => {
         const texture = faker.internet.url()
         manager.configure(box, texture)
-        expect(box.material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
-        expect(box.material.diffuseTexture).toBeInstanceOf(Texture)
+        const material = /** @type {Material} */ (box.material)
+        expect(material).toBeInstanceOf(PBRSpecularGlossinessMaterial)
+        expect(material.diffuseTexture).toBeInstanceOf(Texture)
 
         const box2 = createBox('box2', {}, box.getScene())
         manager.configure(box2, texture)

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -1,3 +1,13 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Texture} Texture
+ * @typedef {import('@src/3d/managers/target').DropZone} DropZone
+ * @typedef {import('@src/3d/managers/target').MultiDropZone} MultiDropZone
+ * @typedef {import('@src/3d/managers/target').SingleDropZone} SingleDropZone
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import { MoveBehavior, TargetBehavior } from '@src/3d/behaviors'
@@ -8,7 +18,9 @@ import { configures3dTestEngine, createBox } from '../../test-utils'
 
 describe('TargetManager', () => {
   let drops
+  /** @type {Scene} */
   let scene
+  /** @type {Scene} */
   let handScene
 
   configures3dTestEngine(created => {
@@ -16,7 +28,7 @@ describe('TargetManager', () => {
     handScene = created.handScene
   })
 
-  beforeAll(() => selectionManager.init({ scene, color: '#FF00FF' }))
+  beforeAll(() => selectionManager.init({ scene, handScene }))
 
   beforeEach(() => {
     vi.resetAllMocks()
@@ -24,16 +36,15 @@ describe('TargetManager', () => {
   })
 
   it('has initial state', () => {
-    expect(manager.scene).toBeNull()
-    expect(manager.playerId).toBeNull()
+    expect(manager.scene).toBeUndefined()
+    expect(manager.playerId).toBeUndefined()
   })
 
   describe('init()', () => {
     it('sets scene', () => {
       const playerId = faker.string.uuid()
       const color = faker.color.rgb()
-      const overlayAlpha = Math.random()
-      manager.init({ scene, playerId, color, overlayAlpha })
+      manager.init({ scene, playerId, color })
       expect(manager.scene).toEqual(scene)
       expect(manager.playerId).toEqual(playerId)
     })
@@ -43,7 +54,7 @@ describe('TargetManager', () => {
     const playerId = faker.string.uuid()
     const color = '#00FF00FF'
 
-    beforeAll(() => manager.init({ scene, playerId, color, overlayAlpha: 0.2 }))
+    beforeAll(() => manager.init({ scene, playerId, color }))
 
     describe('registerTargetable()', () => {
       it('registers a mesh', () => {
@@ -74,6 +85,7 @@ describe('TargetManager', () => {
       it('handles invalid behavior', () => {
         const behavior = new TargetBehavior()
         manager.registerTargetable(behavior)
+        // @ts-expect-error: we don't provide a behavior
         manager.registerTargetable()
       })
     })
@@ -82,12 +94,15 @@ describe('TargetManager', () => {
       it('handles invalid behavior', () => {
         const behavior = new TargetBehavior()
         manager.unregisterTargetable(behavior)
+        // @ts-expect-error: we don't provide a behavior
         manager.unregisterTargetable()
       })
     })
 
     describe('findDropZone()', () => {
+      /** @type {SingleDropZone} */
       let zone1
+      /** @type {SingleDropZone} */
       let zone2
       const aboveZone1 = new Vector3(5, 1, 5)
       const aboveZone2 = new Vector3(-5, 1, -5)
@@ -137,7 +152,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select(zone1.targetable.mesh)
+        selectionManager.select(/** @type {Mesh} */ (zone1.targetable.mesh))
         const mesh = createBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
@@ -231,6 +246,7 @@ describe('TargetManager', () => {
       })
 
       describe('given a mesh with parts', () => {
+        /** @type {Mesh} */
         let mesh
 
         beforeEach(() => {
@@ -299,6 +315,7 @@ describe('TargetManager', () => {
         it('handles invalid zones', () => {
           manager.clear()
           manager.clear(null)
+          // @ts-expect-error: it's ok to pass random object
           manager.clear({})
           expectVisibility(zone1, true)
           expectVisibility(zone2, false)
@@ -306,9 +323,10 @@ describe('TargetManager', () => {
       })
 
       describe('dropOn()', () => {
-        let meshes = ['box1', 'box2']
+        /** @type {Mesh[]} */
+        let meshes
         beforeEach(() => {
-          meshes = meshes.map(id => {
+          meshes = ['box1', 'box2'].map(id => {
             const mesh = createBox(id, {})
             mesh.setAbsolutePosition(aboveZone1)
             manager.findDropZone(mesh, 'box')
@@ -329,8 +347,11 @@ describe('TargetManager', () => {
     })
 
     describe('findPlayerZone()', () => {
+      /** @type {SingleDropZone} */
       let zone1
+      /** @type {SingleDropZone} */
       let zone2
+      /** @type {Mesh} */
       let mesh
 
       beforeEach(() => {
@@ -362,7 +383,7 @@ describe('TargetManager', () => {
       })
 
       it('ignores target part of the current selection', () => {
-        selectionManager.select(zone1.targetable.mesh)
+        selectionManager.select(/** @type {Mesh} */ (zone1.targetable.mesh))
         const mesh = createBox('box', {})
         mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
@@ -416,9 +437,10 @@ describe('TargetManager', () => {
       })
 
       describe('dropOn()', () => {
-        let meshes = ['box1', 'box2']
+        /** @type {Mesh[]} */
+        let meshes
         beforeEach(() => {
-          meshes = meshes.map(id => {
+          meshes = ['box1', 'box2'].map(id => {
             const mesh = createBox(id, {})
             manager.findPlayerZone(mesh, 'box')
             return mesh
@@ -443,6 +465,7 @@ describe('TargetManager', () => {
       })
 
       describe('given a kindless zone', () => {
+        /** @type {Partial<SingleDropZone>} */
         let zone
 
         beforeEach(() => {
@@ -464,6 +487,7 @@ describe('TargetManager', () => {
       })
 
       describe('given a zone with kind', () => {
+        /** @type {Partial<SingleDropZone>} */
         let zone
 
         beforeEach(() => {
@@ -491,7 +515,8 @@ describe('TargetManager', () => {
   })
 
   function createsTargetZone(
-    id,
+    /** @type {string} */ id,
+    /** @type {Record<string, ?> & Partial<{ position: Vector3, scene: Scene }>} */
     { position = new Vector3(0, 0, 0), scene: usedScene, ...properties }
   ) {
     const targetable = createBox(`targetable-${id}`, {}, usedScene ?? scene)
@@ -505,13 +530,22 @@ describe('TargetManager', () => {
     return behavior.addZone(target, { extent: 0.5, ...properties })
   }
 
-  function expectActiveZone(actual, expected, color) {
-    expect(actual.mesh.id).toEqual(expected.mesh.id)
+  function expectActiveZone(
+    /** @type {?DropZone} */ actual,
+    /** @type {Partial<DropZone>} */ expected,
+    /** @type {string} */ color
+  ) {
+    expect(actual?.mesh.id).toEqual(expected.mesh?.id)
     expectVisibility(actual, true)
-    expect(actual.mesh.material?.diffuseColor?.toHexString()).toEqual(color)
+    expect(
+      /** @type {?} */ (actual?.mesh.material)?.diffuseColor?.toHexString()
+    ).toEqual(color.slice(0, -2))
   }
 
-  function expectVisibility(zone, isVisible) {
-    expect(zone.mesh.visibility).toEqual(isVisible ? 1 : 0)
+  function expectVisibility(
+    /** @type {?DropZone} */ zone,
+    /** @type {boolean} */ isVisible
+  ) {
+    expect(zone?.mesh.visibility).toEqual(isVisible ? 1 : 0)
   }
 })

--- a/apps/web/tests/3d/meshes/box.test.js
+++ b/apps/web/tests/3d/meshes/box.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import { controlManager, materialManager } from '@src/3d/managers'
 import { createBox } from '@src/3d/meshes'
@@ -10,6 +17,7 @@ import {
   expectPosition
 } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -17,7 +25,7 @@ beforeAll(() => materialManager.init({ scene }))
 
 describe('createBox()', () => {
   it('creates a box with default values, faces and no behavior', async () => {
-    const mesh = await createBox()
+    const mesh = await createBox({ id: '', texture: '' }, scene)
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [1, 1, 1])
     expect(mesh.isPickable).toBe(false)
@@ -30,33 +38,40 @@ describe('createBox()', () => {
 
   it('creates a box with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createBox({ texture: color })
+    const mesh = await createBox({ id: '', texture: color }, scene)
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [1, 1, 1])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   it('creates a box with initial transformation', async () => {
-    const mesh = await createBox({
-      width: 4,
-      height: 8,
-      depth: 2,
-      transform: { pitch: Math.PI * -0.5 }
-    })
+    const mesh = await createBox(
+      {
+        id: '',
+        texture: '',
+        width: 4,
+        height: 8,
+        depth: 2,
+        transform: { pitch: Math.PI * -0.5 }
+      },
+      scene
+    )
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [2, 8, 4])
   })
 
   describe('given a box with initial position, dimension, images and behaviors', () => {
+    /** @type {Mesh} */
     let mesh
 
     const width = faker.number.int(999)
     const height = faker.number.int(999)
     const id = faker.string.uuid()
     const depth = faker.number.int(999)
+    const texture = faker.color.rgb()
     const x = faker.number.int(999)
     const y = faker.number.int(999)
     const z = faker.number.int(999)
@@ -75,17 +90,21 @@ describe('createBox()', () => {
     }
 
     beforeEach(async () => {
-      mesh = await createBox({
-        id,
-        width,
-        height,
-        depth,
-        x,
-        y,
-        z,
-        faceUV,
-        ...behaviors
-      })
+      mesh = await createBox(
+        {
+          id,
+          texture,
+          width,
+          height,
+          depth,
+          x,
+          y,
+          z,
+          faceUV,
+          ...behaviors
+        },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -120,6 +139,7 @@ describe('createBox()', () => {
       expect(mesh.metadata.serialize()).toEqual({
         shape: 'box',
         id,
+        texture,
         x,
         y,
         z,

--- a/apps/web/tests/3d/meshes/card.test.js
+++ b/apps/web/tests/3d/meshes/card.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import { controlManager, materialManager } from '@src/3d/managers'
 import { createCard } from '@src/3d/meshes'
@@ -10,6 +17,7 @@ import {
   expectPosition
 } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -17,7 +25,7 @@ beforeAll(() => materialManager.init({ scene }))
 
 describe('createCard()', () => {
   it('creates a card with default values, faces and no behavior', async () => {
-    const mesh = await createCard()
+    const mesh = await createCard({ id: '', texture: '' }, scene)
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [3, 0.01, 4.25])
     expect(mesh.isPickable).toBe(false)
@@ -31,32 +39,39 @@ describe('createCard()', () => {
 
   it('creates a card with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createCard({ texture: color })
+    const mesh = await createCard({ id: '', texture: color }, scene)
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [3, 0.01, 4.25])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   it('creates a card with initial transformation', async () => {
-    const mesh = await createCard({
-      width: 4,
-      depth: 2,
-      transform: { pitch: Math.PI * -0.5 }
-    })
+    const mesh = await createCard(
+      {
+        id: '',
+        texture: '',
+        width: 4,
+        depth: 2,
+        transform: { pitch: Math.PI * -0.5 }
+      },
+      scene
+    )
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [2, 0.1, 4])
   })
 
   describe('given a card with initial position, dimension, images and behaviors', async () => {
+    /** @type {Mesh} */
     let mesh
 
     const width = faker.number.int(999)
     const height = faker.number.int(999)
     const id = faker.string.uuid()
     const depth = faker.number.int(999)
+    const texture = faker.color.rgb()
     const x = faker.number.int(999)
     const y = faker.number.int(999)
     const z = faker.number.int(999)
@@ -75,17 +90,21 @@ describe('createCard()', () => {
     }
 
     beforeEach(async () => {
-      mesh = await createCard({
-        id,
-        width,
-        height,
-        depth,
-        x,
-        y,
-        z,
-        faceUV,
-        ...behaviors
-      })
+      mesh = await createCard(
+        {
+          id,
+          texture,
+          width,
+          height,
+          depth,
+          x,
+          y,
+          z,
+          faceUV,
+          ...behaviors
+        },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -126,6 +145,7 @@ describe('createCard()', () => {
         width,
         height,
         depth,
+        texture,
         faceUV,
         detailable: behaviors.detailable,
         rotable: { ...behaviors.rotable, duration: 200 },

--- a/apps/web/tests/3d/meshes/custom.test.js
+++ b/apps/web/tests/3d/meshes/custom.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import {
   controlManager,
@@ -16,6 +23,7 @@ import {
   expectPosition
 } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -29,12 +37,13 @@ const file = 'pawn.obj'
 const pawnDimensions = [1.11, 2.45, 0.84]
 
 beforeEach(() => {
+  // @ts-expect-error customShapeManager is not a map
   customShapeManager.set(file, btoa(pawnData))
 })
 
 describe('createCustom()', () => {
   it('creates a custom mesh from OBJ data with default values, and no behavior', async () => {
-    const mesh = await createCustom({ id: 'pawn', file })
+    const mesh = await createCustom({ id: 'pawn', texture: '', file }, scene)
     expect(mesh.id).toEqual('pawn')
     expect(mesh.name).toEqual('custom')
     expectDimension(mesh, pawnDimensions)
@@ -48,11 +57,15 @@ describe('createCustom()', () => {
   })
 
   it('creates a custom mesh with initial transformation', async () => {
-    const mesh = await createCustom({
-      id: 'pawn',
-      file,
-      transform: { scaleX: 2, scaleY: 2, scaleZ: 2 }
-    })
+    const mesh = await createCustom(
+      {
+        id: '',
+        texture: '',
+        file,
+        transform: { scaleX: 2, scaleY: 2, scaleZ: 2 }
+      },
+      scene
+    )
     expect(mesh.name).toEqual('custom')
     expectDimension(
       mesh,
@@ -62,43 +75,50 @@ describe('createCustom()', () => {
 
   it('throws on an empty data', async () => {
     const file = '/empty.obj'
+    // @ts-expect-error
     customShapeManager.set(file, btoa(JSON.stringify({})))
-    await expect(createCustom({ id: 'empty-pawn', file })).rejects.toThrow(
-      `${file} does not contain any mesh`
-    )
+    await expect(
+      createCustom({ id: '', texture: '', file }, scene)
+    ).rejects.toThrow(`${file} does not contain any mesh`)
   })
 
   it('throws on an invalid data', async () => {
+    // @ts-expect-error
     customShapeManager.set(file, 'invalid base64 data')
-    await expect(createCustom({ id: 'invalid-pawn', file })).rejects.toThrow(
+    await expect(
+      createCustom({ id: '', texture: '', file }, scene)
+    ).rejects.toThrow(
       `Unable to load from pawn.obj: InvalidCharacterError: The string to be decoded contains invalid characters.`
     )
   })
 
   it('throws on mesh-less data', async () => {
+    // @ts-expect-error
     customShapeManager.set(file, btoa('this is invalid'))
-    await expect(createCustom({ id: 'invalid-pawn', file })).rejects.toThrow(
-      `${file} does not contain any mesh`
-    )
+    await expect(
+      createCustom({ id: '', texture: '', file }, scene)
+    ).rejects.toThrow(`${file} does not contain any mesh`)
   })
 
   it('creates a custom mesh with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createCustom({ file, texture: color })
+    const mesh = await createCustom({ id: '', file, texture: color }, scene)
     expect(mesh.name).toEqual('custom')
     expectDimension(mesh, pawnDimensions)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   describe('given a mesh with initial position, dimension, images and behaviors', () => {
+    /** @type {Mesh} */
     let mesh
 
     const id = faker.string.uuid()
     const x = faker.number.int(999)
     const y = faker.number.int(999)
     const z = faker.number.int(999)
+    const texture = faker.color.rgb()
 
     const behaviors = {
       movable: { kind: faker.lorem.word() },
@@ -106,7 +126,10 @@ describe('createCustom()', () => {
     }
 
     beforeEach(async () => {
-      mesh = await createCustom({ file, id, x, y, z, ...behaviors })
+      mesh = await createCustom(
+        { file, id, texture, x, y, z, ...behaviors },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -122,7 +145,6 @@ describe('createCustom()', () => {
         expect.objectContaining(behaviors.rotable)
       )
       expect(mesh.metadata).toEqual({
-        ...behaviors.detailable,
         angle: behaviors.rotable.angle,
         serialize: expect.any(Function),
         rotate: expect.any(Function)
@@ -140,6 +162,7 @@ describe('createCustom()', () => {
         shape: 'custom',
         file,
         id,
+        texture,
         x,
         y,
         z,

--- a/apps/web/tests/3d/meshes/prism.test.js
+++ b/apps/web/tests/3d/meshes/prism.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import { controlManager, materialManager } from '@src/3d/managers'
 import { createPrism } from '@src/3d/meshes'
@@ -6,6 +13,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { configures3dTestEngine, expectPosition } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -13,7 +21,7 @@ beforeAll(() => materialManager.init({ scene }))
 
 describe('createPrism()', () => {
   it('creates a prism with default values and no behavior', async () => {
-    const mesh = await createPrism()
+    const mesh = await createPrism({ id: '', texture: '' }, scene)
     const { boundingBox } = mesh.getBoundingInfo()
     expect(mesh.name).toEqual('prism')
     expect(boundingBox.extendSize.x * 2).toEqual(3)
@@ -29,22 +37,27 @@ describe('createPrism()', () => {
 
   it('creates a prism with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createPrism({ texture: color })
+    const mesh = await createPrism({ id: '', texture: color }, scene)
     const { boundingBox } = mesh.getBoundingInfo()
     expect(mesh.name).toEqual('prism')
     expect(boundingBox.extendSize.x * 2).toEqual(3)
     expect(boundingBox.extendSize.y * 2).toEqual(1)
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   it('creates a prism with initial transformation', async () => {
-    const mesh = await createPrism({
-      dimension: 4,
-      transform: { roll: Math.PI * -0.5 }
-    })
+    const mesh = await createPrism(
+      {
+        id: '',
+        texture: '',
+        diameter: 2,
+        transform: { roll: Math.PI * -0.5 }
+      },
+      scene
+    )
     const { boundingBox } = mesh.getBoundingInfo()
     expect(mesh.name).toEqual('prism')
     expect(boundingBox.extendSize.x * 2).toBeCloseTo(1)
@@ -52,6 +65,7 @@ describe('createPrism()', () => {
   })
 
   describe('given a prism with initial position, edges number, dimension, images and behaviors', () => {
+    /** @type {Mesh} */
     let mesh
 
     const width = faker.number.int({ min: 3, max: 5 })
@@ -61,6 +75,7 @@ describe('createPrism()', () => {
     const x = faker.number.int(999)
     const y = faker.number.int(999)
     const z = faker.number.int(999)
+    const texture = faker.color.rgb()
     const prismRotation = faker.number.int(999)
     const faceUV = [
       Array.from({ length: 4 }, () => faker.number.int(999)),
@@ -77,18 +92,22 @@ describe('createPrism()', () => {
     }
 
     beforeEach(async () => {
-      mesh = await createPrism({
-        id,
-        edges,
-        prismRotation,
-        width,
-        height,
-        x,
-        y,
-        z,
-        faceUV,
-        ...behaviors
-      })
+      mesh = await createPrism(
+        {
+          id,
+          texture,
+          edges,
+          prismRotation,
+          width,
+          height,
+          x,
+          y,
+          z,
+          faceUV,
+          ...behaviors
+        },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -128,6 +147,7 @@ describe('createPrism()', () => {
         x,
         y,
         z,
+        texture,
         faceUV,
         width,
         edges,

--- a/apps/web/tests/3d/meshes/round-token.test.js
+++ b/apps/web/tests/3d/meshes/round-token.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import { controlManager, materialManager } from '@src/3d/managers'
 import { createRoundToken } from '@src/3d/meshes'
@@ -10,6 +17,7 @@ import {
   expectPosition
 } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -17,7 +25,7 @@ beforeAll(() => materialManager.init({ scene }))
 
 describe('createRoundToken()', () => {
   it('creates a token with default values and no behavior', async () => {
-    const mesh = await createRoundToken()
+    const mesh = await createRoundToken({ id: '', texture: '' }, scene)
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [2, 0.1, 2])
     expect(mesh.isPickable).toBe(false)
@@ -31,25 +39,31 @@ describe('createRoundToken()', () => {
 
   it('creates a token with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createRoundToken({ texture: color })
+    const mesh = await createRoundToken({ id: '', texture: color }, scene)
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [2, 0.1, 2])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   it('creates a token with initial transformation', async () => {
-    const mesh = await createRoundToken({
-      dimension: 4,
-      transform: { roll: Math.PI * -0.5 }
-    })
+    const mesh = await createRoundToken(
+      {
+        id: '',
+        texture: '',
+        diameter: 2,
+        transform: { roll: Math.PI * -0.5 }
+      },
+      scene
+    )
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [0.05, 2, 2])
   })
 
   describe('given a token with initial position, dimension, images and behaviors', () => {
+    /** @type {Mesh} */
     let mesh
 
     const diameter = faker.number.int(999)
@@ -63,6 +77,7 @@ describe('createRoundToken()', () => {
       Array.from({ length: 4 }, () => faker.number.int(999)),
       Array.from({ length: 4 }, () => faker.number.int(999))
     ]
+    const texture = faker.color.rgb()
     const behaviors = {
       movable: { kind: faker.lorem.word() },
       rotable: { angle: Math.PI },
@@ -73,16 +88,20 @@ describe('createRoundToken()', () => {
     }
 
     beforeEach(async () => {
-      mesh = await createRoundToken({
-        id,
-        diameter,
-        height,
-        x,
-        y,
-        z,
-        faceUV,
-        ...behaviors
-      })
+      mesh = await createRoundToken(
+        {
+          id,
+          texture,
+          diameter,
+          height,
+          x,
+          y,
+          z,
+          faceUV,
+          ...behaviors
+        },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -123,6 +142,7 @@ describe('createRoundToken()', () => {
         faceUV,
         diameter,
         height,
+        texture,
         detailable: behaviors.detailable,
         rotable: {
           ...behaviors.rotable,

--- a/apps/web/tests/3d/meshes/rounded-tiles.test.js
+++ b/apps/web/tests/3d/meshes/rounded-tiles.test.js
@@ -1,4 +1,11 @@
-import { Color4 } from '@babylonjs/core/Maths/math.color'
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ */
+
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
 import { controlManager, materialManager } from '@src/3d/managers'
 import { createRoundedTile } from '@src/3d/meshes'
@@ -10,6 +17,7 @@ import {
   expectPosition
 } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
 configures3dTestEngine(created => (scene = created.scene))
 
@@ -17,7 +25,7 @@ beforeAll(() => materialManager.init({ scene }))
 
 describe('createRoundedTile()', () => {
   it('creates a tile with default values and no behavior', async () => {
-    const mesh = await createRoundedTile()
+    const mesh = await createRoundedTile({ id: '', texture: '' }, scene)
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [3, 0.05, 3])
     expect(mesh.isPickable).toBe(false)
@@ -30,27 +38,34 @@ describe('createRoundedTile()', () => {
 
   it('creates a tile with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createRoundedTile({ texture: color })
+    const mesh = await createRoundedTile({ id: '', texture: color }, scene)
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [3, 0.05, 3])
     expect(mesh.isPickable).toBe(false)
-    expect(mesh.material.diffuseColor).toEqual(
-      Color4.FromHexString(color).toLinearSpace()
+    expect(/** @type {Material} */ (mesh.material).diffuseColor).toEqual(
+      Color3.FromHexString(color).toLinearSpace()
     )
   })
 
   it('creates a tile with initial transformation', async () => {
-    const mesh = await createRoundedTile({
-      width: 4,
-      height: 8,
-      depth: 2,
-      transform: { pitch: Math.PI * -0.5 }
-    })
+    const mesh = await createRoundedTile(
+      {
+        id: '',
+        texture: '',
+
+        width: 4,
+        height: 8,
+        depth: 2,
+        transform: { pitch: Math.PI * -0.5 }
+      },
+      scene
+    )
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [2, 8, 4])
   })
 
   describe('given a tile with initial position, dimension, images and behaviors', () => {
+    /** @type {Mesh} */
     let mesh
 
     const width = faker.number.int(999)
@@ -63,10 +78,12 @@ describe('createRoundedTile()', () => {
     const faceUV = Array.from({ length: 6 }, () =>
       Array.from({ length: 4 }, () => faker.number.int(999))
     )
+    const texture = faker.color.rgb()
     const behaviors = {
       anchorable: {
         anchors: [
           {
+            id: '',
             width: width * 0.5,
             height: height * 0.5,
             kinds: [faker.lorem.word()]
@@ -82,18 +99,22 @@ describe('createRoundedTile()', () => {
     const borderRadius = Math.random()
 
     beforeEach(async () => {
-      mesh = await createRoundedTile({
-        id,
-        width,
-        height,
-        depth,
-        faceUV,
-        x,
-        y,
-        z,
-        borderRadius,
-        ...behaviors
-      })
+      mesh = await createRoundedTile(
+        {
+          id,
+          width,
+          height,
+          depth,
+          faceUV,
+          texture,
+          x,
+          y,
+          z,
+          borderRadius,
+          ...behaviors
+        },
+        scene
+      )
     })
 
     it('has all the expected data', () => {
@@ -140,6 +161,7 @@ describe('createRoundedTile()', () => {
         height,
         depth,
         borderRadius,
+        texture,
         detailable: behaviors.detailable,
         flippable: {
           ...behaviors.flippable,

--- a/apps/web/tests/3d/utils/actions.test.js
+++ b/apps/web/tests/3d/utils/actions.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import {
   DetailBehaviorName,
   DrawBehaviorName,
@@ -26,7 +31,7 @@ const {
 } = actionNames
 
 describe('buildActionNamesByKey()', () => {
-  const translate = key => key
+  const translate = (/** @type {string} */ key) => key
 
   it('returns no actions when no mesh is given', () => {
     expect(buildActionNamesByKey([], translate)).toEqual(new Map())
@@ -40,14 +45,20 @@ describe('buildActionNamesByKey()', () => {
     { action: detail, behavior: DetailBehaviorName },
     { action: toggleLock, behavior: LockBehaviorName }
   ])('can return $behavior action', ({ behavior, action }) => {
-    expect(buildActionNamesByKey([{ [behavior]: {} }], translate)).toEqual(
-      new Map([[`shortcuts.${action}`, [action]]])
-    )
+    expect(
+      buildActionNamesByKey(
+        [{ shape: 'box', id: '', texture: '', [behavior]: {} }],
+        translate
+      )
+    ).toEqual(new Map([[`shortcuts.${action}`, [action]]]))
   })
 
   it(`can return '${StackBehaviorName}' actions only`, () => {
     expect(
-      buildActionNamesByKey([{ [StackBehaviorName]: {} }], translate)
+      buildActionNamesByKey(
+        [{ shape: 'box', id: '', texture: '', [StackBehaviorName]: {} }],
+        translate
+      )
     ).toEqual(
       new Map([
         [`shortcuts.pop`, [pop]],
@@ -59,7 +70,10 @@ describe('buildActionNamesByKey()', () => {
 
   it(`can return '${QuantityBehaviorName}' actions only`, () => {
     expect(
-      buildActionNamesByKey([{ [QuantityBehaviorName]: {} }], translate)
+      buildActionNamesByKey(
+        [{ shape: 'box', id: '', texture: '', [QuantityBehaviorName]: {} }],
+        translate
+      )
     ).toEqual(
       new Map([
         [`shortcuts.pop`, [decrement]],
@@ -71,7 +85,15 @@ describe('buildActionNamesByKey()', () => {
   it(`can return both '${QuantityBehaviorName}' and '${StackBehaviorName}' actions`, () => {
     expect(
       buildActionNamesByKey(
-        [{ [QuantityBehaviorName]: {}, [StackBehaviorName]: {} }],
+        [
+          {
+            shape: 'box',
+            id: '',
+            texture: '',
+            [QuantityBehaviorName]: {},
+            [StackBehaviorName]: {}
+          }
+        ],
         translate
       )
     ).toEqual(
@@ -88,9 +110,12 @@ describe('buildActionNamesByKey()', () => {
       buildActionNamesByKey(
         [
           {
+            shape: 'box',
+            id: '',
+            texture: '',
             [FlipBehaviorName]: {},
             [RotateBehaviorName]: {},
-            [DetailBehaviorName]: {},
+            [DetailBehaviorName]: { frontImage: '' },
             [DrawBehaviorName]: {},
             [LockBehaviorName]: {},
             [RandomBehaviorName]: {},

--- a/apps/web/tests/3d/utils/behaviors.test.js
+++ b/apps/web/tests/3d/utils/behaviors.test.js
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@src/3d/behaviors/animatable').AnimateBehavior} AnimateBehavior
+ * @typedef {typeof import('@src/3d/behaviors/targetable').TargetBehavior} TargetBehavior
+ */
+
+//
 import { Animation } from '@babylonjs/core/Animations/animation'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import {
@@ -47,18 +56,31 @@ import {
 
 vi.mock('@src/3d/managers/indicator')
 
+/** @type {Engine} */
 let engine
+/** @type {Mesh} */
 let box
+/** @type {typeof import('@src/3d/behaviors/anchorable').AnchorBehavior} */
 let AnchorBehavior
+/** @type {typeof import('@src/3d/behaviors/animatable').AnimateBehavior} */
 let AnimateBehavior
+/** @type {typeof import('@src/3d/behaviors/detailable').DetailBehavior}} */
 let DetailBehavior
+/** @type {typeof import('@src/3d/behaviors/drawable').DrawBehavior} */
 let DrawBehavior
+/** @type {typeof import('@src/3d/behaviors/flippable').FlipBehavior} */
 let FlipBehavior
+/** @type {typeof import('@src/3d/behaviors/lockable').LockBehavior} */
 let LockBehavior
+/** @type {typeof import('@src/3d/behaviors/movable').MoveBehavior} */
 let MoveBehavior
+/** @type {typeof import('@src/3d/behaviors/quantifiable').QuantityBehavior} */
 let QuantityBehavior
+/** @type {typeof import('@src/3d/behaviors/rotable').RotateBehavior} */
 let RotateBehavior
+/** @type {typeof import('@src/3d/behaviors/stackable').StackBehavior} */
 let StackBehavior
+/** @type {typeof import('@src/3d/behaviors/targetable').TargetBehavior} */
 let TargetBehavior
 
 beforeAll(async () => {
@@ -74,9 +96,9 @@ beforeAll(async () => {
     MoveBehavior,
     QuantityBehavior,
     RotateBehavior,
-    StackBehavior,
     TargetBehavior
   } = await import('@src/3d/behaviors'))
+  ;({ StackBehavior } = await import('@src/3d/behaviors/stackable'))
 })
 
 beforeEach(() => {
@@ -302,7 +324,7 @@ describe('registerBehaviors() 3D utility', () => {
     const state = { angle: Math.PI * 0.5, duration: 321 }
     registerBehaviors(box, { rotable: state })
     const behavior = box.getBehaviorByName(RotateBehaviorName)
-    expect(behavior.state).toEqualWithAngle(state)
+    expect(behavior?.state).toEqualWithAngle(state)
   })
 
   it('adds detailable behavior to a mesh', () => {
@@ -318,6 +340,7 @@ describe('registerBehaviors() 3D utility', () => {
     const state = {
       anchors: [
         {
+          id: 'whatever',
           x: 10,
           y: 15,
           z: -5,
@@ -376,7 +399,7 @@ describe('registerBehaviors() 3D utility', () => {
 
   it('adds multiple behaviors to a mesh', () => {
     registerBehaviors(box, {
-      detailable: {},
+      detailable: { frontImage: '' },
       movable: {},
       stackable: { extent: 1.5 },
       anchorable: { anchors: [] },
@@ -384,26 +407,26 @@ describe('registerBehaviors() 3D utility', () => {
       rotable: { angle: Math.PI },
       lockable: { isLocked: false }
     })
-    expect(box.getBehaviorByName(AnchorBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(AnchorBehaviorName)?.state).toEqual({
       anchors: [],
       duration: 100
     })
     expect(box.getBehaviorByName(DetailBehaviorName)).toBeDefined()
-    expect(box.getBehaviorByName(FlipBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(FlipBehaviorName)?.state).toEqual({
       duration: 500,
       isFlipped: false
     })
     expect(box.getBehaviorByName(MoveBehaviorName)).toBeDefined()
-    expect(box.getBehaviorByName(RotateBehaviorName).state).toEqualWithAngle({
+    expect(box.getBehaviorByName(RotateBehaviorName)?.state).toEqualWithAngle({
       duration: 200,
       angle: Math.PI
     })
-    expect(box.getBehaviorByName(StackBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(StackBehaviorName)?.state).toEqual({
       stackIds: [],
       duration: 100,
       extent: 1.5
     })
-    expect(box.getBehaviorByName(LockBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(LockBehaviorName)?.state).toEqual({
       isLocked: false
     })
     expect(box.behaviors).toHaveLength(7)
@@ -417,10 +440,10 @@ describe('registerBehaviors() 3D utility', () => {
   it('adds lockable after all other behavior', () => {
     registerBehaviors(box, { lockable: { isLocked: true }, movable: {} })
 
-    expect(box.getBehaviorByName(LockBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(LockBehaviorName)?.state).toEqual({
       isLocked: true
     })
-    expect(box.getBehaviorByName(MoveBehaviorName).enabled).toBe(false)
+    expect(box.getBehaviorByName(MoveBehaviorName)?.enabled).toBe(false)
   })
 })
 
@@ -461,6 +484,7 @@ describe('restoreBehaviors() 3D utility', () => {
     const state = {
       anchors: [
         {
+          id: 'whatever',
           x: 10,
           y: 15,
           z: -5,
@@ -509,6 +533,7 @@ describe('restoreBehaviors() 3D utility', () => {
     const anchorable = {
       anchors: [
         {
+          id: 'whatever',
           x: 10,
           y: 15,
           z: -5,
@@ -532,6 +557,7 @@ describe('restoreBehaviors() 3D utility', () => {
       snapDistance: 0.5,
       duration: 345
     }
+    const detailable = { frontImage: 'something.png' }
     const lockable = { isLocked: false }
     box.addBehavior(new MoveBehavior(), true)
     box.addBehavior(new FlipBehavior(), true)
@@ -542,7 +568,7 @@ describe('restoreBehaviors() 3D utility', () => {
     box.addBehavior(new AnimateBehavior(), true)
     box.addBehavior(new LockBehavior(), true)
     restoreBehaviors(box.behaviors, {
-      detailable: true,
+      detailable,
       movable,
       flippable,
       anchorable,
@@ -550,18 +576,19 @@ describe('restoreBehaviors() 3D utility', () => {
       stackable,
       lockable
     })
-    expect(box.getBehaviorByName(MoveBehaviorName).state).toEqual(movable)
-    expect(box.getBehaviorByName(FlipBehaviorName).state).toEqual(flippable)
-    expect(box.getBehaviorByName(RotateBehaviorName).state).toEqualWithAngle(
+    expect(box.getBehaviorByName(DetailBehaviorName)?.state).toEqual(detailable)
+    expect(box.getBehaviorByName(MoveBehaviorName)?.state).toEqual(movable)
+    expect(box.getBehaviorByName(FlipBehaviorName)?.state).toEqual(flippable)
+    expect(box.getBehaviorByName(RotateBehaviorName)?.state).toEqualWithAngle(
       rotable
     )
-    expect(box.getBehaviorByName(AnchorBehaviorName).state).toEqual(anchorable)
-    expect(box.getBehaviorByName(StackBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(AnchorBehaviorName)?.state).toEqual(anchorable)
+    expect(box.getBehaviorByName(StackBehaviorName)?.state).toEqual({
       duration: 100,
       extent: 2,
       stackIds: []
     })
-    expect(box.getBehaviorByName(LockBehaviorName).state).toEqual(lockable)
+    expect(box.getBehaviorByName(LockBehaviorName)?.state).toEqual(lockable)
   })
 
   it('does nothing without parameters', () => {
@@ -574,28 +601,28 @@ describe('restoreBehaviors() 3D utility', () => {
     box.addBehavior(new AnimateBehavior(), true)
     box.addBehavior(new LockBehavior(), true)
     restoreBehaviors(box.behaviors, {})
-    expect(box.getBehaviorByName(MoveBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(MoveBehaviorName)?.state).toEqual({
       snapDistance: 0.25,
       duration: 100
     })
-    expect(box.getBehaviorByName(FlipBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(FlipBehaviorName)?.state).toEqual({
       isFlipped: false,
       duration: 500
     })
-    expect(box.getBehaviorByName(RotateBehaviorName).state).toEqualWithAngle({
+    expect(box.getBehaviorByName(RotateBehaviorName)?.state).toEqualWithAngle({
       angle: 0,
       duration: 200
     })
-    expect(box.getBehaviorByName(AnchorBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(AnchorBehaviorName)?.state).toEqual({
       anchors: [],
       duration: 100
     })
-    expect(box.getBehaviorByName(StackBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(StackBehaviorName)?.state).toEqual({
       duration: 100,
       extent: 2,
       stackIds: []
     })
-    expect(box.getBehaviorByName(LockBehaviorName).state).toEqual({
+    expect(box.getBehaviorByName(LockBehaviorName)?.state).toEqual({
       isLocked: false
     })
   })
@@ -640,6 +667,7 @@ describe('serializeBehaviors() 3D utility', () => {
     const state = {
       anchors: [
         {
+          id: 'whatever',
           x: 10,
           y: 15,
           z: -5,
@@ -683,6 +711,7 @@ describe('serializeBehaviors() 3D utility', () => {
     const anchorable = {
       anchors: [
         {
+          id: 'whatever',
           x: 10,
           y: 15,
           z: -5,
@@ -733,6 +762,7 @@ describe('serializeBehaviors() 3D utility', () => {
 })
 
 describe('runAnimation() 3D utility', () => {
+  /** @type {AnimateBehavior} */
   let behavior
 
   beforeEach(() => {
@@ -754,8 +784,8 @@ describe('runAnimation() 3D utility', () => {
       duration,
       keys: [
         { frame: 0, values: [1, undefined, 1] },
-        { frame: 50, values: [1, null, null, 3] },
-        { frame: 100, values: [0, 2] }
+        { frame: 50, values: [1, null, null] },
+        { frame: 100, values: [0, 2, undefined] }
       ]
     })
     expect(animation.getKeys()).toEqual([
@@ -764,8 +794,7 @@ describe('runAnimation() 3D utility', () => {
         frame: 3,
         value: 1,
         inTangent: null,
-        outTangent: null,
-        interpolation: 3
+        outTangent: null
       },
       { frame: 6, value: 0, inTangent: 2 }
     ])
@@ -785,8 +814,8 @@ describe('runAnimation() 3D utility', () => {
       duration,
       keys: [
         { frame: 0, values: [1, 2, 3, undefined, [1, 1, 1]] },
-        { frame: 50, values: [2, 3, 4, null, null, [3, 3, 3]] },
-        { frame: 100, values: [3, 4, 5, [2, 2, 2]] }
+        { frame: 50, values: [2, 3, 4, null, null] },
+        { frame: 100, values: [3, 4, 5, [2, 2, 2], undefined] }
       ]
     })
     const finalRotation = new Vector3(3, 4, 5)
@@ -799,8 +828,7 @@ describe('runAnimation() 3D utility', () => {
       },
       {
         frame: 3,
-        value: new Vector3(2, 3, 4),
-        interpolation: new Vector3(3, 3, 3)
+        value: new Vector3(2, 3, 4)
       },
       { frame: 6, value: finalRotation, inTangent: new Vector3(2, 2, 2) }
     ])
@@ -824,8 +852,8 @@ describe('runAnimation() 3D utility', () => {
         animation,
         duration,
         keys: [
-          { frame: 0, values: [1] },
-          { frame: 100, values: [0] }
+          { frame: 0, values: [1, undefined, undefined] },
+          { frame: 100, values: [0, undefined, undefined] }
         ]
       },
       {
@@ -861,9 +889,9 @@ describe('isMeshFlipped()', () => {
   it('returns true for flipped mesh', async () => {
     box.addBehavior(new FlipBehavior({ isFlipped: true, duration: 50 }), true)
     expect(isMeshFlipped(box)).toBe(true)
-    await box.metadata.flip()
+    await box.metadata.flip?.()
     expect(isMeshFlipped(box)).toBe(false)
-    await box.metadata.flip()
+    await box.metadata.flip?.()
     expect(isMeshFlipped(box)).toBe(true)
   })
 })
@@ -879,13 +907,13 @@ describe('isMeshInverted()', () => {
   it('returns true for inverted mesh', async () => {
     box.addBehavior(new RotateBehavior({ angle: Math.PI, duration: 50 }), true)
     expect(isMeshInverted(box)).toBe(true)
-    await box.metadata.rotate()
+    await box.metadata.rotate?.()
     expect(isMeshInverted(box)).toBe(false)
-    await box.metadata.rotate()
+    await box.metadata.rotate?.()
     expect(isMeshInverted(box)).toBe(false)
-    await box.metadata.rotate()
+    await box.metadata.rotate?.()
     expect(isMeshInverted(box)).toBe(false)
-    await box.metadata.rotate()
+    await box.metadata.rotate?.()
     expect(isMeshInverted(box)).toBe(true)
   })
 
@@ -910,9 +938,9 @@ describe('isMeshLocked()', () => {
   it('returns true for inverted mesh', async () => {
     box.addBehavior(new LockBehavior({ isLocked: true }), true)
     expect(isMeshLocked(box)).toBe(true)
-    await box.metadata.toggleLock()
+    await box.metadata.toggleLock?.()
     expect(isMeshLocked(box)).toBe(false)
-    await box.metadata.toggleLock()
+    await box.metadata.toggleLock?.()
     expect(isMeshLocked(box)).toBe(true)
   })
 })
@@ -922,7 +950,10 @@ describe('getMeshAbsolutePartCenters()', () => {
     box.setAbsolutePosition(new Vector3(1, -3, 4))
     expect(getMeshAbsolutePartCenters(box)).toEqual([box.absolutePosition])
 
-    box.metadata = { partCenters: [] }
+    box.metadata = {
+      serialize: () => ({ shape: 'box', id: '', texture: '' }),
+      partCenters: []
+    }
     expect(getMeshAbsolutePartCenters(box)).toEqual([box.absolutePosition])
   })
 
@@ -931,6 +962,7 @@ describe('getMeshAbsolutePartCenters()', () => {
     box.setAbsolutePosition(position)
     box.computeWorldMatrix(true)
     box.metadata = {
+      serialize: () => ({ shape: 'box', id: '', texture: '' }),
       partCenters: [{ x: -0.5, z: -0.25 }, { z: 0.25 }, { x: 0.5, z: -0.25 }]
     }
     expect(getMeshAbsolutePartCenters(box)).toEqual([
@@ -944,6 +976,7 @@ describe('getMeshAbsolutePartCenters()', () => {
     box.rotation.y = Math.PI * 0.5
     box.computeWorldMatrix(true)
     box.metadata = {
+      serialize: () => ({ shape: 'box', id: '', texture: '' }),
       partCenters: [{ x: -0.5 }, { x: 0.5 }]
     }
     const parts = getMeshAbsolutePartCenters(box)
@@ -954,18 +987,23 @@ describe('getMeshAbsolutePartCenters()', () => {
 })
 
 describe('given a test behavior', () => {
+  /** @type {TestBehavior} */
   let behavior
 
   beforeEach(() => {
     behavior = new TestBehavior()
     box.addBehavior(behavior, true)
-    box.metadata = {}
+    box.metadata = {
+      serialize: () => ({ shape: 'box', id: '', texture: '' })
+    }
   })
 
   describe('attachProperty()', () => {
     it('creates metadata', () => {
+      // @ts-expect-error metadata is not optional
       delete box.metadata
       const getter = vi.fn().mockReturnValue('test')
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachProperty(behavior, 'testProp', getter)
       expect(box.metadata.testProp).toEqual('test')
       expect(getter).toHaveBeenCalledTimes(1)
@@ -974,6 +1012,7 @@ describe('given a test behavior', () => {
     it('creates a getter', () => {
       const value = Math.random()
       const getter = vi.fn().mockReturnValue(value)
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachProperty(behavior, 'testProp', getter)
       expect(box.metadata.testProp).toEqual(value)
       expect(getter).toHaveBeenCalledTimes(1)
@@ -982,10 +1021,12 @@ describe('given a test behavior', () => {
     it('creates rewritable and enumeratable getters', () => {
       const value = Math.random()
       const getter = vi.fn().mockReturnValue(value)
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachProperty(behavior, 'testProp2', getter)
       expect(JSON.stringify(box.metadata)).toEqual(
         JSON.stringify({ testProp2: value })
       )
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachProperty(behavior, 'testProp2', () => null)
       expect(box.metadata.testProp2).toBeNull()
       expect(getter).toHaveBeenCalledTimes(1)
@@ -994,18 +1035,22 @@ describe('given a test behavior', () => {
 
   describe('attachFunctions()', () => {
     it('creates metadata', () => {
+      // @ts-expect-error metadata is not optional
       delete box.metadata
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachFunctions(behavior, 'foo')
       expect(box.metadata.foo).toBeInstanceOf(Function)
     })
 
     it('attaches a single function', () => {
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachFunctions(behavior, 'foo')
       expect(box.metadata.foo).toBeInstanceOf(Function)
       expect(box.metadata.foo()).toEqual('foo')
     })
 
     it('attaches a multiple functions', () => {
+      // @ts-expect-error Testbehavior is not listed as a behavior
       attachFunctions(behavior, 'bar', 'foo')
       expect(box.metadata.foo).toBeInstanceOf(Function)
       expect(box.metadata.bar).toBeInstanceOf(Function)
@@ -1051,11 +1096,12 @@ class TestBehavior {
   constructor() {
     this.mesh = null
     this._foo = 'foo'
+    this.name = 'test'
   }
 
   init() {}
 
-  attach(mesh) {
+  attach(/** @type {Mesh} */ mesh) {
     this.mesh = mesh
   }
 

--- a/apps/web/tests/3d/utils/gravity.test.js
+++ b/apps/web/tests/3d/utils/gravity.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import {
@@ -20,6 +25,7 @@ import {
 configures3dTestEngine()
 
 describe('sortByElevation() 3D utility', () => {
+  /** @type {Mesh[]} */
   let boxes = []
 
   beforeEach(() => {
@@ -228,6 +234,7 @@ describe('isAbove() 3D utility', () => {
       results: [true, true]
     }
   ])(`given $title`, ({ buildMeshes, results }) => {
+    /** @type {Mesh[]} */
     let meshes
     beforeEach(() => {
       meshes = buildMeshes()
@@ -286,8 +293,9 @@ describe('getCenterAltitudeAbove() 3D utility', () => {
 })
 
 // TODO rotations
-
-function setPosition(meshesAndPositions) {
+function setPosition(
+  /** @type {{ x: number, z: number, y: number, mesh: Mesh }[]} */ meshesAndPositions
+) {
   for (const { x, y, z, mesh } of meshesAndPositions) {
     mesh.setAbsolutePosition(new Vector3(x, y, z))
   }

--- a/apps/web/tests/3d/utils/lights.test.js
+++ b/apps/web/tests/3d/utils/lights.test.js
@@ -1,9 +1,16 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+
 import { createLights } from '@src/3d/utils'
 import { describe, expect, it } from 'vitest'
 
 import { configures3dTestEngine } from '../../test-utils'
 
+/** @type {Scene} */
 let scene
+/** @type {Scene} */
 let handScene
 
 configures3dTestEngine(created => {

--- a/apps/web/tests/3d/utils/mesh.test.js
+++ b/apps/web/tests/3d/utils/mesh.test.js
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ */
+
 import { NullEngine } from '@babylonjs/core/Engines/nullEngine'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { Logger } from '@babylonjs/core/Misc/logger'
@@ -11,6 +17,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { createBox, expectDimension } from '../../test-utils'
 
+/** @type {Engine} */
 let engine
 
 beforeAll(() => {
@@ -53,7 +60,9 @@ describe('getDimensions() 3D utility', () => {
 })
 
 describe('isContaining() 3D utility', () => {
+  /** @type {Mesh} */
   let bigBox
+  /** @type {Mesh} */
   let smallBox
 
   beforeAll(() => {
@@ -86,6 +95,7 @@ describe('isContaining() 3D utility', () => {
 })
 
 describe('applyInitialTransform() 3D utility', () => {
+  /** @type {Mesh} */
   let box
 
   beforeEach(() => {

--- a/apps/web/tests/3d/utils/scene-loader.test.js
+++ b/apps/web/tests/3d/utils/scene-loader.test.js
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@tabulous/server/src/graphql/types').Mesh} SerializedMesh
+ * @typedef {import('@src/3d/utils/scene-loader').MeshCreator} MeshCreator
+ */
+
 import { faker } from '@faker-js/faker'
 import { customShapeManager, handManager } from '@src/3d/managers'
 import { getDieModelFile } from '@src/3d/meshes/die'
@@ -32,15 +41,25 @@ vi.mock('@src/3d/managers/custom-shape', () => ({
   customShapeManager: new Map()
 }))
 
+/** @type {Engine} */
 let engine
+/** @type {Scene} */
 let scene
+/** @type {Scene} */
 let handScene
+/** @type {MeshCreator} */
 let createBox
+/** @type {MeshCreator} */
 let createCard
+/** @type {MeshCreator} */
 let createCustom
+/** @type {MeshCreator} */
 let createDie
+/** @type {MeshCreator} */
 let createPrism
+/** @type {MeshCreator} */
 let createRoundToken
+/** @type {MeshCreator} */
 let createRoundedTile
 const renderWidth = 2048
 const renderHeight = 1024
@@ -52,14 +71,18 @@ beforeAll(async () => {
   ;({
     createBox,
     createCard,
+    // @ts-expect-error string|undefined is not compatible with {file: string}
     createCustom,
     createDie,
     createPrism,
     createRoundToken,
     createRoundedTile
   } = await import('@src/3d/meshes'))
+  // @ts-expect-error set is not defined on customShapeManager
   customShapeManager.set(pawnFile, btoa(pawnData))
+  // @ts-expect-error
   customShapeManager.set(getDieModelFile(6), btoa(die6Data))
+  // @ts-expect-error
   customShapeManager.set(getDieModelFile(8), btoa(die8Data))
 })
 
@@ -69,9 +92,12 @@ describe('serializeMeshes() 3D utility', () => {
   const overlay = document.createElement('div')
   const renderWidth = 480
   const renderHeight = 350
-  vi.spyOn(window, 'getComputedStyle').mockImplementation(() => ({
-    height: `${renderHeight / 4}px`
-  }))
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(
+    () =>
+      /** @type {CSSStyleDeclaration} */ ({
+        height: `${renderHeight / 4}px`
+      })
+  )
 
   it('handles empty scene', () => {
     expect(serializeMeshes()).toEqual([])
@@ -79,13 +105,10 @@ describe('serializeMeshes() 3D utility', () => {
 
   describe('given an scene', () => {
     beforeAll(() => {
-      ;({ engine, scene, handScene } = initialize3dEngine(
-        {
-          renderWidth,
-          renderHeight
-        },
-        { renderWidth, renderHeight }
-      ))
+      ;({ engine, scene, handScene } = initialize3dEngine({
+        renderWidth,
+        renderHeight
+      }))
       handManager.init({ scene, handScene, overlay })
     })
 
@@ -102,18 +125,20 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes boxes', async () => {
-      const box1 = await createBox({ id: 'box1' })
-      const box2 = await createBox({
-        id: 'box2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        width: faker.number.int(999),
-        height: faker.number.int(999),
-        depth: faker.number.int(999)
-      })
+      const box1 = await createBox({ id: 'box1', texture: '' }, scene)
+      const box2 = await createBox(
+        {
+          id: 'box2',
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          width: faker.number.int(999),
+          height: faker.number.int(999),
+          depth: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         box1.metadata.serialize(),
         box2.metadata.serialize()
@@ -121,18 +146,20 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes cards', async () => {
-      const card1 = await createCard({ id: 'card1' })
-      const card2 = await createCard({
-        id: 'card2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        width: faker.number.int(999),
-        height: faker.number.int(999),
-        depth: faker.number.int(999)
-      })
+      const card1 = await createCard({ id: 'card1', texture: '' }, scene)
+      const card2 = await createCard(
+        {
+          id: 'card2',
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          width: faker.number.int(999),
+          height: faker.number.int(999),
+          depth: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         card1.metadata.serialize(),
         card2.metadata.serialize()
@@ -140,17 +167,19 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes dice', async () => {
-      const die6 = await createDie({ id: 'd6' })
-      const die8 = await createBox({
-        id: 'd8',
-        faces: 8,
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        diameter: faker.number.int(999)
-      })
+      const die6 = await createDie({ id: 'd6', texture: '' }, scene)
+      const die8 = await createBox(
+        {
+          id: 'd8',
+          faces: 8,
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          diameter: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         die6.metadata.serialize(),
         die8.metadata.serialize()
@@ -158,19 +187,21 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes prism', async () => {
-      const prism1 = await createPrism({ id: 'prism1' })
-      const prism2 = await createPrism({
-        id: 'prism2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        prismRotation: faker.number.int(999),
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        width: faker.number.int(999),
-        edges: faker.number.int(999),
-        depth: faker.number.int(999)
-      })
+      const prism1 = await createPrism({ id: 'prism1', texture: '' }, scene)
+      const prism2 = await createPrism(
+        {
+          id: 'prism2',
+          texture: faker.internet.url(),
+          prismRotation: faker.number.int(999),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          width: faker.number.int(999),
+          edges: faker.number.int(999),
+          depth: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         prism1.metadata.serialize(),
         prism2.metadata.serialize()
@@ -178,17 +209,22 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes round tokens', async () => {
-      const token1 = await createRoundToken({ id: 'token1' })
-      const token2 = await createRoundToken({
-        id: 'token2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        diameter: faker.number.int(999),
-        height: faker.number.int(999)
-      })
+      const token1 = await createRoundToken(
+        { id: 'token1', texture: '' },
+        scene
+      )
+      const token2 = await createRoundToken(
+        {
+          id: 'token2',
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          diameter: faker.number.int(999),
+          height: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         token1.metadata.serialize(),
         token2.metadata.serialize()
@@ -196,20 +232,22 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes rounded tiles', async () => {
-      const tile1 = await createRoundedTile({ id: 'tile1' })
-      const tile2 = await createRoundedTile({
-        id: 'tile2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        borderRadius: faker.number.int(999),
-        faceUV: [Array.from({ length: 4 }, () => faker.number.int(999))],
-        width: faker.number.int(999),
-        height: faker.number.int(999),
-        depth: faker.number.int(999)
-      })
+      const tile1 = await createRoundedTile({ id: 'tile1', texture: '' }, scene)
+      const tile2 = await createRoundedTile(
+        {
+          id: 'tile2',
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          borderRadius: faker.number.int(999),
+          faceUV: [Array.from({ length: 4 }, () => faker.number.int(999))],
+          width: faker.number.int(999),
+          height: faker.number.int(999),
+          depth: faker.number.int(999)
+        },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([
         tile1.metadata.serialize(),
         tile2.metadata.serialize()
@@ -217,31 +255,39 @@ describe('serializeMeshes() 3D utility', () => {
     })
 
     it('serializes custom shapes', async () => {
-      const pawn1 = await createCustom({ id: 'pawn1', file: pawnFile })
+      const pawn1 = await createCustom(
+        { id: 'pawn1', texture: '', file: pawnFile },
+        scene
+      )
       expect(serializeMeshes(scene)).toEqual([pawn1.metadata.serialize()])
     })
 
     it('ignores phantom meshes', async () => {
-      const tile1 = await createRoundedTile({ id: 'tile1' })
-      const tile2 = await createRoundedTile({
-        id: 'tile2',
-        texture: faker.internet.url(),
-        images: [faker.word.sample()],
-        x: faker.number.int(999),
-        y: faker.number.int(999),
-        z: faker.number.int(999),
-        borderRadius: faker.number.int(999),
-        faceUV: [Array.from({ length: 4 }, () => faker.number.int(999))],
-        width: faker.number.int(999),
-        height: faker.number.int(999),
-        depth: faker.number.int(999)
-      })
+      const tile1 = await createRoundedTile({ id: 'tile1', texture: '' }, scene)
+      const tile2 = await createRoundedTile(
+        {
+          id: 'tile2',
+          texture: faker.internet.url(),
+          x: faker.number.int(999),
+          y: faker.number.int(999),
+          z: faker.number.int(999),
+          borderRadius: faker.number.int(999),
+          faceUV: [Array.from({ length: 4 }, () => faker.number.int(999))],
+          width: faker.number.int(999),
+          height: faker.number.int(999),
+          depth: faker.number.int(999)
+        },
+        scene
+      )
       tile1.isPhantom = true
       expect(serializeMeshes(scene)).toEqual([tile2.metadata.serialize()])
     })
 
     it('keep track of meshes transitioning between scenes', async () => {
-      const mesh = await createCard({ id: 'card1', drawable: {} })
+      const mesh = await createCard(
+        { id: 'card1', texture: '', drawable: {} },
+        scene
+      )
       const serialized = {
         ...mesh.metadata.serialize(),
         x: expect.any(Number),
@@ -258,14 +304,14 @@ describe('serializeMeshes() 3D utility', () => {
       expect(serializeMeshes(scene)).toEqual([])
       expect(serializeMeshes(handScene)).toEqual([serialized])
 
-      const handMesh = handScene.getMeshById(mesh.id)
+      const handMesh = /** @type {Mesh} */ (handScene.getMeshById(mesh.id))
       handManager.draw(handMesh)
 
       expect(serializeMeshes(scene)).toEqual([serialized])
       expect(serializeMeshes(handScene)).toEqual([])
 
       await expectAnimationEnd(
-        getAnimatableBehavior(scene.getMeshById(mesh.id))
+        getAnimatableBehavior(/** @type {Mesh} */ (scene.getMeshById(mesh.id)))
       )
 
       expect(serializeMeshes(scene)).toEqual([serialized])
@@ -433,19 +479,20 @@ describe('loadMeshes() 3D utility', () => {
   })
 
   it('throws on unsupported shape', async () => {
+    // @ts-expect-error 'unknown' is not a valid Shape
     await expect(loadMeshes(scene, [{ shape: 'unknown' }])).rejects.toThrow(
       'mesh shape unknown is not supported'
     )
   })
 
   it('disposes all existing cards, tokens, tiles and boxes but leaves other meshes', async () => {
-    createTable()
-    createRoundToken({ id: 'token' })
-    createBox({ id: 'box' })
-    createRoundedTile({ id: 'tile' })
-    createCard({ id: 'card' })
-    createPrism({ id: 'prism' })
-    createDie({ id: 'die' })
+    createTable(undefined, scene)
+    createRoundToken({ id: 'token', texture: '' }, scene)
+    createBox({ id: 'box', texture: '' }, scene)
+    createRoundedTile({ id: 'tile', texture: '' }, scene)
+    createCard({ id: 'card', texture: '' }, scene)
+    createPrism({ id: 'prism', texture: '' }, scene)
+    createDie({ id: 'die', texture: '' }, scene)
 
     expect(scene.getMeshById('table')).toBeDefined()
     expect(scene.getMeshById('token')).toBeDefined()
@@ -467,102 +514,136 @@ describe('loadMeshes() 3D utility', () => {
   })
 
   it('adds new meshes with their behaviors', async () => {
-    await loadMeshes(scene, [
-      card1,
-      token1,
-      tile1,
-      card2,
-      pawn1,
-      box1,
-      prism1,
-      die1
-    ])
+    await loadMeshes(
+      scene,
+      /** @type {SerializedMesh[]} */ ([
+        card1,
+        token1,
+        tile1,
+        card2,
+        pawn1,
+        box1,
+        prism1,
+        die1
+      ])
+    )
     expect(scene.getMeshById(card1.id)).toBeDefined()
-    expect(scene.getMeshById(card1.id).metadata.serialize()).toEqual(card1)
+    expect(scene.getMeshById(card1.id)?.metadata.serialize()).toEqual(card1)
     expect(scene.getMeshById(card2.id)).toBeDefined()
-    expect(scene.getMeshById(card2.id).metadata.serialize()).toEqual(card2)
+    expect(scene.getMeshById(card2.id)?.metadata.serialize()).toEqual(card2)
     expect(scene.getMeshById(token1.id)).toBeDefined()
-    expect(scene.getMeshById(token1.id).metadata.serialize()).toEqual(token1)
+    expect(scene.getMeshById(token1.id)?.metadata.serialize()).toEqual(token1)
     expect(scene.getMeshById(tile1.id)).toBeDefined()
-    expect(scene.getMeshById(tile1.id).metadata.serialize()).toEqual(tile1)
+    expect(scene.getMeshById(tile1.id)?.metadata.serialize()).toEqual(tile1)
     expect(scene.getMeshById(pawn1.id)).toBeDefined()
-    expect(scene.getMeshById(pawn1.id).metadata.serialize()).toEqual(pawn1)
+    expect(scene.getMeshById(pawn1.id)?.metadata.serialize()).toEqual(pawn1)
     expect(scene.getMeshById(box1.id)).toBeDefined()
-    expect(scene.getMeshById(box1.id).metadata.serialize()).toEqual(box1)
+    expect(scene.getMeshById(box1.id)?.metadata.serialize()).toEqual(box1)
     expect(scene.getMeshById(prism1.id)).toBeDefined()
-    expect(scene.getMeshById(prism1.id).metadata.serialize()).toEqual(prism1)
+    expect(scene.getMeshById(prism1.id)?.metadata.serialize()).toEqual(prism1)
     expect(scene.getMeshById(die1.id)).toBeDefined()
-    expect(scene.getMeshById(die1.id).metadata.serialize()).toEqual(die1)
+    expect(scene.getMeshById(die1.id)?.metadata.serialize()).toEqual(die1)
   })
 
   it('updates existing meshes with their behaviors', async () => {
-    const originalCard = await createCard({
-      id: card1.id,
-      x: 21,
-      y: 62,
-      z: 52
-    })
-    const originalTile = await createRoundedTile({
-      id: tile1.id,
-      x: -23,
-      y: 0,
-      z: -5.34
-    })
-    const originalToken = await createRoundToken({
-      id: token1.id,
-      x: 10,
-      y: 20,
-      z: 30,
-      flippable: { isFlipped: false },
-      rotable: { angle: Math.PI * 2 }
-    })
-    const originalPawn = await createCustom({
-      id: pawn1.id,
-      file: pawnFile,
-      x: 30,
-      y: 20,
-      z: 10
-    })
-    const originalBox = await createBox({
-      id: box1.id,
-      x: -5,
-      y: -6,
-      z: -7
-    })
-    const originalPrism = await createPrism({
-      id: prism1.id,
-      x: 10,
-      y: 11,
-      z: 12
-    })
-    const originalDie = await createDie({
-      id: die1.id,
-      x: -2,
-      y: 5,
-      z: 3,
-      randomizable: { face: 6 }
-    })
-    await loadMeshes(scene, [
-      card1,
-      card2,
-      token1,
-      tile1,
-      pawn1,
-      box1,
-      prism1,
-      die1
-    ])
+    const originalCard = await createCard(
+      {
+        id: card1.id,
+        x: 21,
+        y: 62,
+        z: 52,
+        texture: ''
+      },
+      scene
+    )
+    const originalTile = await createRoundedTile(
+      {
+        id: tile1.id,
+        x: -23,
+        y: 0,
+        z: -5.34,
+        texture: ''
+      },
+      scene
+    )
+    const originalToken = await createRoundToken(
+      {
+        id: token1.id,
+        x: 10,
+        y: 20,
+        z: 30,
+        flippable: { isFlipped: false },
+        rotable: { angle: Math.PI * 2 },
+        texture: ''
+      },
+      scene
+    )
+    const originalPawn = await createCustom(
+      {
+        id: pawn1.id,
+        file: pawnFile,
+        x: 30,
+        y: 20,
+        z: 10,
+        texture: ''
+      },
+      scene
+    )
+    const originalBox = await createBox(
+      {
+        id: box1.id,
+        x: -5,
+        y: -6,
+        z: -7,
+        texture: ''
+      },
+      scene
+    )
+    const originalPrism = await createPrism(
+      {
+        id: prism1.id,
+        x: 10,
+        y: 11,
+        z: 12,
+        texture: ''
+      },
+      scene
+    )
+    const originalDie = await createDie(
+      {
+        id: die1.id,
+        x: -2,
+        y: 5,
+        z: 3,
+        randomizable: { face: 6 },
+        texture: ''
+      },
+      scene
+    )
+    await loadMeshes(
+      scene,
+      /** @type {SerializedMesh[]} */ ([
+        card1,
+        card2,
+        token1,
+        tile1,
+        pawn1,
+        box1,
+        prism1,
+        die1
+      ])
+    )
     expect(scene.getMeshById(card1.id)).toBeDefined()
-    expect(scene.getMeshById(card1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(card1.id)?.metadata.serialize()).toEqual({
       ...originalCard.metadata.serialize(),
       x: card1.x,
       y: card1.y,
       z: card1.z
     })
     expect(scene.getMeshById(card2.id)).toBeDefined()
-    expect(scene.getMeshById(card2.id).metadata.serialize()).toEqual(card2)
+    expect(scene.getMeshById(card2.id)?.metadata.serialize()).toEqual(card2)
     expect(scene.getMeshById(token1.id)).toBeDefined()
-    expect(scene.getMeshById(token1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(token1.id)?.metadata.serialize()).toEqual({
       ...originalToken.metadata.serialize(),
       x: token1.x,
       y: token1.y,
@@ -571,35 +652,35 @@ describe('loadMeshes() 3D utility', () => {
       rotable: token1.rotable
     })
     expect(scene.getMeshById(tile1.id)).toBeDefined()
-    expect(scene.getMeshById(tile1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(tile1.id)?.metadata.serialize()).toEqual({
       ...originalTile.metadata.serialize(),
       x: tile1.x,
       y: tile1.y,
       z: tile1.z
     })
     expect(scene.getMeshById(pawn1.id)).toBeDefined()
-    expect(scene.getMeshById(pawn1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(pawn1.id)?.metadata.serialize()).toEqual({
       ...originalPawn.metadata.serialize(),
       x: pawn1.x,
       y: pawn1.y,
       z: pawn1.z
     })
     expect(scene.getMeshById(box1.id)).toBeDefined()
-    expect(scene.getMeshById(box1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(box1.id)?.metadata.serialize()).toEqual({
       ...originalBox.metadata.serialize(),
       x: box1.x,
       y: box1.y,
       z: box1.z
     })
     expect(scene.getMeshById(prism1.id)).toBeDefined()
-    expect(scene.getMeshById(prism1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(prism1.id)?.metadata.serialize()).toEqual({
       ...originalPrism.metadata.serialize(),
       x: prism1.x,
       y: prism1.y,
       z: prism1.z
     })
     expect(scene.getMeshById(die1.id)).toBeDefined()
-    expect(scene.getMeshById(die1.id).metadata.serialize()).toEqual({
+    expect(scene.getMeshById(die1.id)?.metadata.serialize()).toEqual({
       ...originalDie.metadata.serialize(),
       x: die1.x,
       y: die1.y,
@@ -634,22 +715,25 @@ describe('loadMeshes() 3D utility', () => {
       z: -5,
       movable: {}
     }
-    await loadMeshes(scene, [
-      card5,
-      card1,
-      {
-        shape: 'card',
-        id: 'card2',
-        stackable: { stackIds: [] },
-        movable: {}
-      },
-      { shape: 'card', id: 'card3', movable: {} },
-      { shape: 'card', id: 'card4', movable: {} },
-      { shape: 'card', id: 'card6', movable: {} }
-    ])
+    await loadMeshes(
+      scene,
+      /** @type {SerializedMesh[]} */ ([
+        card5,
+        card1,
+        {
+          shape: 'card',
+          id: 'card2',
+          stackable: { stackIds: [] },
+          movable: {}
+        },
+        { shape: 'card', id: 'card3', movable: {} },
+        { shape: 'card', id: 'card4', movable: {} },
+        { shape: 'card', id: 'card6', movable: {} }
+      ])
+    )
     const mesh1 = scene.getMeshById(card1.id)
     expect(mesh1).not.toBeNull()
-    expect(mesh1.metadata.serialize()).toEqual({
+    expect(mesh1?.metadata.serialize()).toEqual({
       ...card1,
       depth: 4.25,
       height: 0.01,
@@ -665,7 +749,7 @@ describe('loadMeshes() 3D utility', () => {
     })
     const mesh5 = scene.getMeshById(card5.id)
     expect(mesh5).not.toBeNull()
-    expect(mesh5.metadata.serialize()).toEqual({
+    expect(mesh5?.metadata.serialize()).toEqual({
       ...card5,
       depth: 4.25,
       height: 0.01,
@@ -708,16 +792,19 @@ describe('loadMeshes() 3D utility', () => {
       movable: {}
     }
 
-    await loadMeshes(scene, [
-      card4,
-      card1,
-      { shape: 'card', id: 'card2', movable: {} },
-      { shape: 'card', id: 'card3', movable: {} }
-    ])
+    await loadMeshes(
+      scene,
+      /** @type {SerializedMesh[]} */ ([
+        card4,
+        card1,
+        { shape: 'card', id: 'card2', movable: {} },
+        { shape: 'card', id: 'card3', movable: {} }
+      ])
+    )
     const mesh1 = scene.getMeshById(card1.id)
     expect(mesh1).not.toBeNull()
     expectPosition(mesh1, [pos1.x, pos1.y, pos1.z])
-    expect(mesh1.metadata.serialize()).toEqual({
+    expect(mesh1?.metadata.serialize()).toEqual({
       ...card1,
       ...pos1,
       movable: { duration: 100, snapDistance: 0.25 },

--- a/apps/web/tests/3d/utils/table.test.js
+++ b/apps/web/tests/3d/utils/table.test.js
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').PBRSpecularGlossinessMaterial} Material
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+
 import { faker } from '@faker-js/faker'
 import { materialManager } from '@src/3d/managers'
 import { createTable } from '@src/3d/utils'
@@ -6,7 +12,9 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { configures3dTestEngine } from '../../test-utils'
 
 describe('createTable() 3D utility', () => {
+  /** @type {Scene} */
   let scene
+  /** @type {Scene} */
   let handScene
 
   configures3dTestEngine(created => {
@@ -20,12 +28,14 @@ describe('createTable() 3D utility', () => {
     const width = faker.number.int(999)
     const height = faker.number.int(999)
     const texture = faker.internet.url()
-    const table = createTable({ width, height, texture })
+    const table = createTable({ width, height, texture }, scene)
     const { boundingBox } = table.getBoundingInfo()
     expect(table.name).toEqual('table')
     expect(boundingBox.extendSize.x * 2).toEqual(width)
     expect(boundingBox.extendSize.z * 2).toEqual(height)
-    expect(table.material.diffuseTexture?.name).toEqual(texture)
+    expect(
+      /** @type {Material} */ (table.material).diffuseTexture?.name
+    ).toEqual(texture)
     expect(table.isPickable).toBe(false)
     expect(table.absolutePosition.x).toEqual(0)
     expect(table.absolutePosition.y).toBeCloseTo(-0.01)
@@ -34,15 +44,17 @@ describe('createTable() 3D utility', () => {
 
   it('creates a table mesh with a color', () => {
     const texture = `${faker.internet.color().toUpperCase()}FF`
-    const table = createTable({ texture })
-    expect(table.material.diffuseColor?.toGammaSpace().toHexString()).toEqual(
-      texture
-    )
-    expect(table.material.diffuseTexture).toBeNull()
+    const table = createTable({ texture }, scene)
+    expect(
+      /** @type {Material} */ (table.material).diffuseColor
+        ?.toGammaSpace()
+        .toHexString()
+    ).toEqual(texture.slice(0, -2))
+    expect(/** @type {Material} */ (table.material).diffuseTexture).toBeNull()
   })
 
   it('creates a table mesh with default values', () => {
-    const table = createTable()
+    const table = createTable(undefined, scene)
     const { boundingBox } = table.getBoundingInfo()
     expect(table.name).toEqual('table')
     expect(boundingBox.extendSize.x * 2).toEqual(400)

--- a/apps/web/tests/3d/utils/vector.test.js
+++ b/apps/web/tests/3d/utils/vector.test.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * @typedef {import('@babylonjs/core').ArcRotateCamera} ArcRotateCamera
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ */
+
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { CreateGround } from '@babylonjs/core/Meshes/Builders/groundBuilder'
 import {
@@ -10,11 +18,19 @@ import {
 } from '@src/3d/utils'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
-import { createBox, initialize3dEngine } from '../../test-utils'
+import {
+  createBox,
+  expectCloseVector,
+  initialize3dEngine
+} from '../../test-utils'
 
+/** @type {Engine} */
 let engine
+/** @type {Scene} */
 let scene
+/** @type {ArcRotateCamera} */
 let camera
+/** @type {Mesh} */
 let box
 const renderWidth = 2048
 const renderHeight = 1024
@@ -38,45 +54,57 @@ afterAll(() => engine.dispose())
 
 describe('screenToGround() 3D utility', () => {
   it('converts screen center position to ground origin', () => {
-    const { x, y, z } = screenToGround(scene, {
-      x: renderWidth * 0.5,
-      y: renderHeight * 0.5
-    })
-    expect(x).toBeCloseTo(0, 5)
-    expect(y).toBeCloseTo(0, 5)
-    expect(z).toBeCloseTo(-0.000012, 5)
+    expectCloseVector(
+      screenToGround(scene, {
+        x: renderWidth * 0.5,
+        y: renderHeight * 0.5
+      }),
+      [0, 0, -0.000012],
+      undefined,
+      5
+    )
   })
 
   it('converts screen top left corner', () => {
-    const { x, y, z } = screenToGround(scene, { x: 0, y: 0 })
-    expect(x).toBeCloseTo(-51.255399, 5)
-    expect(y).toBeCloseTo(0, 5)
-    expect(z).toBeCloseTo(27.739206, 5)
+    expectCloseVector(
+      screenToGround(scene, {
+        x: 0,
+        y: 0
+      }),
+      [-51.255399, 0, 27.739206],
+      undefined,
+      5
+    )
   })
 
   it('converts screen bottom right corner', () => {
-    const { x, y, z } = screenToGround(scene, {
-      x: renderWidth,
-      y: renderHeight
-    })
-    expect(x).toBeCloseTo(35.978456, 5)
-    expect(y).toBeCloseTo(0, 5)
-    expect(z).toBeCloseTo(-19.47141, 5)
+    expectCloseVector(
+      screenToGround(scene, {
+        x: renderWidth,
+        y: renderHeight
+      }),
+      [35.978456, 0, -19.47141],
+      undefined,
+      5
+    )
   })
 
   it('handles camera moves', () => {
     camera.lockedTarget = new Vector3(10, 0, -10)
-    const { x, y, z } = screenToGround(scene, {
-      x: renderWidth * 0.5,
-      y: renderHeight * 0.5
-    })
-    expect(x).toBeCloseTo(10, 5)
-    expect(y).toBeCloseTo(0, 5)
-    expect(z).toBeCloseTo(-9.999969, 5)
+    expectCloseVector(
+      screenToGround(scene, {
+        x: renderWidth * 0.5,
+        y: renderHeight * 0.5
+      }),
+      [10, 0, -9.999969],
+      undefined,
+      5
+    )
   })
 })
 
 describe('isAboveTable() 3D utility', () => {
+  /** @type {Mesh} */
   let table
   const width = 50
   const height = 25
@@ -137,6 +165,7 @@ describe('isAboveTable() 3D utility', () => {
 })
 
 describe('isPositionAboveTable() 3D utility', () => {
+  /** @type {Mesh} */
   let table
   const width = 50
   const height = 25
@@ -190,7 +219,7 @@ describe('getMeshScreenPosition() 3D utility', () => {
 
   it('returns screen position of a positioned mesh', () => {
     box.setAbsolutePosition(new Vector3(10, 15, -5))
-    const { x, y } = getMeshScreenPosition(box)
+    const { x, y } = getMeshScreenPosition(box) ?? {}
     expect(x).toBeCloseTo(1377.798085, 5)
     expect(y).toBeCloseTo(472.344409, 5)
   })
@@ -200,13 +229,13 @@ describe('getMeshScreenPosition() 3D utility', () => {
     camera.lockedTarget = new Vector3(10, 10, 10)
     camera.beta = Math.PI
     scene.updateTransformMatrix()
-    const { x, y } = getMeshScreenPosition(box)
+    const { x, y } = getMeshScreenPosition(box) ?? {}
     expect(x).toBeCloseTo(1023.999991, 5)
     expect(y).toBeCloseTo(181.728928, 5)
   })
 
   it('handles missing mesh', () => {
-    expect(getMeshScreenPosition()).toBeNull()
+    expect(getMeshScreenPosition(undefined)).toBeNull()
     expect(getMeshScreenPosition(null)).toBeNull()
   })
 })

--- a/apps/web/tests/atelier/setup.js
+++ b/apps/web/tests/atelier/setup.js
@@ -1,3 +1,8 @@
+/**
+ * @template T
+ * @typedef {import('vitest').MockedObject<T>} MockedObject
+ */
+
 import './styles.postcss'
 
 import * as kitClient from '../../node_modules/@sveltejs/kit/src/runtime/client/singletons'
@@ -7,22 +12,27 @@ initLocale()
 
 kitClient.init({
   client: {
-    goto: () => {},
-    invalidate: () => {},
-    invalidateAll: () => {},
-    preload_code: () => {},
-    preload_data: () => {},
+    _hydrate: async () => {},
+    _start_router: () => {},
+    after_navigate: () => {},
+    apply_action: () => {},
     before_navigate: () => {},
-    after_navigate: () => {}
+    disable_scroll_handling: () => {},
+    goto: () => {},
+    invalidate_all: () => {},
+    invalidate: () => {},
+    preload_code: () => {},
+    preload_data: () => {}
   }
 })
 
+/** @type {?import('$app/stores')} */
 let storeMock = null
 
 /**
  * Only used when running the test suite, for toolshots.
  * Reconciles sveltekit $app/stores mocks from test suite and atelier tools.
- * @param {object} mock - mock for $app/stores
+ * @param {import('$app/stores')} mock - mock for $app/stores
  */
 export function setStoreMockForTestSuite(mock) {
   storeMock = mock

--- a/apps/web/tests/atelier/tools.test.js
+++ b/apps/web/tests/atelier/tools.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { configureToolshot } from '@atelier-wb/toolshot'
 import { join } from 'path'
 import { beforeAll, beforeEach, vi } from 'vitest'

--- a/apps/web/tests/components/Aside.tools.svelte
+++ b/apps/web/tests/components/Aside.tools.svelte
@@ -52,7 +52,7 @@
   name="Components/Aside"
   props={{
     game: { kind: 'splendor' },
-    player: players[0],
+    user: players[0],
     playerById,
     connected: [],
     thread: [],

--- a/apps/web/tests/components/FriendList.tools.svelte
+++ b/apps/web/tests/components/FriendList.tools.svelte
@@ -4,7 +4,7 @@
   import avatar from '@tests/fixtures/avatar.png'
   import { players as playerWithColors } from '@tests/fixtures/Discussion.testdata'
 
-  const currentPlayer = {
+  const user = {
     id: '135790',
     username: 'Fernande',
     usernameSearchable: true
@@ -46,22 +46,22 @@
   <Tool
     name="Empty list"
     props={{
-      currentPlayer,
+      user,
       friends: []
     }}
   />
   <Tool
     name="With friends"
-    props={{ currentPlayer, friends: players.map(player => ({ player })) }}
+    props={{ user, friends: players.map(player => ({ player })) }}
   />
   <Tool
     name="With requests and proposals"
-    props={{ currentPlayer, friends: friendsWithRequests }}
+    props={{ user, friends: friendsWithRequests }}
   />
   <Tool
     name="With lobby"
     props={{
-      currentPlayer: { ...currentPlayer, usernameSearchable: false },
+      user: { ...user, usernameSearchable: false },
       game: { availableSeats: 5 },
       playerById,
       friends: friendsWithRequests
@@ -70,7 +70,7 @@
   <Tool
     name="With game"
     props={{
-      currentPlayer: { ...currentPlayer, usernameSearchable: false },
+      user: { ...user, usernameSearchable: false },
       game: { kind: 'klondike', availableSeats: 3 },
       playerById,
       friends: friendsWithRequests
@@ -79,7 +79,7 @@
   <Tool
     name="With game with no seats"
     props={{
-      currentPlayer: { ...currentPlayer, usernameSearchable: false },
+      user: { ...user, usernameSearchable: false },
       game: { kind: 'klondike' },
       playerById,
       friends: friendsWithRequests

--- a/apps/web/tests/components/Menu.test.js
+++ b/apps/web/tests/components/Menu.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import Menu from '@src/components/Menu.svelte'
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte'
 import { get, writable } from 'svelte/store'
@@ -12,7 +13,7 @@ describe('Menu component', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    value$.set()
+    value$.set(undefined)
   })
 
   function renderComponent(props = {}) {
@@ -53,7 +54,9 @@ describe('Menu component', () => {
       renderComponent({ options })
       expect(screen.queryByRole('menu')).toBeInTheDocument()
 
-      fireEvent.click(document.querySelector('#other'))
+      fireEvent.click(
+        /** @type {HTMLElement} */ (document.querySelector('#other'))
+      )
       await waitFor(() =>
         expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       )
@@ -66,7 +69,9 @@ describe('Menu component', () => {
       expect(screen.queryByRole('menu')).toBeInTheDocument()
 
       fireEvent.focus(get(ref$))
-      fireEvent.keyDown(document.activeElement, { key: 'Escape' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'Escape'
+      })
       await waitFor(() =>
         expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       )
@@ -79,7 +84,9 @@ describe('Menu component', () => {
       expect(screen.queryByRole('menu')).toBeInTheDocument()
 
       fireEvent.focus(get(ref$))
-      fireEvent.keyDown(document.activeElement, { key: 'Tab' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'Tab'
+      })
       await waitFor(() =>
         expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       )
@@ -133,13 +140,19 @@ describe('Menu component', () => {
       fireEvent.focus(get(ref$))
       expect(document.activeElement).toEqual(items[0])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowDown'
+      })
       expect(document.activeElement).toEqual(items[1])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowDown'
+      })
       expect(document.activeElement).toEqual(items[2])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowDown'
+      })
       expect(document.activeElement).toEqual(items[2])
     })
 
@@ -149,7 +162,9 @@ describe('Menu component', () => {
       fireEvent.focus(get(ref$))
       expect(document.activeElement).toEqual(items[0])
 
-      fireEvent.keyDown(document.activeElement, { key: 'End' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'End'
+      })
       expect(document.activeElement).toEqual(items[2])
     })
 
@@ -161,13 +176,19 @@ describe('Menu component', () => {
       fireEvent.focus(menu)
       expect(document.activeElement).toEqual(items[2])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowUp'
+      })
       expect(document.activeElement).toEqual(items[1])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowUp'
+      })
       expect(document.activeElement).toEqual(items[0])
 
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowUp'
+      })
       expect(document.activeElement).toEqual(items[0])
     })
 
@@ -179,7 +200,9 @@ describe('Menu component', () => {
       fireEvent.focus(menu)
       expect(document.activeElement).toEqual(items[2])
 
-      fireEvent.keyDown(document.activeElement, { key: 'Home' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'Home'
+      })
       expect(document.activeElement).toEqual(items[0])
     })
 
@@ -191,10 +214,14 @@ describe('Menu component', () => {
       renderComponent({ options })
       const items = screen.queryAllByRole('menuitem')
       fireEvent.focus(get(ref$))
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key: 'ArrowDown'
+      })
       expect(document.activeElement).toEqual(items[1])
 
-      fireEvent.keyDown(document.activeElement, { key })
+      fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+        key
+      })
       await waitFor(() =>
         expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       )
@@ -221,16 +248,24 @@ describe('Menu component', () => {
     fireEvent.focus(get(ref$))
     expect(document.activeElement).toEqual(items[1])
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+    fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+      key: 'ArrowDown'
+    })
     expect(document.activeElement).toEqual(items[3])
 
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' })
+    fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+      key: 'ArrowUp'
+    })
     expect(document.activeElement).toEqual(items[1])
 
-    fireEvent.keyDown(document.activeElement, { key: 'End' })
+    fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+      key: 'End'
+    })
     expect(document.activeElement).toEqual(items[3])
 
-    fireEvent.keyDown(document.activeElement, { key: 'Home' })
+    fireEvent.keyDown(/** @type {HTMLElement} */ (document.activeElement), {
+      key: 'Home'
+    })
     expect(document.activeElement).toEqual(items[1])
   })
 

--- a/apps/web/tests/components/MinimizableSection.svelte
+++ b/apps/web/tests/components/MinimizableSection.svelte
@@ -1,10 +1,22 @@
 <script>
+  // @ts-check
+  /**
+   * @typedef {import('@src/stores/game-manager').Player} Player
+   */
+
   import { Discussion, MinimizableSection } from '@src/components'
   import { players, thread } from '@tests/fixtures/Discussion.testdata'
 
   export let placement = 'top'
+  /** @type {number} */
   let currentTab
-  const playerById = new Map(players.map(player => [player.id, player]))
+  /** @type {Map<string, Player>}*/
+  const playerById = new Map(
+    players.map(player => [
+      player.id,
+      { ...player, isHost: false, playing: false, currentGameId: null }
+    ])
+  )
 </script>
 
 <aside class={placement}>

--- a/apps/web/tests/components/MinimizableSection.test.js
+++ b/apps/web/tests/components/MinimizableSection.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import MinimizableSection from '@src/components/MinimizableSection.svelte'
 import { fireEvent, render, screen } from '@testing-library/svelte'
 import { tick } from 'svelte'
@@ -9,7 +10,9 @@ describe('MinimizableSection component', () => {
   const handleChange = vi.fn()
   const handleResize = vi.fn()
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   describe.each([
     ['top', 75],
@@ -55,7 +58,9 @@ describe('MinimizableSection component', () => {
 
     it('can resize', async () => {
       renderComponent()
-      const gutter = screen.queryByRole('scrollbar')
+      const gutter = /** @type {HTMLElement} */ (
+        screen.queryByRole('scrollbar')
+      )
       const downEvent = new Event('pointerdown')
       Object.assign(downEvent, { x: 100, y: 200 })
       fireEvent(gutter, downEvent)
@@ -83,7 +88,9 @@ describe('MinimizableSection component', () => {
 
     it('can not resize when minimized', async () => {
       renderComponent({ minimized: true })
-      const gutter = screen.queryByRole('scrollbar')
+      const gutter = /** @type {HTMLElement} */ (
+        screen.queryByRole('scrollbar')
+      )
       const downEvent = new Event('pointerdown')
       Object.assign(downEvent, { x: 100, y: 200 })
       fireEvent(gutter, downEvent)
@@ -102,6 +109,7 @@ describe('MinimizableSection component', () => {
     })
 
     describe('given some tabs', () => {
+      /** @type {HTMLElement[]} */
       let tabs
 
       beforeEach(() => {

--- a/apps/web/tests/components/QuantityButton.test.js
+++ b/apps/web/tests/components/QuantityButton.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import QuantityButton from '@src/components/QuantityButton.svelte'
 import { fireEvent, render, screen } from '@testing-library/svelte'
 import { tick } from 'svelte'
@@ -28,7 +29,7 @@ describe('QuantityButton component', () => {
     render(html`<${QuantityButton} on:click=${handleClick} />`)
     const buttons = screen.getAllByRole('button')
     expect(buttons).toHaveLength(3)
-    expect(buttons[0]).toHaveTextContent(1)
+    expect(buttons[0]).toHaveTextContent('1')
     expect(handleClick).not.toHaveBeenCalled()
   })
 
@@ -44,10 +45,11 @@ describe('QuantityButton component', () => {
   it(`increments quantity with keyboard`, async () => {
     renderComponent()
     screen.getAllByRole('button')[0].focus()
-    fireEvent.keyUp(document.activeElement, { code: 'ArrowUp' })
+    const activeElement = /** @type {HTMLElement} */ (document.activeElement)
+    fireEvent.keyUp(activeElement, { code: 'ArrowUp' })
     await tick()
     expectQuantity(2)
-    fireEvent.keyUp(document.activeElement, { code: 'ArrowRight' })
+    fireEvent.keyUp(activeElement, { code: 'ArrowRight' })
     await tick()
     expectQuantity(3)
     expect(handleClick).not.toHaveBeenCalled()
@@ -66,10 +68,11 @@ describe('QuantityButton component', () => {
     quantity$.set(10)
     renderComponent()
     screen.getAllByRole('button')[0].focus()
-    fireEvent.keyUp(document.activeElement, { code: 'ArrowLeft' })
+    const activeElement = /** @type {HTMLElement} */ (document.activeElement)
+    fireEvent.keyUp(activeElement, { code: 'ArrowLeft' })
     await tick()
     expectQuantity(9)
-    fireEvent.keyUp(document.activeElement, { code: 'ArrowDown' })
+    fireEvent.keyUp(activeElement, { code: 'ArrowDown' })
     await tick()
     expectQuantity(8)
     expect(handleClick).not.toHaveBeenCalled()
@@ -89,13 +92,15 @@ describe('QuantityButton component', () => {
     quantity$.set(5)
     renderComponent()
     screen.getAllByRole('button')[0].focus()
-    fireEvent.keyUp(document.activeElement, { code: 'Home' })
+    fireEvent.keyUp(/** @type {HTMLElement} */ (document.activeElement), {
+      code: 'Home'
+    })
     await tick()
     expectQuantity(1)
     expect(handleClick).not.toHaveBeenCalled()
   })
 
-  it(`resetto 1 when incrementing above max`, async () => {
+  it(`reset to 1 when incrementing above max`, async () => {
     renderComponent({ max: 3 })
     for (let times = 1; times <= 3; times++) {
       expectQuantity(times)
@@ -110,7 +115,9 @@ describe('QuantityButton component', () => {
     const max = 5
     renderComponent({ max })
     screen.getAllByRole('button')[0].focus()
-    fireEvent.keyUp(document.activeElement, { code: 'End' })
+    fireEvent.keyUp(/** @type {HTMLElement} */ (document.activeElement), {
+      code: 'End'
+    })
     await tick()
     expectQuantity(max)
     expect(handleClick).not.toHaveBeenCalled()
@@ -126,8 +133,8 @@ describe('QuantityButton component', () => {
     )
   })
 
-  function expectQuantity(quantity) {
+  function expectQuantity(quantity = 0) {
     expect(get(quantity$)).toEqual(quantity)
-    expect(screen.getAllByRole('button')[0]).toHaveTextContent(quantity)
+    expect(screen.getAllByRole('button')[0]).toHaveTextContent(`${quantity}`)
   }
 })

--- a/apps/web/tests/components/RuleViewer.test.js
+++ b/apps/web/tests/components/RuleViewer.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { RuleViewer } from '@src/components'
 import { gameAssetsUrl } from '@src/utils'
 import { fireEvent, render, screen } from '@testing-library/svelte'
@@ -15,15 +16,21 @@ import {
 } from 'vitest'
 
 describe.each([{ lang: 'fr' }, { lang: 'en' }])('$lang', ({ lang }) => {
-  beforeAll(() => locale.set(lang))
+  beforeAll(() => {
+    locale.set(lang)
+  })
 
-  afterAll(() => locale.set('fr'))
+  afterAll(() => {
+    locale.set('fr')
+  })
 
   describe('RuleViewer component', () => {
     const handleChange = vi.fn()
     const game = 'cards'
 
-    beforeEach(vi.resetAllMocks)
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
 
     function renderComponent(props = {}) {
       return render(
@@ -124,44 +131,49 @@ describe.each([{ lang: 'fr' }, { lang: 'en' }])('$lang', ({ lang }) => {
       expect(handleChange).toHaveBeenCalledTimes(2)
     })
 
-    it('pans the imagee', async () => {
+    it('pans the image', async () => {
       renderComponent({ lastPage: 2 })
-      const image = screen.queryByRole('img')
-      image.getBoundingClientRect = () => ({ width: 300, height: 500 })
+      const image = /** @type {HTMLImageElement} */ (screen.queryByRole('img'))
+      image.getBoundingClientRect = () =>
+        /** @type {DOMRect} **/ ({ width: 300, height: 500 })
       fireEvent.load(image)
       const container = image.parentElement
-      expect(container.scrollTop).toBe(0)
-      expect(container.scrollLeft).toBe(0)
+      expect(container?.scrollTop).toBe(0)
+      expect(container?.scrollLeft).toBe(0)
       const downEvent = new Event('pointerdown')
       Object.assign(downEvent, { clientX: 100, clientY: 100 })
-      fireEvent(container, downEvent)
+      fireEvent(/** @type {HTMLImageElement} */ (container), downEvent)
       const moveEvent = new Event('pointermove')
       Object.assign(moveEvent, { clientX: 50, clientY: 75 })
       fireEvent(window, moveEvent)
       fireEvent.pointerUp(image)
-      expect(container.scrollTop).toBe(25)
-      expect(container.scrollLeft).toBe(50)
+      expect(container?.scrollTop).toBe(25)
+      expect(container?.scrollLeft).toBe(50)
       expect(handleChange).not.toHaveBeenCalled()
     })
 
     it('zooms the image out and in', async () => {
       renderComponent({ lastPage: 2 })
-      const image = screen.queryByRole('img')
+      const image = /** @type {HTMLImageElement} */ (screen.queryByRole('img'))
+      const parentElement = /** @type {HTMLImageElement} */ (
+        image.parentElement
+      )
       const width = 300
       const height = 500
-      image.getBoundingClientRect = () => ({ width, height })
+      image.getBoundingClientRect = () =>
+        /** @type {DOMRect} **/ ({ width, height })
       fireEvent.load(image)
       expect(image).toHaveStyle({
         width: `90px`,
         height: `150px`
       })
-      fireEvent.wheel(image.parentElement, { deltaY: -10 })
-      fireEvent.wheel(image.parentElement, { deltaY: -5 })
+      fireEvent.wheel(parentElement, { deltaY: -10 })
+      fireEvent.wheel(parentElement, { deltaY: -5 })
       expect(image).toHaveStyle({
         width: `150px`,
         height: `250px`
       })
-      fireEvent.wheel(image.parentElement, { deltaY: 5 })
+      fireEvent.wheel(parentElement, { deltaY: 5 })
       expect(image).toHaveStyle({
         width: `120px`,
         height: `200px`
@@ -172,13 +184,17 @@ describe.each([{ lang: 'fr' }, { lang: 'en' }])('$lang', ({ lang }) => {
     it('can not zoom the image to far', async () => {
       const minZoom = 0.5
       renderComponent({ minZoom })
-      const image = screen.queryByRole('img')
+      const image = /** @type {HTMLImageElement} */ (screen.queryByRole('img'))
+      const parentElement = /** @type {HTMLImageElement} */ (
+        image.parentElement
+      )
       const width = 300
       const height = 500
-      image.getBoundingClientRect = () => ({ width, height })
+      image.getBoundingClientRect = () =>
+        /** @type {DOMRect} **/ ({ width, height })
       fireEvent.load(image)
       for (let i = 0; i < 20; i++) {
-        fireEvent.wheel(image.parentElement, { deltaY: 1 })
+        fireEvent.wheel(parentElement, { deltaY: 1 })
       }
       expect(image).toHaveStyle({
         width: `${width * minZoom}px`,
@@ -190,13 +206,17 @@ describe.each([{ lang: 'fr' }, { lang: 'en' }])('$lang', ({ lang }) => {
     it('can not zoom the image to close', async () => {
       const maxZoom = 1.6
       renderComponent({ maxZoom })
-      const image = screen.queryByRole('img')
+      const image = /** @type {HTMLImageElement} */ (screen.queryByRole('img'))
+      const parentElement = /** @type {HTMLImageElement} */ (
+        image.parentElement
+      )
       const width = 300
       const height = 500
-      image.getBoundingClientRect = () => ({ width, height })
+      image.getBoundingClientRect = () =>
+        /** @type {DOMRect} **/ ({ width, height })
       fireEvent.load(image)
       for (let i = 0; i < 20; i++) {
-        fireEvent.wheel(image.parentElement, { deltaY: -1 })
+        fireEvent.wheel(parentElement, { deltaY: -1 })
       }
       expect(image).toHaveStyle({
         width: `${width * maxZoom}px`,

--- a/apps/web/tests/components/Toaster.tools.svelte
+++ b/apps/web/tests/components/Toaster.tools.svelte
@@ -3,7 +3,6 @@
   import { faker } from '@faker-js/faker'
   import { Button, Toaster } from '@src/components'
 
-  let message = null
   const icons = [
     'build',
     'adjust',
@@ -14,6 +13,12 @@
   ]
 
   const colors = ['#d6a63d', '#41d26d', '#ffa280', undefined, undefined]
+
+  let message = {
+    icon: icons[0],
+    color: colors[0],
+    content: 'Hello world'
+  }
 
   function addToast() {
     message = {

--- a/apps/web/tests/components/Typeahead.svelte
+++ b/apps/web/tests/components/Typeahead.svelte
@@ -1,13 +1,19 @@
 <script>
+  // @ts-check
+  /** @typedef {import('@src/components').LabelMenuOption} LabelMenuOption */
+
   import { Typeahead } from '@src/components'
 
   export let withObject = false
+  /** @type {((Record<string, ?> & string)|LabelMenuOption)[]} */
   let options
 
   function findOptions() {
-    options = withObject
-      ? [{ label: 'Hello' }, { label: 'Salut' }, { label: 'Hallo' }]
-      : ['Hello', 'Salut', 'Hallo']
+    options = /** @type {?} */ (
+      withObject
+        ? [{ label: 'Hello' }, { label: 'Salut' }, { label: 'Hallo' }]
+        : ['Hello', 'Salut', 'Hallo']
+    )
   }
 </script>
 

--- a/apps/web/tests/components/__snapshots__/Aside.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Aside.tools.shot
@@ -2,11 +2,11 @@
 
 exports[`Friends only 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   />
    
   <aside
@@ -445,6 +445,7 @@ exports[`Friends only 1`] = `
               class="s-2FHiERVIQQ6s"
             >
               <span
+                aria-expanded="true"
                 aria-haspopup="menu"
                 class="wrapper s-JM3fRWrV7jJU"
               >
@@ -503,11 +504,11 @@ exports[`Friends only 1`] = `
 
 exports[`Lobby 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   />
    
   <aside
@@ -999,11 +1000,11 @@ exports[`Lobby 1`] = `
 
 exports[`Multiple connected 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   >
     <button
       class="s-NMyTiX1zi6rz"
@@ -1420,11 +1421,11 @@ exports[`Multiple connected 1`] = `
 
 exports[`No peers 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   />
    
   <aside
@@ -1675,11 +1676,11 @@ exports[`No peers, no rules book 1`] = `undefined`;
 
 exports[`Single connected 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   />
    
   <aside
@@ -2028,11 +2029,11 @@ exports[`Single connected 1`] = `
 
 exports[`Single connected, no rules book, thread 1`] = `
 <main
-  class="flex w-full h-screen"
+  class="flex w-full h-screen s-704Ys9uC0Q3P"
   style="height: 100vh;"
 >
   <section
-    class="flex-1"
+    class="flex-1 s-704Ys9uC0Q3P"
   />
    
   <aside

--- a/apps/web/tests/components/__snapshots__/Discussion.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Discussion.tools.shot
@@ -2,7 +2,7 @@
 
 exports[`Long thread 1`] = `
 <div
-  class="w-1/3 m-auto h-400px"
+  class="w-1/3 m-auto h-400px s-k5apxeG8geqr"
 >
   <div
     class="discussion s-4DrpFHLJm4IA"

--- a/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Dropdown.tools.shot
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon only 1`] = `
-<div>
-  <div>
+<div
+  class="s-eXK2szYm-Ncy"
+>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -63,7 +67,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -82,8 +88,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 `;
 
 exports[`Invalid value 1`] = `
-<div>
-  <div>
+<div
+  class="s-eXK2szYm-Ncy"
+>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -144,7 +154,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -164,9 +176,11 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 
 exports[`Left aligned 1`] = `
 <div
-  class="p-8"
+  class="p-8 s-eXK2szYm-Ncy"
 >
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -227,7 +241,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -247,10 +263,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 
 exports[`Right aligned 1`] = `
 <div
-  class="p-8"
+  class="p-8 s-eXK2szYm-Ncy"
   style="text-align: right;"
 >
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -311,7 +329,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -330,8 +350,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 `;
 
 exports[`Split clicks 1`] = `
-<div>
-  <div>
+<div
+  class="s-eXK2szYm-Ncy"
+>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -392,7 +416,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -411,8 +437,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 `;
 
 exports[`Value as text 1`] = `
-<div>
-  <div>
+<div
+  class="s-eXK2szYm-Ncy"
+>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -473,7 +503,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit
@@ -492,8 +524,12 @@ lacus vestibulum sed arcu non odio euismod lacinia.
 `;
 
 exports[`With colors 1`] = `
-<div>
-  <div>
+<div
+  class="s-eXK2szYm-Ncy"
+>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Commodo nulla facilisi
 nullam vehicula ipsum a arcu cursus. Eget sit amet tellus cras adipiscing
@@ -555,7 +591,9 @@ erat pellentesque adipiscing commodo elit at imperdiet.
   </span>
   <!--&lt;Dropdown&gt;-->
    
-  <div>
+  <div
+    class="s-eXK2szYm-Ncy"
+  >
     Mus mauris vitae ultricies leo integer malesuada nunc vel risus. Tincidunt
 vitae semper quis lectus nulla at. Ac felis donec et odio pellentesque
 diam volutpat. Lectus sit amet est placerat in egestas erat. Cursus sit

--- a/apps/web/tests/components/__snapshots__/FriendList.tools.shot
+++ b/apps/web/tests/components/__snapshots__/FriendList.tools.shot
@@ -41,6 +41,7 @@ exports[`Empty list 1`] = `
     class="s-2FHiERVIQQ6s"
   >
     <span
+      aria-expanded="true"
       aria-haspopup="menu"
       class="wrapper s-JM3fRWrV7jJU"
     >
@@ -347,6 +348,7 @@ exports[`With friends 1`] = `
     class="s-2FHiERVIQQ6s"
   >
     <span
+      aria-expanded="true"
       aria-haspopup="menu"
       class="wrapper s-JM3fRWrV7jJU"
     >
@@ -1306,6 +1308,7 @@ exports[`With requests and proposals 1`] = `
     class="s-2FHiERVIQQ6s"
   >
     <span
+      aria-expanded="true"
       aria-haspopup="menu"
       class="wrapper s-JM3fRWrV7jJU"
     >

--- a/apps/web/tests/components/__snapshots__/Toaster.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Toaster.tools.shot
@@ -4,7 +4,44 @@ exports[`Interactive 1`] = `
 HTMLCollection [
   <div
     class="s-u8CdeWxIm4f1"
-  />,
+  >
+    
+    <div
+      class="s-qGWxPda9kJl2"
+      style="--top: 0px; --bg-color: #d6a63d; --duration: 4s; --close-duration: 0.4s;"
+    >
+      <span
+        class="material-icons s-qGWxPda9kJl2"
+      >
+        build
+      </span>
+       
+      <strong
+        class="s-qGWxPda9kJl2"
+      >
+        Hello world
+      </strong>
+       
+      <button
+        class="transparent s-NMyTiX1zi6rz"
+      >
+        <div
+          class="s-NMyTiX1zi6rz"
+        >
+          <span
+            class="material-icons s-NMyTiX1zi6rz"
+          >
+            close
+          </span>
+          
+          
+        </div>
+         
+      </button>
+      <!--&lt;Button&gt;-->
+    </div>
+    <!--&lt;Message&gt;-->
+  </div>,
   <button
     class="s-NMyTiX1zi6rz"
   >
@@ -29,11 +66,6 @@ exports[`Text only 1`] = `
     class="s-qGWxPda9kJl2"
     style="--top: 0px; --bg-color: #fcfcfc; --duration: 4s; --close-duration: 0.4s;"
   >
-    <span
-      class="material-icons s-qGWxPda9kJl2"
-    >
-      
-    </span>
      
     <strong
       class="s-qGWxPda9kJl2"

--- a/apps/web/tests/components/__snapshots__/Typeahead.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Typeahead.tools.shot
@@ -2,6 +2,7 @@
 
 exports[`With labels 1`] = `
 <span
+  aria-expanded="false"
   aria-haspopup="menu"
   class="wrapper s-JM3fRWrV7jJU"
 >
@@ -23,6 +24,7 @@ exports[`With labels 1`] = `
 
 exports[`With objects 1`] = `
 <span
+  aria-expanded="false"
   aria-haspopup="menu"
   class="wrapper s-JM3fRWrV7jJU"
 >

--- a/apps/web/tests/fixtures/Discussion.testdata.js
+++ b/apps/web/tests/fixtures/Discussion.testdata.js
@@ -1,44 +1,75 @@
+// @ts-check
+/**
+ * @typedef {import('@src/graphql').Game} Game
+ * @typedef {import('@src/graphql').LightPlayer} LightPlayer
+ * @typedef {import('@tabulous/server/src/graphql/types').PlayerPreference} PlayerPreference
+ */
+/**
+ * @typedef {import('@src/stores/game-manager').Player} Player
+ */
+
+/** @type {Map<string, Player>} a map of player details by their id. */
+/** @type {(LightPlayer & Omit<PlayerPreference, 'playerId'>)[]} */
 export const players = [
-  { id: '123456', username: 'Fernand Naudin', color: '#9c3096' },
-  { id: '741852', username: 'Maître Follas', color: '#ff4500' },
-  { id: '369258', username: 'Pascal', color: '#239646' },
-  { id: '543498', username: 'Bastien', color: '#73778c' }
+  {
+    id: '123456',
+    username: 'Fernand Naudin',
+    color: '#9c3096',
+    currentGameId: null
+  },
+  {
+    id: '741852',
+    username: 'Maître Follas',
+    color: '#ff4500',
+    currentGameId: null
+  },
+  { id: '369258', username: 'Pascal', color: '#239646', currentGameId: null },
+  { id: '543498', username: 'Bastien', color: '#73778c', currentGameId: null }
 ]
 
+/** @type {Game['messages']} discussion thread. */
 export const thread = [
   {
     playerId: '123456',
-    text: `Qu'est-ce qui se passe encore ?`
+    text: `Qu'est-ce qui se passe encore ?`,
+    time: Date.now() - 5000
   },
   {
     playerId: '741852',
-    text: `Notre ami va se faire un plaisir de vous l'expliquer.`
+    text: `Notre ami va se faire un plaisir de vous l'expliquer.`,
+    time: Date.now() - 4500
   },
   {
     playerId: '369258',
     text: `Les Volfoni ont organisé à la péniche une petite réunion des cadres, façon meeting, si vous voyez ce que je veux dire.
-M'enfin quoi, on parle dans votre dos.`
+M'enfin quoi, on parle dans votre dos.`,
+    time: Date.now() - 4000
   },
   {
     playerId: '123456',
-    text: `Et tu tiens ça d'où ?`
+    text: `Et tu tiens ça d'où ?`,
+    time: Date.now() - 3500
   },
   {
     playerId: '369258',
-    text: `Je ne peux pas le dire, j'ai promis. Ce serait mal.`
+    text: `Je ne peux pas le dire, j'ai promis. Ce serait mal.`,
+    time: Date.now() - 3000
   },
-  { playerId: '123456', text: 'Alors ?' },
+  { playerId: '123456', text: 'Alors ?', time: Date.now() - 2500 },
   {
     playerId: '741852',
     text: `Eh bien. Euh. Y'a deux solutions : ou on se dérange, ou on méprise. 
-Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire, bien sûr.`
+Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire, bien sûr.`,
+    time: Date.now() - 2000
   },
   {
     playerId: '123456',
-    text: 'Bon, on va y aller, hmm ?'
+    text: 'Bon, on va y aller, hmm ?',
+    time: Date.now() - 1500
   },
   {
     playerId: '369258',
-    text: `Monsieur Fernand, y'a peut-être une place pour moi dans votre auto. Des fois que la réunion devienne houleuse ... J'ai une présence tranquillisante.`
+    text: `Monsieur Fernand, y'a peut-être une place pour moi dans votre auto. Des fois que la réunion devienne houleuse ... J'ai une présence tranquillisante.`,
+    time: Date.now() - 1000
   }
 ]

--- a/apps/web/tests/hooks.server.test.js
+++ b/apps/web/tests/hooks.server.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { faker } from '@faker-js/faker'
 import { handle } from '@src/hooks.server'
 import { describe, expect, it, vi } from 'vitest'
@@ -22,15 +23,17 @@ describe('Sveltekit handle() hook', () => {
         const url = `/current-${faker.internet.domainWord()}?data=${faker.lorem.word()}`
         const request = new Request(`http://localhost:3000${url}`)
         request.headers.append('accept-language', header)
-        const response = await handle({
-          event: {
-            url: new URL(url, 'http://localhost:3000'),
-            locals: {},
-            request,
-            params: {}
-          },
-          resolve: vi.fn().mockResolvedValue(new Response())
-        })
+        const response = await handle(
+          /** @type {?} */ ({
+            event: {
+              url: new URL(url, 'http://localhost:3000'),
+              locals: {},
+              request,
+              params: {}
+            },
+            resolve: vi.fn().mockResolvedValue(new Response())
+          })
+        )
         expect(response.status).toBe(303)
         expect(response.headers.get('location')).toBe(`/${lang}${url}`)
       }
@@ -144,7 +147,7 @@ describe('Sveltekit handle() hook', () => {
       request = new Request(`https://localhost:3000${urlRoot}`),
       response = new Response()
     } = {}) {
-      return {
+      return /** @type {?} */ ({
         event: {
           url: new URL(url, 'https://localhost:3000'),
           locals: {},
@@ -152,7 +155,7 @@ describe('Sveltekit handle() hook', () => {
           params: { lang }
         },
         resolve: vi.fn().mockResolvedValue(response)
-      }
+      })
     }
   })
 })

--- a/apps/web/tests/integration/account.spec.js
+++ b/apps/web/tests/integration/account.spec.js
@@ -7,7 +7,10 @@ import { fn } from 'vitest/dist/spy.js'
 import { AccountPage } from './pages/index.js'
 import { describe, expect, it, mockGraphQl } from './utils/index.js'
 
-for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
+for (const { lang } of /** @type {{ lang: import('./utils').Locale }[]} */ ([
+  { lang: 'fr' },
+  { lang: 'en' }
+])) {
   describe(`${lang} Account page`, () => {
     const player = {
       id: faker.string.uuid(),
@@ -180,7 +183,10 @@ for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
 
         await accountPage.switchLangTo(otherLang)
 
-        accountPage = new AccountPage(page, otherLang)
+        accountPage = new AccountPage(
+          page,
+          /** @type {import('./utils').Locale} */ (otherLang)
+        )
         await accountPage.goTo()
         await accountPage.getStarted()
       })

--- a/apps/web/tests/integration/game.spec.js
+++ b/apps/web/tests/integration/game.spec.js
@@ -6,7 +6,10 @@ import { GamePage, HomePage } from './pages/index.js'
 import { translate } from './utils/index.js'
 import { describe, expect, it, mockGraphQl } from './utils/index.js'
 
-for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
+for (const { lang } of /** @type {{ lang: import('./utils').Locale }[]} */ ([
+  { lang: 'fr' },
+  { lang: 'en' }
+])) {
   describe(`${lang} Game page`, () => {
     const player = {
       id: faker.string.uuid(),

--- a/apps/web/tests/integration/home.spec.js
+++ b/apps/web/tests/integration/home.spec.js
@@ -627,8 +627,10 @@ for (const { lang } of /** @type {{ lang: import('./utils').Locale }[]} */ ([
 
       it('can kick a lobby guest', async ({ page }) => {
         const homePage = new HomePage(page, lang)
-        graphQlMocks.onQuery(operation => {
+        const kickSpy = fn()
+        graphQlMocks.onQuery((operation, req) => {
           if (operation === 'kick') {
+            kickSpy(req)
             graphQlMocks.sendToSubscription({
               data: {
                 receiveGameUpdates: { ...lobby, players: [player] }
@@ -638,6 +640,13 @@ for (const { lang } of /** @type {{ lang: import('./utils').Locale }[]} */ ([
           }
         })
         await homePage.kick(friends[0].player.username)
+        // TODO find how to extend playwrigh's expect.
+        // @ts-expect-error: playwright does not know about vitest matchers
+        expect(kickSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: { gameId: lobby.id, playerId: friends[0].player.id }
+          })
+        )
       })
     })
 

--- a/apps/web/tests/integration/home.spec.js
+++ b/apps/web/tests/integration/home.spec.js
@@ -1,4 +1,4 @@
-// @ts-checkcan promo
+// @ts-check
 import { faker } from '@faker-js/faker'
 import { supportedLanguages } from '@src/params/lang.js'
 // note: we can't import the full vitest because it mockeypatches Jest symbols, which Playwright doesn't like
@@ -14,14 +14,15 @@ import {
   translate
 } from './utils/index.js'
 
-for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
+for (const { lang } of /** @type {{ lang: import('./utils').Locale }[]} */ ([
+  { lang: 'fr' },
+  { lang: 'en' }
+])) {
   describe(`${lang} Home page`, () => {
     const catalog = [
       {
         name: 'playground',
-        locales: { fr: { title: 'Aire de jeu' }, en: { title: 'Playground' } },
-        minAge: null,
-        minTime: null
+        locales: { fr: { title: 'Aire de jeu' }, en: { title: 'Playground' } }
       },
       {
         name: 'klondike',
@@ -532,7 +533,7 @@ for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
         players: [player]
       }
       let gameJoined = lobby
-      /** @type {import('./utils/server.js').GraphQlMockResult} */
+      /** @type {import('./utils/server').GraphQlMockResult} */
       let graphQlMocks
 
       beforeEach(async ({ page }) => {
@@ -626,9 +627,8 @@ for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
 
       it('can kick a lobby guest', async ({ page }) => {
         const homePage = new HomePage(page, lang)
-        graphQlMocks.onQuery((operation, request) => {
+        graphQlMocks.onQuery(operation => {
           if (operation === 'kick') {
-            console.log(request)
             graphQlMocks.sendToSubscription({
               data: {
                 receiveGameUpdates: { ...lobby, players: [player] }
@@ -642,6 +642,7 @@ for (const { lang } of [{ lang: 'fr' }, { lang: 'en' }]) {
     })
 
     describe('given some friends', () => {
+      /** @type {import('./utils/server').GraphQlMockResult} */
       let graphQlMocks
 
       beforeEach(async ({ page }) => {

--- a/apps/web/tests/integration/pages/account.js
+++ b/apps/web/tests/integration/pages/account.js
@@ -11,6 +11,7 @@ import {
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../utils').Locale} Locale
  */
 
 export const AccountPage = mixin(
@@ -18,12 +19,12 @@ export const AccountPage = mixin(
     /**
      * Represent the account page for testing
      * @param {Page} page - the actual page.
-     * @param {string} lang - current language.
+     * @param {Locale} lang - current language.
      */
     constructor(page, lang) {
       /** @type {string} */
       this.pageKind = 'account'
-      /** @type {string} */
+      /** @type {Locale} */
       this.lang = lang
       /** @type {Page} */
       this.page = page

--- a/apps/web/tests/integration/pages/game.js
+++ b/apps/web/tests/integration/pages/game.js
@@ -7,6 +7,7 @@ import { AsideMixin, mixin, TermsSupportedMixin } from './mixins/index.js'
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../utils').Locale} Locale
  */
 
 export const GamePage = mixin(
@@ -14,12 +15,12 @@ export const GamePage = mixin(
     /**
      * Represent the game page for testing
      * @param {Page} page - the actual page.
-     * @param {string} lang - current language.
+     * @param {Locale} lang - current language.
      */
     constructor(page, lang) {
       /** @type {string} */
       this.pageKind = 'game'
-      /** @type {string} */
+      /** @type {Locale} */
       this.lang = lang
       /** @type {Page} */
       this.page = page

--- a/apps/web/tests/integration/pages/home.js
+++ b/apps/web/tests/integration/pages/home.js
@@ -14,6 +14,7 @@ import {
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../utils').Locale} Locale
  */
 
 export const HomePage = mixin(
@@ -21,12 +22,12 @@ export const HomePage = mixin(
     /**
      * Represent the home page for testing
      * @param {Page} page - the actual page.
-     * @param {string} lang - current language.
+     * @param {Locale} lang - current language.
      */
     constructor(page, lang) {
       /** @type {string} */
       this.pageKind = 'home'
-      /** @type {string} */
+      /** @type {Locale} */
       this.lang = lang
       /** @type {Page} */
       this.page = page
@@ -113,13 +114,13 @@ export const HomePage = mixin(
     /**
      * Expects several catalog items, sorted by their locale title.
      * Lobby link creation is expected first.
-     * @param {object[]} catalog - expected catalog items.
+     * @param {import('@tabulous/server/src/graphql/types').CatalogItem[]} catalog - expected catalog items.
      * @param {boolean} [withLobby=true] - whether to include link to create lobby or not.
      * @returns {Promise<void>}
      */
     async expectSortedCatalogItems(catalog, withLobby = true) {
       const names = [
-        ...catalog.map(({ locales }) => locales[this.lang].title).sort()
+        ...catalog.map(({ locales }) => locales[this.lang]?.title ?? '').sort()
       ]
       if (withLobby) {
         names.splice(

--- a/apps/web/tests/integration/pages/login.js
+++ b/apps/web/tests/integration/pages/login.js
@@ -6,18 +6,19 @@ import { translate } from '../utils/index.js'
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../utils').Locale} Locale
  */
 
 export class LoginPage {
   /**
    * Represent the login page for testing.
    * @param {Page} page - the actual page.
-   * @param {string} lang - current language.
+   * @param {Locale} lang - current language.
    */
   constructor(page, lang) {
     /** @type {string} */
     this.pageKind = 'login'
-    /** @type {string} */
+    /** @type {Locale} */
     this.lang = lang
     /** @type {Page} */
     this.page = page

--- a/apps/web/tests/integration/pages/mixins/aside.js
+++ b/apps/web/tests/integration/pages/mixins/aside.js
@@ -5,11 +5,16 @@ import { expect } from '../../utils/index.js'
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../../utils').Locale} Locale
  */
 
 export class AsideMixin {
+  /**
+   * @param {Page} page - the actual page.
+   * @param {Locale} lang - current language.
+   */
   constructor(page, lang) {
-    /** @type {string} */
+    /** @type {Locale} */
     this.lang = lang
     /** @type {Page} */
     this.page = page
@@ -61,13 +66,13 @@ export class AsideMixin {
 
   /**
    * Expects several friends. It tests request/proposal state.
-   * @param {object[]} friends - expected friends objects.
+   * @param {import('@tabulous/server/src/graphql/types').Friendship[]} friends - expected friends objects.
    * @returns {Promise<void>}
    */
   async expectFriends(friends) {
-    for (const [i, friendItem] of Object.entries(
-      await this.friendItems.all()
-    )) {
+    for (const [i, friendItem] of [
+      ...(await this.friendItems.all())
+    ].entries()) {
       const { player, isRequest, isProposal } = friends[i]
       const label = isRequest
         ? translate('labels.friendship-requested', player, this.lang)
@@ -83,13 +88,13 @@ export class AsideMixin {
 
   /**
    * Expects several players/attendees.
-   * @param {object[]} players - expected players objects.
+   * @param {import('@tabulous/server/src/graphql/types').Player[]} players - expected players objects.
    * @returns {Promise<void>}
    */
   async expectPlayers(players) {
-    for (const [i, playerItem] of Object.entries(
-      await this.playerItems.all()
-    )) {
+    for (const [i, playerItem] of [
+      ...(await this.playerItems.all())
+    ].entries()) {
       const player = players[i]
       expect(
         await playerItem.locator('span').first().textContent(),

--- a/apps/web/tests/integration/pages/mixins/authenticated-header.js
+++ b/apps/web/tests/integration/pages/mixins/authenticated-header.js
@@ -4,11 +4,16 @@ import { translate } from '../../utils/index.js'
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../../utils').Locale} Locale
  */
 
 export class AuthenticatedHeaderMixin {
+  /**
+   * @param {Page} page - the actual page.
+   * @param {Locale} lang - current language.
+   */
   constructor(page, lang) {
-    /** @type {string} */
+    /** @type {Locale} */
     this.lang = lang
     /** @type {Page} */
     this.page = page

--- a/apps/web/tests/integration/pages/mixins/index.js
+++ b/apps/web/tests/integration/pages/mixins/index.js
@@ -5,11 +5,12 @@ export { TermsSupportedMixin } from './terms-supported.js'
 
 /**
  * @typedef {import('@playwright/test').Page} Page
+ * @typedef {import('../../utils').Locale} Locale
  */
 
 /**
  * @template T
- * @typedef {{ new(page: Page, lang: string): T}} Constructor
+ * @typedef {{ new(page: Page, lang: Locale): T}} Constructor
  */
 
 /**
@@ -31,6 +32,10 @@ export { TermsSupportedMixin } from './terms-supported.js'
 export function mixin(BaseConstructor, ...Mixins) {
   // @ts-ignore because TypeScript does not like constructor to have a generic parameter
   class Augmented extends BaseConstructor {
+    /**
+     * @param {Page} page - the actual page.
+     * @param {Locale} lang - current language.
+     */
     constructor(page, lang) {
       super(page, lang)
       for (const Mixin of Mixins) {

--- a/apps/web/tests/integration/pages/mixins/terms-supported.js
+++ b/apps/web/tests/integration/pages/mixins/terms-supported.js
@@ -4,11 +4,16 @@ import { expect, translate } from '../../utils/index.js'
 /**
  * @typedef {import('@playwright/test').Page} Page
  * @typedef {import('@playwright/test').Locator} Locator
+ * @typedef {import('../../utils').Locale} Locale
  */
 
 export class TermsSupportedMixin {
+  /**
+   * @param {Page} page - the actual page.
+   * @param {Locale} lang - current language.
+   */
   constructor(page, lang) {
-    /** @type {string} */
+    /** @type {Locale} */
     this.lang = lang
     /** @type {Page} */
     this.page = page

--- a/apps/web/tests/integration/utils/index.js
+++ b/apps/web/tests/integration/utils/index.js
@@ -1,4 +1,5 @@
 // @ts-check
+/** @typedef {'en'|'fr'} Locale */
 export * from './labels.js'
 export * from './playwright.js'
 export * from './server.js'

--- a/apps/web/tests/integration/utils/labels.js
+++ b/apps/web/tests/integration/utils/labels.js
@@ -1,3 +1,4 @@
+// @ts-check
 import formatMessage from 'format-message'
 import { readFileSync } from 'fs'
 import * as yaml from 'js-yaml'
@@ -19,11 +20,12 @@ function loadLocales() {
   })
 }
 
-function readLocale(relativePath) {
+function readLocale(/** @type {string} */ relativePath) {
   return flatten(yaml.load(readFileSync(join(__dirname, relativePath))))
 }
 
-function flatten(obj) {
+function flatten(/** @type {Record<string, ?>} */ obj) {
+  /** @type {Record<string, ?>} */
   const result = {}
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === 'object') {

--- a/apps/web/tests/integration/utils/playwright.js
+++ b/apps/web/tests/integration/utils/playwright.js
@@ -9,6 +9,7 @@ import {
 
 export const it = test.extend({
   coverageMap: [
+    // @ts-expect-error
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       const coverageMap = await initializeCoverage()
@@ -18,12 +19,12 @@ export const it = test.extend({
     { scope: 'worker' }
   ],
 
-  // @ts-ignore
+  // @ts-expect-error
   page: async ({ browserName, page, coverageMap }, use) => {
     if (browserName !== 'chromium') {
       console.log(`coverage is not supported on ${browserName}`)
     } else {
-      const handleConsole = (...args) => {
+      const handleConsole = (/** @type {...?} */ ...args) => {
         console.log(...args)
       }
       page.on('console', handleConsole)
@@ -31,6 +32,7 @@ export const it = test.extend({
       await page.coverage.startJSCoverage()
       await use(page)
       page.removeListener('console', handleConsole)
+      // @ts-expect-error
       await extendCoverage(coverageMap, await page.coverage.stopJSCoverage())
     }
   }

--- a/apps/web/tests/matchers.js
+++ b/apps/web/tests/matchers.js
@@ -1,3 +1,16 @@
+// @ts-check
+/**
+ * @typedef {import('@vitest/expect').MatcherState} MatcherState
+ * @typedef {import('@vitest/expect').SyncExpectationResult} SyncExpectationResult
+ */
+
+/**
+ * @template {{ angle: number }} E
+ * @this {MatcherState}
+ * @param {?} actual
+ * @param {E} expected
+ * @returns {SyncExpectationResult}
+ */
 export function toEqualWithAngle(actual, expected) {
   const decimals = 10
   const actualHasAngle = typeof actual === 'object' && 'angle' in actual
@@ -7,7 +20,7 @@ export function toEqualWithAngle(actual, expected) {
     const { angle: actualAngle, ...otherActual } = actual
     const { angle: expectedAngle, ...otherExpected } = expected
     pass =
-      this.equals(otherActual, otherExpected, this.customTesters) &&
+      this.equals(otherActual, otherExpected) &&
       actualAngle.toFixed(decimals) === expectedAngle.toFixed(decimals)
   }
   return {

--- a/apps/web/tests/params/lang.test.js
+++ b/apps/web/tests/params/lang.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { match } from '@src/params/lang'
 import { describe, expect, it } from 'vitest'
 
@@ -15,6 +16,6 @@ describe('lang route parameter validator', () => {
     },
     { value: 'pt', title: 'rejects unsupported language', result: false }
   ])('$title', ({ value, result }) => {
-    expect(match(value)).toBe(result)
+    expect(match(/** @type {string} */ (value))).toBe(result)
   })
 })

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/account/+page.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/account/+page.test.js
@@ -1,7 +1,17 @@
+// @ts-check
+/**
+ * @typedef {import('@src/common').Locale} Locale
+ * @typedef {import('@src/graphql').PlayerWithSearchable}  PlayerWithSearchable
+ */
+/**
+ * @template {any[]} P, R
+ * @typedef {import('vitest').Mock<P, R>} Mock
+ */
+
 import { faker } from '@faker-js/faker'
 import { initLocale } from '@src/common'
 import AccountPage from '@src/routes/[[lang=lang]]/(auth)/account/+page.svelte'
-import { updateCurrentPlayer } from '@src/stores'
+import { updateCurrentPlayer as originalUpdateCurrentPlayer } from '@src/stores'
 import { fireEvent, render, screen, within } from '@testing-library/svelte'
 import userEvent from '@testing-library/user-event'
 import { sleep, translate } from '@tests/test-utils'
@@ -12,10 +22,17 @@ import { invalidate } from '$app/navigation'
 
 vi.mock('@src/stores')
 
-describe.each([
-  { title: '/', lang: undefined },
-  { title: '/en', lang: 'en' }
-])('$title', ({ lang }) => {
+const updateCurrentPlayer =
+  /** @type {Mock<[String, string], Promise<PlayerWithSearchable>>} */ (
+    originalUpdateCurrentPlayer
+  )
+
+describe.each(
+  /** @type {{title: string, lang: Locale|undefined}[]} */ ([
+    { title: '/', lang: undefined },
+    { title: '/en', lang: 'en' }
+  ])
+)('$title', ({ lang }) => {
   describe('/account route', () => {
     const player = {
       id: faker.string.uuid(),
@@ -23,9 +40,13 @@ describe.each([
       username: 'Batman'
     }
 
-    beforeAll(() => initLocale(lang))
+    beforeAll(() => {
+      initLocale(lang)
+    })
 
-    beforeEach(vi.resetAllMocks)
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
 
     it('debounce input and saves username', async () => {
       const username = 'Robin'

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/FPSViewer.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/FPSViewer.test.js
@@ -1,6 +1,12 @@
+// @ts-check
+/**
+ * @template T
+ * @typedef {import('rxjs').BehaviorSubject<T>} BehaviorSubject
+ */
+
 import { faker } from '@faker-js/faker'
 import FPSViewer from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/FPSViewer.svelte'
-import { fps } from '@src/stores/game-engine'
+import { fps as actualFps } from '@src/stores/game-engine'
 import { render, screen } from '@testing-library/svelte'
 import { translate } from '@tests/test-utils'
 import { tick } from 'svelte'
@@ -9,27 +15,33 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@src/stores/game-engine', async () => {
   const { BehaviorSubject, Subject } = require('rxjs')
-  const gameEngine = await vi.importActual('@src/stores/game-engine')
+  const gameEngine = /** @type {Record<string, ?>} */ (
+    await vi.importActual('@src/stores/game-engine')
+  )
   return {
     ...gameEngine,
-    fps: new BehaviorSubject(),
-    engine: new BehaviorSubject(),
+    fps: new BehaviorSubject(undefined),
+    engine: new BehaviorSubject(undefined),
     action: new Subject()
   }
 })
 
+const fps = /** @type {BehaviorSubject<string>} */ (actualFps)
+
 describe('FPSViewer connected component', () => {
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   it('displays current frame per seconds', async () => {
-    const fps1 = faker.number.int(999)
+    const fps1 = `${faker.number.int(999)}`
     fps.next(fps1)
     render(html`<${FPSViewer} />`)
     expect(
       screen.getByText(translate('fps _', { value: fps1 }))
     ).toBeInTheDocument()
 
-    const fps2 = faker.number.int(999)
+    const fps2 = `${faker.number.int(999)}`
     fps.next(fps2)
     await tick()
     expect(

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/GameMenu.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/GameMenu.test.js
@@ -1,6 +1,16 @@
+// @ts-check
+/**
+ * @template T
+ * @typedef {import('rxjs').BehaviorSubject<T>} BehaviorSubject
+ */
+/**
+ * @template {any[]}  P, R
+ * @typedef {import('vitest').Mock<P, R>} Mock
+ */
+
 import GameMenu from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/GameMenu.svelte'
-import { isFullscreen, toggleFullscreen } from '@src/stores'
-import { areIndicatorsVisible, toggleIndicators } from '@src/stores/indicators'
+import * as stores from '@src/stores'
+import * as indicators from '@src/stores/indicators'
 import { fireEvent, render, screen } from '@testing-library/svelte'
 import { translate } from '@tests/test-utils'
 import { tick } from 'svelte'
@@ -23,6 +33,15 @@ vi.mock('@src/stores/indicators', () => {
     toggleIndicators: vi.fn()
   }
 })
+
+const isFullscreen = /** @type {BehaviorSubject<boolean>} */ (
+  stores.isFullscreen
+)
+const areIndicatorsVisible = /** @type {BehaviorSubject<boolean>} */ (
+  indicators.areIndicatorsVisible
+)
+const toggleFullscreen = /** @type {Mock<?, ?>} */ (stores.toggleFullscreen)
+const toggleIndicators = /** @type {Mock<?, ?>} */ (indicators.toggleIndicators)
 
 describe('GameMenu connected component', () => {
   beforeEach(() => {
@@ -101,31 +120,41 @@ describe('GameMenu connected component', () => {
 })
 
 function selectHomeOption() {
-  return screen.queryByRole('menuitem', {
-    name: `home ${translate('actions.quit-game')}`
-  })
+  return /** @type {HTMLLIElement} */ (
+    screen.queryByRole('menuitem', {
+      name: `home ${translate('actions.quit-game')}`
+    })
+  )
 }
 
 function selectEnterFullscreenOption() {
-  return screen.queryByRole('menuitem', {
-    name: `fullscreen ${translate('actions.enter-fullscreen')}`
-  })
+  return /** @type {HTMLLIElement} */ (
+    screen.queryByRole('menuitem', {
+      name: `fullscreen ${translate('actions.enter-fullscreen')}`
+    })
+  )
 }
 
 function selectExitFullscreenOption() {
-  return screen.queryByRole('menuitem', {
-    name: `fullscreen_exit ${translate('actions.leave-fullscreen')}`
-  })
+  return /** @type {HTMLLIElement} */ (
+    screen.queryByRole('menuitem', {
+      name: `fullscreen_exit ${translate('actions.leave-fullscreen')}`
+    })
+  )
 }
 
 function selectHideIndicatorsOption() {
-  return screen.queryByRole('menuitem', {
-    name: `label_off ${translate('actions.hide-indicators')}`
-  })
+  return /** @type {HTMLLIElement} */ (
+    screen.queryByRole('menuitem', {
+      name: `label_off ${translate('actions.hide-indicators')}`
+    })
+  )
 }
 
 function selectShowIndicatorsOption() {
-  return screen.queryByRole('menuitem', {
-    name: `label ${translate('actions.show-indicators')}`
-  })
+  return /** @type {HTMLLIElement} */ (
+    screen.queryByRole('menuitem', {
+      name: `label ${translate('actions.show-indicators')}`
+    })
+  )
 }

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/MeshDetails.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/MeshDetails.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import MeshDetails from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/MeshDetails.svelte'
 import { gameAssetsUrl, sleep } from '@src/utils'
 import { fireEvent, render, screen } from '@testing-library/svelte'
@@ -21,7 +22,9 @@ describe('/game/[gameId] MeshDetails component', () => {
     )
   }
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   it('displays a mesh image', async () => {
     renderComponent({ mesh: mesh1 })
@@ -33,6 +36,7 @@ describe('/game/[gameId] MeshDetails component', () => {
   })
 
   describe('given being open', () => {
+    /** @type {HTMLImageElement} */
     let image
 
     beforeEach(() => {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/Container.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/Container.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {Partial<import('@tabulous/server/src/utils').Schema>} Schema
+ */
+
 import Parameters from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/Container.svelte'
 import { fireEvent, render, screen } from '@testing-library/svelte'
 import { extractText, sleep, translate } from '@tests/test-utils'
@@ -7,10 +12,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 describe('Parameters component', () => {
   const handleSubmit = vi.fn()
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
-  async function renderComponent(schema) {
-    function onSubmit({ detail }) {
+  async function renderComponent(/** @type {Schema} */ schema) {
+    function onSubmit(/** @type {CustomEvent<?>} */ { detail }) {
       handleSubmit(detail)
     }
     const result = render(
@@ -242,7 +249,7 @@ describe('Parameters component', () => {
 
     let dropdowns = screen.getAllByRole('combobox')
     expect(dropdowns).toHaveLength(2)
-    expect(dropdowns[0]).toHaveTextContent(counts[0])
+    expect(dropdowns[0]).toHaveTextContent(counts[0].toString())
     expect(dropdowns[1]).toHaveTextContent(characters[0])
 
     await fireEvent.click(dropdowns[0])
@@ -251,7 +258,7 @@ describe('Parameters component', () => {
 
     dropdowns = screen.getAllByRole('combobox')
     expect(dropdowns).toHaveLength(3)
-    expect(dropdowns[0]).toHaveTextContent(counts[1])
+    expect(dropdowns[0]).toHaveTextContent(counts[1].toString())
     expect(dropdowns[1]).toHaveTextContent(characters[0])
     expect(dropdowns[2]).toHaveTextContent(characters[1])
 

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/utils.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/utils.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { findViolations } from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/Parameters/utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -1105,7 +1106,9 @@ describe('Parameters findViolations() utility', () => {
       properties: { color: { enum: ['green', 'blue'] } }
     }
 
-    beforeEach(vi.resetAllMocks)
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
 
     it('invokes enrichProps on valid then', () => {
       expect(

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/RadialMenu.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/RadialMenu.test.js
@@ -1,10 +1,13 @@
+// @ts-check
 import RadialMenu from '@src/routes/[[lang=lang]]/(auth)/game/[gameId]/RadialMenu.svelte'
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('/game/[gameId] Radial Menu component', () => {
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   function renderComponent(props = {}) {
     return render(html`<${RadialMenu} open=${true} ...${props} />`)

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/__snapshots__/Parameters.tools.shot
@@ -35,7 +35,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="side"
             role="combobox"
           >
@@ -92,7 +92,7 @@ exports[`Multiple choices 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="position"
             role="combobox"
           >
@@ -202,7 +202,7 @@ exports[`Single choice 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
-            class="s-NMyTiX1zi6rz has-text"
+            class="has-text s-NMyTiX1zi6rz"
             id="side"
             role="combobox"
           >

--- a/apps/web/tests/routes/[[lang=lang]]/+layout.server.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/+layout.server.test.js
@@ -1,0 +1,72 @@
+// @ts-check
+import { faker } from '@faker-js/faker'
+import { load } from '@src/routes/[[lang=lang]]/+layout.server'
+import { redirect } from '@sveltejs/kit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe.each([
+  { title: '/', lang: undefined, urlRoot: '' },
+  { title: '/en', lang: 'en', urlRoot: '/en' }
+])('$title', ({ lang, urlRoot }) => {
+  const depends = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('layout server loader', () => {
+    describe('given first connection', () => {
+      const session = {
+        player: {
+          id: faker.number.int(999).toString(),
+          username: faker.person.fullName()
+        }
+      }
+
+      it('does not redirect when accessing terms', () => {
+        expect(
+          load(
+            /** @type {?} */ ({
+              url: new URL(`${urlRoot}/accept-terms`, 'https://example.org'),
+              locals: { bearer: null, timeZone: 'GMT', session },
+              params: { lang },
+              depends
+            })
+          )
+        ).toEqual({
+          lang,
+          session,
+          bearer: null,
+          timeZone: 'GMT'
+        })
+        expect(depends).toHaveBeenCalledWith('data:session')
+      })
+
+      describe.each([{ location: `/` }, { location: `${urlRoot}/home` }])(
+        'when accessing $location',
+        ({ location }) => {
+          it('redirects to terms', async () => {
+            await expect(async () =>
+              load(
+                /** @type {?} */ ({
+                  url: new URL(location, 'https://example.org'),
+                  locals: { session },
+                  params: { lang },
+                  depends
+                })
+              )
+            ).rejects.toEqual(
+              redirect(
+                307,
+                `${urlRoot}/accept-terms?redirect=${encodeURIComponent(
+                  location
+                )}`
+              )
+            )
+            expect(depends).not.toHaveBeenCalled()
+          })
+        }
+      )
+    })
+  })
+})

--- a/apps/web/tests/routes/[[lang=lang]]/+page.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/+page.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { load } from '@src/routes/[[lang=lang]]/+page'
 import { redirect } from '@sveltejs/kit'
 import { describe, expect, it } from 'vitest'
@@ -9,7 +10,7 @@ describe.each([
   describe('/ route server loader', () => {
     it('always redirects to home page', async () => {
       try {
-        load({ params: { lang } })
+        load(/** @type {?} */ ({ params: { lang } }))
         throw new Error('should have thrown')
       } catch (err) {
         expect(err).toEqual(redirect(307, `${urlRoot}/home`))

--- a/apps/web/tests/routes/[[lang=lang]]/accept-terms/+page.tools.svelte
+++ b/apps/web/tests/routes/[[lang=lang]]/accept-terms/+page.tools.svelte
@@ -8,6 +8,7 @@
   component={AcceptTermsPage}
   name="Routes/accept-terms"
   setup={() => setSvelteUrl('/accept-terms')}
+  props={{ data: {} }}
 >
   <Tool name="Default" />
 </ToolBox>

--- a/apps/web/tests/routes/[[lang=lang]]/home/CatalogItem.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/home/CatalogItem.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import CatalogItem from '@src/routes/[[lang=lang]]/home/CatalogItem.svelte'
 import { gameAssetsUrl } from '@src/utils'
 import { fireEvent, render, screen } from '@testing-library/svelte'
@@ -9,9 +10,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 describe('/home CatalogItem component', () => {
   const handleSelect = vi.fn()
 
-  beforeEach(vi.clearAllMocks)
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
-  afterEach(() => locale.set('fr'))
+  afterEach(() => {
+    locale.set('fr')
+  })
 
   function renderComponent(props = {}) {
     return render(

--- a/apps/web/tests/routes/[[lang=lang]]/home/__snapshots__/+page.tools.shot
+++ b/apps/web/tests/routes/[[lang=lang]]/home/__snapshots__/+page.tools.shot
@@ -1358,6 +1358,7 @@ exports[`Authenticated 1`] = `
                 class="s-2FHiERVIQQ6s"
               >
                 <span
+                  aria-expanded="true"
                   aria-haspopup="menu"
                   class="wrapper s-JM3fRWrV7jJU"
                 >

--- a/apps/web/tests/routes/[[lang=lang]]/login/+page.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/login/+page.test.js
@@ -1,20 +1,32 @@
+// @ts-check
+/** @typedef {import('@src/common').Locale} Locale */
+/**
+ * @template T
+ * @typedef {import('rxjs').BehaviorSubject<T>} BehaviorSubject
+ */
+
 import { initLocale } from '@src/common'
 import LoginPage from '@src/routes/[[lang=lang]]/login/+page.svelte'
 import { render } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { page } from '$app/stores'
+import * as stores from '$app/stores'
 
 vi.mock('$app/stores', () => {
   const { BehaviorSubject } = require('rxjs')
-  return { page: new BehaviorSubject() }
+  return { page: new BehaviorSubject(undefined) }
 })
 
-describe.each([
-  { title: '/', lang: undefined, urlRoot: '' },
-  { title: '/en', lang: 'en', urlRoot: '/en' }
-])('$title', ({ lang, urlRoot }) => {
+/** @type {BehaviorSubject<{ url: URL, route: Object, params: { lang: Locale|undefined }}>} */
+const page = /** @type {?} */ (stores.page)
+
+describe.each(
+  /** @type {{ title: String, lang: Locale|undefined, urlRoot: string }[]} */ ([
+    { title: '/', lang: undefined, urlRoot: '' },
+    { title: '/en', lang: 'en', urlRoot: '/en' }
+  ])
+)('$title', ({ lang, urlRoot }) => {
   beforeAll(() => {
     page.next({
       url: new URL(`http://localhost/${urlRoot}/login`),

--- a/apps/web/tests/routes/[[lang=lang]]/login/Form.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/login/Form.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { faker } from '@faker-js/faker'
 import Form from '@src/routes/[[lang=lang]]/login/Form.svelte'
 import { authUrl } from '@src/utils'
@@ -32,8 +33,8 @@ describe('Login Form component', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    id$.set()
-    password$.set()
+    id$.set(undefined)
+    password$.set(undefined)
   })
 
   afterAll(() => {

--- a/apps/web/tests/routes/[[lang=lang]]/terms-of-service/+page.tools.svelte
+++ b/apps/web/tests/routes/[[lang=lang]]/terms-of-service/+page.tools.svelte
@@ -10,6 +10,7 @@
   component={TermsOfServicePage}
   name="Routes/terms-of-service"
   setup={() => setSvelteUrl('/terms-of-service')}
+  props={{ data: { session: null } }}
 >
   <Tool name="Anonymous" />
   <Tool

--- a/apps/web/tests/stores/catalog.test.js
+++ b/apps/web/tests/stores/catalog.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('../test-utils').RunQueryMock} RunQueryMock
+ */
+
 import * as graphQL from '@src/graphql'
 import { listCatalog } from '@src/stores/catalog'
 import { runQuery } from '@src/stores/graphql-client'
@@ -5,6 +10,8 @@ import { locale } from 'svelte-intl'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@src/stores/graphql-client')
+
+const runQueryMock = /** @type {RunQueryMock} */ (runQuery)
 
 describe('listCatalog()', () => {
   const catalog = [
@@ -22,21 +29,25 @@ describe('listCatalog()', () => {
     }
   ]
 
-  beforeEach(() => vi.clearAllMocks())
-  afterEach(() => locale.set('fr'))
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    locale.set('fr')
+  })
 
   it('list all items of the catalog', async () => {
-    runQuery.mockResolvedValueOnce([...catalog])
+    runQueryMock.mockResolvedValueOnce([...catalog])
     expect(await listCatalog()).toEqual([catalog[1], catalog[2], catalog[0]])
-    expect(runQuery).toHaveBeenCalledWith(graphQL.listCatalog)
-    expect(runQuery).toHaveBeenCalledOnce()
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.listCatalog)
+    expect(runQueryMock).toHaveBeenCalledOnce()
   })
 
   it('sort returned items by locale title', async () => {
     locale.set('en')
-    runQuery.mockResolvedValueOnce([...catalog])
+    runQueryMock.mockResolvedValueOnce([...catalog])
     expect(await listCatalog()).toEqual([catalog[2], catalog[0], catalog[1]])
-    expect(runQuery).toHaveBeenCalledWith(graphQL.listCatalog)
-    expect(runQuery).toHaveBeenCalledOnce()
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.listCatalog)
+    expect(runQueryMock).toHaveBeenCalledOnce()
   })
 })

--- a/apps/web/tests/stores/discussion.test.js
+++ b/apps/web/tests/stores/discussion.test.js
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ * @template T
+ * @typedef {import('rxjs').Subject<T>} Subject
+ */
+/**
+ * @typedef {import('@src/stores/peer-channels').Message} Message
+ */
 import * as peerChannels from '@src/stores/peer-channels'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -7,11 +15,17 @@ vi.mock('@src/stores/peer-channels', () => {
   return {
     lastMessageReceived: new Subject(),
     lastMessageSent,
-    send: data => lastMessageSent.next({ data })
+    send: (/** @type {?} */ data) => lastMessageSent.next({ data })
   }
 })
 
+const peerChannelsMock =
+  /** @type {typeof peerChannels & { lastMessageReceived: Subject<Message>, lastMessageSent: Subject<Message> }} */ (
+    peerChannels
+  )
+
 describe('Discussion store', () => {
+  /** @type {typeof import('@src/stores/discussion')} */
   let discussion
   const playerId = '123456'
   const text1 = 'message 1'
@@ -31,7 +45,7 @@ describe('Discussion store', () => {
   it('enqueues received messages', () => {
     expect(discussion.serializeThread()).toEqual([])
     for (const text of [text1, text2, text3]) {
-      peerChannels.lastMessageReceived.next({
+      peerChannelsMock.lastMessageReceived.next({
         data: { type: 'message', text },
         playerId
       })
@@ -57,16 +71,16 @@ describe('Discussion store', () => {
 
   it('enqueues sent and received messages', () => {
     expect(discussion.serializeThread()).toEqual([])
-    peerChannels.lastMessageReceived.next({
+    peerChannelsMock.lastMessageReceived.next({
       data: { type: 'message', text: text1 },
       playerId
     })
     discussion.sendToThread(text2)
-    peerChannels.lastMessageReceived.next({
+    peerChannelsMock.lastMessageReceived.next({
       data: { type: 'message', text: text3 },
       playerId
     })
-    peerChannels.lastMessageReceived.next({
+    peerChannelsMock.lastMessageReceived.next({
       data: { type: 'message', text: text4 },
       playerId
     })
@@ -81,7 +95,7 @@ describe('Discussion store', () => {
   })
 
   it('loads messages into thread', () => {
-    peerChannels.lastMessageReceived.next({
+    peerChannelsMock.lastMessageReceived.next({
       data: { type: 'message', text: text1 },
       playerId
     })

--- a/apps/web/tests/stores/friends.test.js
+++ b/apps/web/tests/stores/friends.test.js
@@ -1,3 +1,15 @@
+// @ts-check
+/**
+ * @typedef {import('@src/graphql').Friendship} Friendship
+ * @typedef {import('../test-utils').RunQueryMock} RunQueryMock
+ * @typedef {import('../test-utils').RunMutationMock} RunMutationMock
+ * @typedef {import('../test-utils').RunSubscriptionMock} RunSubscriptionMock
+ */
+/**
+ * @template T
+ * @typedef {import('rxjs').Observable<T>} Observable
+ */
+
 import { faker } from '@faker-js/faker'
 import * as graphQL from '@src/graphql'
 import {
@@ -20,40 +32,46 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('@src/stores/graphql-client')
 vi.mock('@src/stores/notifications')
 
+const runQueryMock = /** @type {RunQueryMock} */ (runQuery)
+const runMutationMock = /** @type {RunMutationMock} */ (runMutation)
+const runSubscriptionMock = /** @type {RunSubscriptionMock} */ (runSubscription)
+
 const player = {
   id: faker.string.uuid(),
   username: faker.person.firstName()
 }
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('requestFriendship()', () => {
   it('sends mutation for a given player', async () => {
     expect(await requestFriendship(player)).toBeUndefined()
-    expect(runMutation).toHaveBeenCalledWith(graphQL.requestFriendship, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.requestFriendship, {
       id: player.id
     })
-    expect(runMutation).toHaveBeenCalledOnce()
+    expect(runMutationMock).toHaveBeenCalledOnce()
   })
 })
 
 describe('acceptFriendship()', () => {
   it('sends mutation for a given player', async () => {
     expect(await acceptFriendship(player)).toBeUndefined()
-    expect(runMutation).toHaveBeenCalledWith(graphQL.acceptFriendship, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.acceptFriendship, {
       id: player.id
     })
-    expect(runMutation).toHaveBeenCalledOnce()
+    expect(runMutationMock).toHaveBeenCalledOnce()
   })
 })
 
 describe('endFriendship()', () => {
   it('sends mutation for a given player', async () => {
     expect(await endFriendship(player)).toBeUndefined()
-    expect(runMutation).toHaveBeenCalledWith(graphQL.endFriendship, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.endFriendship, {
       id: player.id
     })
-    expect(runMutation).toHaveBeenCalledOnce()
+    expect(runMutationMock).toHaveBeenCalledOnce()
   })
 })
 
@@ -67,8 +85,8 @@ describe('listFriends()', () => {
   ]
 
   it('list sorted friends, requests and proposals', async () => {
-    runQuery.mockResolvedValueOnce([...friendships])
-    runSubscription.mockReturnValueOnce(new Subject())
+    runQueryMock.mockResolvedValueOnce([...friendships])
+    runSubscriptionMock.mockReturnValueOnce(new Subject())
     const list$ = listFriends()
     expect(get(list$)).toEqual([])
 
@@ -80,18 +98,19 @@ describe('listFriends()', () => {
       friendships[3]
     ])
 
-    expect(runQuery).toHaveBeenCalledWith(graphQL.listFriends, {}, false)
-    expect(runQuery).toHaveBeenCalledOnce()
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.listFriends, {}, false)
+    expect(runQueryMock).toHaveBeenCalledOnce()
     expect(notify).not.toHaveBeenCalled()
   })
 
   describe('given a list of friends', () => {
+    /** @type {Observable<Friendship[]>} */
     let list$
     const updates = new Subject()
 
     beforeEach(async () => {
-      runQuery.mockResolvedValueOnce([...friendships])
-      runSubscription.mockReturnValueOnce(updates)
+      runQueryMock.mockResolvedValueOnce([...friendships])
+      runSubscriptionMock.mockReturnValueOnce(updates)
       list$ = listFriends()
       await waitForObservable(list$)
     })

--- a/apps/web/tests/stores/locale.test.js
+++ b/apps/web/tests/stores/locale.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { buildLocaleComparator, comparator$ } from '@src/stores/locale'
 import { shuffle } from '@src/utils'
 import { get } from 'svelte/store'
@@ -5,7 +6,9 @@ import { locale } from 'svelte-intl'
 import { afterEach, describe, expect, it } from 'vitest'
 
 describe('comparator$', () => {
-  afterEach(() => locale.set('fr'))
+  afterEach(() => {
+    locale.set('fr')
+  })
 
   it('is initialized with default locale', async () => {
     expect(get(comparator$).resolvedOptions()).toMatchObject({

--- a/apps/web/tests/stores/notifications.test.js
+++ b/apps/web/tests/stores/notifications.test.js
@@ -1,17 +1,27 @@
+// @ts-check
 import { notify } from '@src/stores/notifications'
 import { translate } from '@tests/test-utils.js'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/** @typedef {typeof Notification & { permission: string } & import('vitest').Mock<?, ?>} NotificationMock */
 
 describe('Notification store notify()', () => {
   const requestPermission = vi.fn()
   const focus = vi.spyOn(window, 'focus')
 
+  /** @type {NotificationMock} */
+  let NotificationMock
+
   beforeAll(() => {
+    // @ts-expect-error not mocking the whole class
     window.Notification = vi.fn()
     Notification.requestPermission = requestPermission
+    NotificationMock = /** @type {NotificationMock} */ (Notification)
   })
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   describe('given visible window', () => {
     beforeEach(() => {
@@ -24,7 +34,7 @@ describe('Notification store notify()', () => {
 
     it('does nothing', async () => {
       await notify({ contentKey: 'labels.home' })
-      expect(Notification).not.toHaveBeenCalled()
+      expect(NotificationMock).not.toHaveBeenCalled()
       expect(requestPermission).not.toHaveBeenCalled()
     })
   })
@@ -39,56 +49,56 @@ describe('Notification store notify()', () => {
     })
 
     it('requests user permission and displays notification when granted', async () => {
-      Notification.permission = 'default'
+      NotificationMock.permission = 'default'
       requestPermission.mockImplementation(async () => {
-        Notification.permission = 'granted'
+        NotificationMock.permission = 'granted'
       })
       const contentKey = 'labels.home'
       await notify({ contentKey })
       expect(requestPermission).toHaveBeenCalledOnce()
-      expect(Notification).toHaveBeenCalledWith(translate(contentKey), {
+      expect(NotificationMock).toHaveBeenCalledWith(translate(contentKey), {
         requireInteraction: true
       })
-      expect(Notification).toHaveBeenCalledOnce()
+      expect(NotificationMock).toHaveBeenCalledOnce()
       expect(focus).not.toHaveBeenCalled()
     })
 
     it('requests user permission and stops when denied', async () => {
-      Notification.permission = 'default'
+      NotificationMock.permission = 'default'
       requestPermission.mockImplementation(async () => {
-        Notification.permission = 'denied'
+        NotificationMock.permission = 'denied'
       })
       await notify({ contentKey: 'labels.home' })
       expect(requestPermission).toHaveBeenCalledOnce()
-      expect(Notification).not.toHaveBeenCalled()
+      expect(NotificationMock).not.toHaveBeenCalled()
       expect(focus).not.toHaveBeenCalled()
     })
 
     it('displays notification when granted already', async () => {
-      Notification.permission = 'granted'
+      NotificationMock.permission = 'granted'
       const contentKey = 'labels.home'
       await notify({ contentKey })
-      expect(Notification).toHaveBeenCalledWith(translate(contentKey), {
+      expect(NotificationMock).toHaveBeenCalledWith(translate(contentKey), {
         requireInteraction: true
       })
-      expect(Notification).toHaveBeenCalledOnce()
+      expect(NotificationMock).toHaveBeenCalledOnce()
       expect(requestPermission).not.toHaveBeenCalled()
       expect(focus).not.toHaveBeenCalled()
     })
 
     it('focuses window when clicking on notification', async () => {
-      Notification.permission = 'granted'
+      NotificationMock.permission = 'granted'
       await notify({ contentKey: 'labels.home' })
-      expect(Notification).toHaveBeenCalledOnce()
+      expect(NotificationMock).toHaveBeenCalledOnce()
       expect(requestPermission).not.toHaveBeenCalled()
-      Notification.mock.instances[0].onclick()
+      NotificationMock.mock.instances[0].onclick()
       expect(focus).toHaveBeenCalledOnce()
     })
 
     it('does nothing when denied already', async () => {
-      Notification.permission = 'denied'
+      NotificationMock.permission = 'denied'
       await notify({ contentKey: 'labels.home' })
-      expect(Notification).not.toHaveBeenCalled()
+      expect(NotificationMock).not.toHaveBeenCalled()
       expect(requestPermission).not.toHaveBeenCalled()
       expect(focus).not.toHaveBeenCalled()
     })

--- a/apps/web/tests/stores/players.test.js
+++ b/apps/web/tests/stores/players.test.js
@@ -1,3 +1,14 @@
+// @ts-check
+/**
+ * @typedef {import('@src/graphql').Friendship} Friendship
+ * @typedef {import('../test-utils').RunQueryMock} RunQueryMock
+ * @typedef {import('../test-utils').RunMutationMock} RunMutationMock
+ */
+/**
+ * @template T
+ * @typedef {import('rxjs').Observable<T>} Observable
+ */
+
 import { faker } from '@faker-js/faker'
 import * as graphQL from '@src/graphql'
 import {
@@ -20,6 +31,9 @@ import { goto } from '$app/navigation'
 
 vi.mock('@src/stores/graphql-client')
 
+const runQueryMock = /** @type {RunQueryMock} */ (runQuery)
+const runMutationMock = /** @type {RunMutationMock} */ (runMutation)
+
 const id = faker.string.uuid()
 const username = faker.person.firstName()
 const password = faker.internet.password()
@@ -30,41 +44,43 @@ const turnCredentials = {
 }
 const token = faker.string.uuid()
 
-beforeEach(vi.resetAllMocks)
+beforeEach(() => {
+  vi.resetAllMocks()
+})
 
 describe('searchPlayers()', () => {
   it('search players by user name', async () => {
     const username = faker.person.firstName()
     expect(await searchPlayers(username)).toBeUndefined()
-    expect(runQuery).toHaveBeenCalledWith(graphQL.searchPlayers, {
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.searchPlayers, {
       search: username
     })
-    expect(runQuery).toHaveBeenCalledTimes(1)
+    expect(runQueryMock).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('logIn()', () => {
   it('returns session on success', async () => {
     const session = { token, player, turnCredentials }
-    runMutation.mockResolvedValueOnce(session)
+    runMutationMock.mockResolvedValueOnce(session)
     expect(await logIn(id, password)).toEqual(session)
-    expect(runMutation).toHaveBeenCalledWith(graphQL.logIn, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.logIn, {
       id,
       password
     })
-    expect(runMutation).toHaveBeenCalledTimes(1)
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
     expect(goto).not.toHaveBeenCalled()
   })
 
   it('throws on failure', async () => {
     const error = new Error('forbidden')
-    runMutation.mockRejectedValueOnce(error)
+    runMutationMock.mockRejectedValueOnce(error)
     await expect(logIn(id, password)).rejects.toThrow(error)
-    expect(runMutation).toHaveBeenCalledWith(graphQL.logIn, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.logIn, {
       id,
       password
     })
-    expect(runMutation).toHaveBeenCalledTimes(1)
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
     expect(goto).not.toHaveBeenCalled()
   })
 })
@@ -80,10 +96,10 @@ describe('logOut()', () => {
 describe('recoverSession()', () => {
   it('returns null on invalid session', async () => {
     const bearer = faker.string.uuid()
-    runQuery.mockRejectedValueOnce(new Error('forbidden'))
+    runQueryMock.mockRejectedValueOnce(new Error('forbidden'))
     expect(await recoverSession(fetch, bearer)).toBeNull()
-    expect(runQuery).toHaveBeenCalledWith(graphQL.getCurrentPlayer)
-    expect(runQuery).toHaveBeenCalledTimes(1)
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.getCurrentPlayer)
+    expect(runQueryMock).toHaveBeenCalledTimes(1)
     expect(initGraphQlClient).toHaveBeenCalledWith({
       graphQlUrl,
       fetch,
@@ -97,10 +113,10 @@ describe('recoverSession()', () => {
   it('returns session on success', async () => {
     const bearer = faker.string.uuid()
     const session = { token, player, turnCredentials }
-    runQuery.mockResolvedValueOnce(session)
+    runQueryMock.mockResolvedValueOnce(session)
     expect(await recoverSession(fetch, bearer)).toEqual(session)
-    expect(runQuery).toHaveBeenCalledWith(graphQL.getCurrentPlayer)
-    expect(runQuery).toHaveBeenCalledTimes(1)
+    expect(runQueryMock).toHaveBeenCalledWith(graphQL.getCurrentPlayer)
+    expect(runQueryMock).toHaveBeenCalledTimes(1)
     expect(initGraphQlClient).toHaveBeenCalledWith({
       graphQlUrl,
       fetch,
@@ -114,10 +130,10 @@ describe('recoverSession()', () => {
 
 describe('acceptTerms()', () => {
   it('returns player on success', async () => {
-    runMutation.mockResolvedValueOnce(player)
+    runMutationMock.mockResolvedValueOnce(player)
     expect(await acceptTerms()).toEqual(player)
-    expect(runMutation).toHaveBeenCalledWith(graphQL.acceptTerms)
-    expect(runMutation).toHaveBeenCalledTimes(1)
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.acceptTerms)
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -125,12 +141,12 @@ describe('updateCurrentPlayer()', () => {
   it('returns player on success', async () => {
     const username = faker.person.fullName()
     const avatar = faker.internet.avatar()
-    runMutation.mockResolvedValueOnce(player)
+    runMutationMock.mockResolvedValueOnce(player)
     expect(await updateCurrentPlayer(username, avatar)).toEqual(player)
-    expect(runMutation).toHaveBeenCalledWith(graphQL.updateCurrentPlayer, {
+    expect(runMutationMock).toHaveBeenCalledWith(graphQL.updateCurrentPlayer, {
       username,
       avatar
     })
-    expect(runMutation).toHaveBeenCalledTimes(1)
+    expect(runMutationMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/stores/toaster.test.js
+++ b/apps/web/tests/stores/toaster.test.js
@@ -1,3 +1,8 @@
+// @ts-check
+/**
+ * @typedef {import('rxjs').Subscription} Subscription
+ */
+
 import { lastToast, toastError, toastInfo } from '@src/stores/toaster'
 import { translate } from '@tests/test-utils.js'
 import {
@@ -12,13 +17,16 @@ import {
 
 describe('Toaster store', () => {
   const messageReceived = vi.fn()
+  /** @type {Subscription} */
   let subscription
 
   beforeAll(() => {
     subscription = lastToast.subscribe(messageReceived)
   })
 
-  beforeEach(vi.resetAllMocks)
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
 
   afterAll(() => subscription.unsubscribe())
 

--- a/apps/web/tests/test-utils.js
+++ b/apps/web/tests/test-utils.js
@@ -364,8 +364,13 @@ export function expectAbsoluteRotation(mesh, angle, axis) {
 /**
  * @param {Mesh[]} meshes - list of stacked meshes, who should relate to each other as a stack.
  * @param {boolean} isLastMovable - whether the top-most mesh should be movable or not
+ * @param {string} [baseParentId] - parent mesh id for the stack base mesh (undefined by default)
  */
-export function expectStacked(meshes, isLastMovable = true) {
+export function expectStacked(
+  meshes,
+  isLastMovable = true,
+  baseParentId = undefined
+) {
   const ids = getIds(meshes.slice(1))
   for (const [rank, mesh] of meshes.entries()) {
     expect(
@@ -378,6 +383,9 @@ export function expectStacked(meshes, isLastMovable = true) {
           .stackIds,
         `state stackIds of mesh #${rank}`
       ).toEqual(ids)
+      expect(mesh.parent?.id).toEqual(baseParentId)
+    } else {
+      expect(mesh.parent?.id).toEqual(meshes[0].id)
     }
     if (rank === meshes.length - 1) {
       expectInteractible(mesh, true, isLastMovable)

--- a/apps/web/tests/test-utils.js
+++ b/apps/web/tests/test-utils.js
@@ -1,3 +1,33 @@
+//@ts-check
+/**
+ * @typedef {import('@babylonjs/core').Engine} Engine
+ * @typedef {import('@babylonjs/core').Mesh} Mesh
+ * @typedef {import('@babylonjs/core').Scene} Scene
+ * @typedef {import('@src/3d/behaviors/animatable').AnimateBehavior} AnimateBehavior
+ * @typedef {import('@src/3d/behaviors/stackable').StackBehavior} StackBehavior
+ * @typedef {import('@src/3d/behaviors/targetable').TargetBehavior} TargetBehavior
+ * @typedef {import('@src/3d/managers/indicator').MeshSizeIndicator} MeshSizeIndicator
+ * @typedef {import('@src/3d/managers/move').MoveDetails} MoveDetails
+ * @typedef {import('@src/3d/managers/target').SingleDropZone} SingleDropZone
+ * @typedef {import('@src/components').MenuOption} MenuOption
+ * @typedef {import('@src/stores/graphql-client').runMutation} RunMutation
+ * @typedef {import('@src/stores/graphql-client').runQuery} RunQuery
+ * @typedef {import('@src/stores/graphql-client').runSubscription} RunSubscription
+ * @typedef {import('@src/types').Translate} Translate
+ * @typedef {import('@src/utils').ScreenPosition} ScreenPosition
+ * @typedef {import('@tabulous/server/src/graphql/types').ActionName} ActionName
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {typeof import('@src/3d/managers/indicator').indicatorManager} IndicatorManager
+ */
+/**
+ * @template {any[]} Args, Return
+ * @typedef {import('vitest').SpyInstance<Args, Return>} SpyInstance
+ */
+/**
+ * @template T
+ * @typedef {import('rxjs').Observable<T>} Observable
+ */
+
 // mandatory side effects
 import '@babylonjs/core/Animations/animatable'
 import '@babylonjs/core/Rendering/edgesRenderer'
@@ -25,53 +55,90 @@ import { getCenterAltitudeAbove } from '@src/3d/utils/gravity'
 import { ExtendedScene } from '@src/3d/utils/scene'
 import { makeLogger } from '@src/utils/logger'
 import fastify from 'fastify'
-import { appendFileSync, rmSync } from 'fs'
 import { get } from 'svelte/store'
 import { _ } from 'svelte-intl'
-import { inspect } from 'util'
 import { afterAll, afterEach, beforeAll, expect } from 'vitest'
 import { vi } from 'vitest'
 
+/** @typedef {import('vitest').Mock<Parameters<RunQuery>, ReturnType<RunQuery>>} RunQueryMock */
+/** @typedef {import('vitest').Mock<Parameters<RunMutation>, ReturnType<RunMutation>>} RunMutationMock */
+/** @typedef {import('vitest').Mock<Parameters<RunSubscription>, ReturnType<RunSubscription>>} RunSubscriptionMock */
+
+/**
+ * Mocks a logger to silent its input (except errors)
+ * @param {string} name - mocked logger name.
+ * @returns {import('vitest').MockedObject<import('@src/utils').Logger>} a mocked logger, which functions are spies.
+ */
 export function mockLogger(name) {
   const logger = makeLogger(name)
   const noop = () => {}
-  return {
+  return /** @type {?} */ ({
     trace: vi.spyOn(logger, 'trace').mockImplementation(noop),
     debug: vi.spyOn(logger, 'debug').mockImplementation(noop),
     log: vi.spyOn(logger, 'log').mockImplementation(noop),
     info: vi.spyOn(logger, 'info').mockImplementation(noop),
     warn: vi.spyOn(logger, 'warn').mockImplementation(noop),
     error: vi.spyOn(logger, 'error') // .mockImplementation(noop)
-  }
+  })
 }
 
+/**
+ * Translates a string using current locale.
+ * @type {Translate}
+ */
 export function translate(...args) {
   return get(_)(...args)
 }
 
+/**
+ * Sleeps for a given time
+ * @param {number} [time] - time in milliseconds
+ * @returns {Promise<void>}
+ */
 export async function sleep(time = 0) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
 
+/**
+ * @param {HTMLElement|HTMLElement[]} nodes - checked element(s).
+ * @returns {(string|undefined)[]|string|undefined} list or single value returned
+ */
 export function extractText(nodes) {
   const texts = (Array.isArray(nodes) ? nodes : [nodes]).map(item =>
-    item.textContent.trim()
+    item.textContent?.trim()
   )
   return Array.isArray(nodes) ? texts : texts[0]
 }
 
+/**
+ * @param {HTMLElement|HTMLElement[]} nodes - checked element(s).
+ * @param {string} attributeName - extracted attribute.
+ * @returns {(string|undefined)[]|string|undefined} list or single value returned
+ */
 export function extractAttribute(nodes, attributeName) {
   const texts = (Array.isArray(nodes) ? nodes : [nodes]).map(item =>
-    item.getAttribute(attributeName).trim()
+    item.getAttribute(attributeName)?.trim()
   )
   return Array.isArray(nodes) ? texts : texts[0]
 }
 
+/**
+ * Creates headless 3D engine for testing.
+ * @param {object} [engineProps]
+ * @param {number} engineProps.renderWidth - rendered surface width.
+ * @param {number} engineProps.renderHeight - rendered surface width.
+ * @returns {{ engine: Engine, scene: Scene, camera: ArcRotateCamera, handScene: Scene}} created objects.
+ */
 export function initialize3dEngine(
   engineProps = { renderWidth: 2048, renderHeight: 1024 }
 ) {
   Logger.LogLevels = Logger.NoneLogLevel
-  const engine = new NullEngine(engineProps)
+  const engine = new NullEngine({
+    ...engineProps,
+    textureSize: 512,
+    deterministicLockstep: false,
+    lockstepMaxSteps: 4
+  })
   const handScene = initialize3dScene(engine).scene
   handScene.autoClear = false
   const main = initialize3dScene(engine)
@@ -79,10 +146,15 @@ export function initialize3dEngine(
     main.scene.render()
     handScene.render()
   })
-  engine.inputElement = engineProps.interation || document.body
+  engine.inputElement = document.body
   return { engine, ...main, handScene }
 }
 
+/**
+ * Creates headless 3D scene and camera for testing.
+ * @param {Engine} engine - host engine for the created scene and camera.
+ * @returns {{ scene: Scene, camera: ArcRotateCamera }} created camera and scene.
+ */
 export function initialize3dScene(engine) {
   const scene = new ExtendedScene(engine)
   const camera = new ArcRotateCamera(
@@ -98,19 +170,32 @@ export function initialize3dScene(engine) {
   return { scene, camera }
 }
 
+/**
+ * @param {Scene} scene - disposed scene.
+ */
 export function disposeAllMeshes(scene) {
   for (const mesh of [...(scene?.meshes ?? [])]) {
     mesh.dispose()
   }
 }
 
-export function configures3dTestEngine(callback, engineProps) {
+/**
+ * To be called within a test `describe`
+ * Automaticall creates and headless 3D engine, scenes and camera when the test suite starts,
+ * disposes all meshes after each tests, and disposes the engine at the end.
+ * @param {(args: ReturnType<initialize3dEngine>) => void} [callback] - invoked with the created objects.
+ * @param {Parameters<initialize3dEngine>} engineProps - engine properties
+ */
+export function configures3dTestEngine(callback, ...engineProps) {
+  /** @type {Engine} */
   let engine
+  /** @type {Scene} */
   let scene
+  /** @type {Scene} */
   let handScene
 
   beforeAll(() => {
-    const data = initialize3dEngine(engineProps)
+    const data = initialize3dEngine(...engineProps)
     ;({ engine, scene, handScene } = data)
     callback?.(data)
   })
@@ -123,92 +208,123 @@ export function configures3dTestEngine(callback, engineProps) {
   afterAll(() => engine.dispose())
 }
 
+/** @type {CreateBox} */
 export function createBox(...args) {
   const box = CreateBox(...args)
   box.isHittable = true
   return box
 }
 
+/** @type {CreateCylinder} */
 export function createCylinder(...args) {
   const cylinder = CreateCylinder(...args)
   cylinder.isHittable = true
   return cylinder
 }
 
-const debugFile = 'debug.txt'
-
-export function debug(...args) {
-  appendFileSync(
-    debugFile,
-    `${args
-      .map(arg => (arg instanceof Object ? inspect(arg) : arg))
-      .join(', ')}\n`
-  )
-}
-
-export function cleanDebugFile() {
-  rmSync(debugFile, { force: true })
-}
-
+/**
+ * @param {?Mesh} mesh - actual mesh.
+ * @param {number[]} position - expected absolute position (x, y, z).
+ * @param {string} [message] - optional error message.
+ */
 export function expectPosition(mesh, [x, y, z], message) {
-  mesh.computeWorldMatrix(true)
-  expectCloseVector(mesh.absolutePosition, [x, y, z], message)
+  mesh?.computeWorldMatrix(true)
+  expectCloseVector(mesh?.absolutePosition, [x, y, z], message)
 }
 
+/**
+ * @param {?Mesh} mesh - actual mesh.
+ * @param {number[]} dimension - expected dimensions (width, height, depth).
+ */
 export function expectDimension(mesh, [width, height, depth]) {
-  expectCloseVector(mesh.getBoundingInfo().boundingBox.extendSize, [
+  expectCloseVector(mesh?.getBoundingInfo().boundingBox.extendSize, [
     width / 2,
     height / 2,
     depth / 2
   ])
 }
 
-export function expectCloseVector(actual, [x, y, z], message) {
-  expect(actual.x, message ?? 'x/pitch').toBeCloseTo(x, 1)
-  expect(actual.y, message ?? 'y/yaw').toBeCloseTo(y, 1)
-  expect(actual.z, message ?? 'z/roll').toBeCloseTo(z, 1)
+/**
+ * @param {?Partial<Vector3>|undefined} actual - actual vector.
+ * @param {number[]} position - expected position (x, y, z).
+ * @param {string} [message] - optional error message.
+ * @param {number} precision - comparison precision, default to 1 decimal.
+ */
+export function expectCloseVector(actual, [x, y, z], message, precision = 1) {
+  expect(actual?.x, message ?? 'x/pitch').toBeCloseTo(x, precision)
+  expect(actual?.y, message ?? 'y/yaw').toBeCloseTo(y, precision)
+  expect(actual?.z, message ?? 'z/roll').toBeCloseTo(z, precision)
 }
 
+/**
+ * @param {ScreenPosition} actual - actual screen position.
+ * @param {ScreenPosition} expected - expected position.
+ * @param {string} [message] - optional error message.
+ */
 export function expectScreenPosition(actual, { x, y }, message) {
   expect(actual?.x, message).toBeCloseTo(x, 1)
   expect(actual?.y, message).toBeCloseTo(y, 1)
 }
 
+/**
+ * @param {Mesh} mesh - actual anchorable mesh.
+ * @param {Mesh} snapped - expected snapped mesh.
+ * @param {number} [anchorRank=0] - rank of the snapped anchor, defaults to 0.
+ */
 export function expectSnapped(mesh, snapped, anchorRank = 0) {
   const behavior = mesh.getBehaviorByName(AnchorBehaviorName)
-  const anchor = behavior.state.anchors[anchorRank]
-  const zone = behavior.zones[anchorRank]
-  expect(anchor.snappedId).toEqual(snapped.id)
-  expect(mesh.metadata.anchors[anchorRank].snappedId).toEqual(snapped.id)
+  const anchor = behavior?.state.anchors[anchorRank]
+  const zone = behavior?.zones[anchorRank]
+  expect(anchor?.snappedId).toEqual(snapped.id)
+  expect(mesh.metadata.anchors?.[anchorRank].snappedId).toEqual(snapped.id)
   expectZoneEnabled(mesh, anchorRank, false)
-  expect(behavior.snappedZone(snapped.id)?.mesh.id).toEqual(zone.mesh.id)
-  zone.mesh.computeWorldMatrix(true)
+  expect(behavior?.snappedZone(snapped.id)?.mesh.id).toEqual(zone?.mesh.id)
+  zone?.mesh.computeWorldMatrix(true)
   expectPosition(snapped, [
-    zone.mesh.absolutePosition.x,
+    zone?.mesh.absolutePosition.x ?? 0,
     getCenterAltitudeAbove(mesh, snapped),
-    zone.mesh.absolutePosition.z
+    zone?.mesh.absolutePosition.z ?? 0
   ])
 }
 
+/**
+ * @param {Mesh} mesh - actual anchorable mesh.
+ * @param {Mesh} snapped - expected unsnapped mesh.
+ * @param {number} [anchorRank=0] - rank of the snapped anchor, defaults to 0.
+ */
 export function expectUnsnapped(mesh, snapped, anchorRank = 0) {
   const behavior = mesh.getBehaviorByName(AnchorBehaviorName)
-  const anchor = behavior.state.anchors[anchorRank]
+  const anchor = behavior?.state.anchors[anchorRank]
   expectZoneEnabled(mesh, anchorRank)
-  expect(behavior.snappedZone(snapped.id)).toBeNull()
-  expect(anchor.snappedId).not.toBeDefined()
-  expect(mesh.metadata.anchors[anchorRank].snappedId).not.toBeDefined()
+  expect(behavior?.snappedZone(snapped.id)).toBeNull()
+  expect(anchor?.snappedId).not.toBeDefined()
+  expect(mesh.metadata.anchors?.[anchorRank].snappedId).not.toBeDefined()
 }
 
+/**
+ * @param {Mesh} mesh - actual targetable mesh.
+ * @param {number} [rank=0] - rank of the checked zone, defaults to 0.
+ * @param {boolean} [enabled=true] - whether this zone should be enabled.
+ */
 export function expectZoneEnabled(mesh, rank = 0, enabled = true) {
   const behavior = mesh.getBehaviorByName(AnchorBehaviorName)
-  expect(behavior.zones[rank]?.enabled).toBe(enabled)
+  expect(behavior?.zones[rank]?.enabled).toBe(enabled)
 }
 
+/**
+ * @param {Mesh} mesh - actual targetable mesh.
+ * @param {boolean} [isPickable=true] - whether this mesh should be pickable.
+ */
 export function expectPickable(mesh, isPickable = true) {
   expect(mesh.isPickable).toBe(isPickable)
   expect(getAnimatableBehavior(mesh)?.isAnimated).toBe(!isPickable)
 }
 
+/**
+ * @param {Mesh} mesh - actual flippable mesh.
+ * @param {boolean} [isFlipped=true] - whether this mesh should be pickable.
+ * @param {number} [initialRotation=0] - initial rotation added to the flipped rotation.
+ */
 export function expectFlipped(mesh, isFlipped = true, initialRotation = 0) {
   expect(mesh.metadata.isFlipped).toBe(isFlipped)
   expect(mesh.getBehaviorByName(FlipBehaviorName)?.state.isFlipped).toBe(
@@ -217,14 +333,24 @@ export function expectFlipped(mesh, isFlipped = true, initialRotation = 0) {
   expectAbsoluteRotation(mesh, initialRotation + (isFlipped ? Math.PI : 0), 'z')
 }
 
+/**
+ * @param {Mesh} mesh - actual rotable mesh.
+ * @param {number} angle - expected absolute rotation angle.
+ * @param {number} [unroundedAngle=angle] - initial rotation added to the flipped rotation.
+ */
 export function expectRotated(mesh, angle, unroundedAngle = angle) {
   expect(mesh.metadata.angle, 'metadata rotation angle').toBeCloseTo(angle)
-  expect(mesh.getBehaviorByName(RotateBehaviorName).state.angle).toBeCloseTo(
+  expect(mesh.getBehaviorByName(RotateBehaviorName)?.state.angle).toBeCloseTo(
     angle
   )
   expectAbsoluteRotation(mesh, unroundedAngle, 'y')
 }
 
+/**
+ * @param {Mesh} mesh - actual mesh.
+ * @param {number} angle - expected absolute angle.
+ * @param {'x'|'y'|'z'} axis - rotation axis.
+ */
 export function expectAbsoluteRotation(mesh, angle, axis) {
   mesh.computeWorldMatrix(true)
   const rotation = Quaternion.Identity()
@@ -235,6 +361,10 @@ export function expectAbsoluteRotation(mesh, angle, axis) {
   ).toBeCloseTo(angle)
 }
 
+/**
+ * @param {Mesh[]} meshes - list of stacked meshes, who should relate to each other as a stack.
+ * @param {boolean} isLastMovable - whether the top-most mesh should be movable or not
+ */
 export function expectStacked(meshes, isLastMovable = true) {
   const ids = getIds(meshes.slice(1))
   for (const [rank, mesh] of meshes.entries()) {
@@ -244,7 +374,8 @@ export function expectStacked(meshes, isLastMovable = true) {
     ).toEqual(getIds(meshes))
     if (rank === 0) {
       expect(
-        getTargetableBehavior(mesh).state.stackIds,
+        /** @type {StackBehavior} */ (getTargetableBehavior(mesh)).state
+          .stackIds,
         `state stackIds of mesh #${rank}`
       ).toEqual(ids)
     }
@@ -259,22 +390,41 @@ export function expectStacked(meshes, isLastMovable = true) {
   }
 }
 
-export function expectStackIndicator(mesh, size) {
+/**
+ * @param {Mesh} mesh - actual mesh.
+ * @param {number} size - the expected size indicator attached to this mesh, or 0 to expect no indicator
+ */
+export function expectStackIndicator(mesh, size = 0) {
   const id = `${mesh.id}.stack-size`
   expect(indicatorManager.isManaging({ id })).toBe(size > 0)
   if (size) {
-    expect(indicatorManager.getById(id)?.size).toEqual(size)
+    expect(
+      /** @type {MeshSizeIndicator|undefined} */ (indicatorManager.getById(id))
+        ?.size
+    ).toEqual(size)
   }
 }
 
-export function expectQuantityIndicator(mesh, quantity) {
+/**
+ * @param {Mesh} mesh - actual mesh.
+ * @param {number} quantity - the expected quantity indicator attached to this mesh, or 1 to expect no indicator
+ */
+export function expectQuantityIndicator(mesh, quantity = 1) {
   const id = `${mesh.id}.quantity`
   expect(indicatorManager.isManaging({ id })).toBe(quantity > 1)
   if (quantity > 1) {
-    expect(indicatorManager.getById(id)?.size).toEqual(quantity)
+    expect(
+      /** @type {MeshSizeIndicator|undefined} */ (indicatorManager.getById(id))
+        ?.size
+    ).toEqual(quantity)
   }
 }
 
+/**
+ * @param {SpyInstance<Parameters<IndicatorManager['registerFeedback']>, void>} registerFeedbackSpy - spy for indicatorManager.registerFeedback().
+ * @param {ActionName|'unlock'|'lock'} action - the expected action reported.
+ * @param {...(number[]|Mesh)} meshesOrPositions - expected mesh or position (Vector3 components) for this feedback.
+ */
 export function expectMeshFeedback(
   registerFeedbackSpy,
   action,
@@ -294,11 +444,14 @@ export function expectMeshFeedback(
   registerFeedbackSpy.mockClear()
 }
 
-function getIds(meshes = []) {
+function getIds(/** @type {Mesh[]} */ meshes = []) {
   return meshes.map(({ id }) => id)
 }
 
-function expectOnTop(meshAbove, meshBelow) {
+function expectOnTop(
+  /** @type {Mesh} */ meshAbove,
+  /** @type {Mesh} */ meshBelow
+) {
   expectPosition(meshAbove, [
     meshBelow.absolutePosition.x,
     getCenterAltitudeAbove(meshBelow, meshAbove),
@@ -306,8 +459,16 @@ function expectOnTop(meshAbove, meshBelow) {
   ])
 }
 
+/**
+ *
+ * @param {Mesh} mesh - actual mesh
+ * @param {boolean} isInteractible - whether this mesh should be interactible.
+ * @param {boolean} [isMovable] - whether this mesh should be movable.
+ */
 export function expectInteractible(mesh, isInteractible = true, isMovable) {
-  for (const [rank, zone] of getTargetableBehavior(mesh).zones.entries()) {
+  for (const [rank, zone] of (
+    getTargetableBehavior(mesh)?.zones ?? []
+  ).entries()) {
     expect(zone.enabled, `zone #${rank} enable status`).toBe(isInteractible)
   }
   const movable = mesh.getBehaviorByName(MoveBehaviorName)
@@ -324,22 +485,38 @@ export function expectInteractible(mesh, isInteractible = true, isMovable) {
   }
 }
 
+/**
+ * @param {?AnimateBehavior} [behavior] - animatable behavior.
+ * @returns {Promise<void>}
+ */
 export async function expectAnimationEnd(behavior) {
   await new Promise(resolve =>
-    behavior.onAnimationEndObservable.addOnce(resolve)
+    behavior?.onAnimationEndObservable.addOnce(resolve)
   )
 }
 
-export function expectMeshes(actual, expected) {
+/**
+ * @param {Mesh[]} actual - list of actual meshes.
+ * @param {Mesh[]} expected - list of expected meshes.
+ */
+export function expectMeshIds(actual, expected) {
   expect(getIds(actual)).toEqual(getIds(expected))
 }
 
+/**
+ * @param {Scene} scene - scene to wait for the next frame
+ * @returns {Promise<void>}
+ */
 export async function waitNextRender(scene) {
   await new Promise(resolve =>
     scene.getEngine().onEndFrameObservable.addOnce(resolve)
   )
 }
 
+/**
+ * @param {SpyInstance<[MoveDetails], void>} moveRecorded - spy attached to moveManager.onMoveObservable.
+ * @param {...Mesh} meshes - expected list of moved meshes.
+ */
 export function expectMoveRecorded(moveRecorded, ...meshes) {
   expect(moveRecorded).toHaveBeenCalledTimes(meshes.length)
   for (const [rank, mesh] of meshes.entries()) {
@@ -350,19 +527,29 @@ export function expectMoveRecorded(moveRecorded, ...meshes) {
   }
 }
 
+/**
+ * @param {TargetBehavior} behavior - actual targetable behavior .
+ * @param {Partial<SingleDropZone>} zone - expected zone.
+ * @param {number} zoneRank - rank of the checked zone, defaults to 0.
+ */
 export function expectZone(
   behavior,
-  { extent = 1.2, enabled = true, kinds, priority = 0, ignoreParts = false }
+  { extent = 1.2, enabled = true, kinds, priority = 0, ignoreParts = false },
+  zoneRank = 0
 ) {
   expect(behavior.zones).toHaveLength(1)
-  expect(behavior.zones[0].extent).toEqual(extent)
-  expect(behavior.zones[0].enabled).toEqual(enabled)
-  expect(behavior.zones[0].kinds).toEqual(kinds)
-  expect(behavior.zones[0].priority).toEqual(priority)
-  expect(behavior.zones[0].mesh?.parent?.id).toEqual(behavior.mesh.id)
-  expect(behavior.zones[0].ignoreParts).toEqual(ignoreParts)
+  expect(behavior.zones[zoneRank].extent).toEqual(extent)
+  expect(behavior.zones[zoneRank].enabled).toEqual(enabled)
+  expect(behavior.zones[zoneRank].kinds).toEqual(kinds)
+  expect(behavior.zones[zoneRank].priority).toEqual(priority)
+  expect(behavior.zones[zoneRank].mesh?.parent?.id).toEqual(behavior.mesh?.id)
+  expect(behavior.zones[zoneRank].ignoreParts).toEqual(ignoreParts)
 }
 
+/**
+ * @param {Scene} scene - tested scene.
+ * @param {...Mesh} meshes - meshes expected to be disposed.
+ */
 export function expectDisposed(scene, ...meshes) {
   for (const mesh of meshes) {
     expect(
@@ -372,6 +559,10 @@ export function expectDisposed(scene, ...meshes) {
   }
 }
 
+/**
+ * @param {Scene} scene - tested scene.
+ * @param {...Mesh} meshes - meshes expected to be in the scene.
+ */
 export function expectNotDisposed(scene, ...meshes) {
   for (const mesh of meshes) {
     expect(
@@ -381,7 +572,16 @@ export function expectNotDisposed(scene, ...meshes) {
   }
 }
 
-export async function configureGraphQlServer(mocks) {
+/**
+ * To be called within a test `describe`
+ * Automaticall starts an http server answering mocked value on POST localhost:3001/graphql.
+ * Stops the server at the end of the test suite.
+ * @param {object} mocks
+ * @param {(body: ?) => Promise<?>|?} [mocks.handleGraphQl] - optional callback invoked with the graphql payload, that should return or resolved to the operation result.
+ * @returns {Promise<void>}
+ */
+export async function configureGraphQlServer(mocks = {}) {
+  /** @type {FastifyInstance} */
   let server
 
   beforeAll(async () => {
@@ -394,7 +594,8 @@ export async function configureGraphQlServer(mocks) {
       credentials: true
     })
     server.post('/graphql', async request => {
-      const { operationName: operation } = request.body
+      const { operationName: operation } =
+        /** @type {{ operationName: string }} */ (request.body)
       try {
         return {
           data: {
@@ -402,7 +603,7 @@ export async function configureGraphQlServer(mocks) {
           }
         }
       } catch (error) {
-        return { errors: [error.message] }
+        return { errors: [/** @type {Error} */ (error).message] }
       }
     })
     const port = 3001
@@ -414,10 +615,20 @@ export async function configureGraphQlServer(mocks) {
   })
 }
 
+/**
+ * @param {string} value - initial value for this generated id.
+ * @returns {string} random id.
+ */
 export function makeId(value) {
   return `${value}-${faker.number.int(200)}`
 }
 
+/**
+ * @template R
+ * @param {Observable<R>} observable - observable to listen to.
+ * @param {number} timeout - number of milliseconds to wait for a value, defaults to 100.
+ * @returns {Promise<R>} resolved the first value emited by this observable.
+ */
 export function waitForObservable(observable, timeout = 100) {
   return new Promise((resolve, reject) => {
     setTimeout(
@@ -431,4 +642,16 @@ export function waitForObservable(observable, timeout = 100) {
       }
     })
   })
+}
+
+/**
+ * @param {MenuOption} option - extracted menu option.
+ * @returns {string} exctracted value
+ */
+export function getMenuOptionValue(option) {
+  return typeof option === 'string'
+    ? option
+    : 'label' in option
+    ? option.label
+    : ''
 }

--- a/apps/web/tests/utils/collections.test.js
+++ b/apps/web/tests/utils/collections.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import * as collections from '@src/utils/collections'
 import { describe, expect, it } from 'vitest'
 

--- a/apps/web/tests/utils/dom.test.js
+++ b/apps/web/tests/utils/dom.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { faker } from '@faker-js/faker'
 import { setCssVariables } from '@src/utils'
 import { describe, expect, it } from 'vitest'

--- a/apps/web/tests/utils/logger.test.js
+++ b/apps/web/tests/utils/logger.test.js
@@ -1,13 +1,24 @@
+// @ts-check
+/**
+ * @template {any[]} P, R
+ * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
+ */
+
 import { faker } from '@faker-js/faker'
 import { makeLogger } from '@src/utils/logger'
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('Logger', () => {
+  /** @type {SpyInstance<Parameters<typeof console.trace>, void>} */
   let trace
+  /** @type {SpyInstance<Parameters<typeof console.log>, void>} */
   let log
+  /** @type {SpyInstance<Parameters<typeof console.info>, void>} */
   let info
+  /** @type {SpyInstance<Parameters<typeof console.warn>, void>} */
   let warn
+  /** @type {SpyInstance<Parameters<typeof console.error>, void>} */
   let error
 
   beforeEach(() => {
@@ -93,6 +104,7 @@ describe('Logger', () => {
     it('reports unknown level', () => {
       const level = faker.commerce.productMaterial()
 
+      // @ts-expect-error string can not be assigned to Level
       expect(configureLoggers({ anchorable: level })).not.toHaveProperty(
         'anchorable',
         level

--- a/apps/web/tests/utils/math.test.js
+++ b/apps/web/tests/utils/math.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import {
   buildEnclosedCircle,
   buildGroundRectangle,
@@ -36,8 +38,8 @@ describe('mathematical utilities', () => {
     it('builds a rectangle out of a bounding box', () => {
       expect(
         buildGroundRectangle({
-          minimumWorld: { x: 1, y: 2, z: 3 },
-          maximumWorld: { x: 4, y: 5, z: 6 }
+          minimumWorld: new Vector3(1, 2, 3),
+          maximumWorld: new Vector3(4, 5, 6)
         })
       ).toEqual({
         min: { x: 1, y: 3 },

--- a/apps/web/tests/utils/object.test.js
+++ b/apps/web/tests/utils/object.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { getValue } from '@src/utils'
 import { describe, expect, it } from 'vitest'
 

--- a/apps/web/tests/utils/string.test.js
+++ b/apps/web/tests/utils/string.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { abbreviate, translateError } from '@src/utils'
 import { get } from 'svelte/store'
 import { _ } from 'svelte-intl'
@@ -38,7 +39,7 @@ describe('string utilities', () => {
         output: 'NP'
       }
     ])('$title', ({ input, output }) => {
-      expect(abbreviate(input)).toBe(output)
+      expect(abbreviate(/** @type {?} */ (input))).toBe(output)
     })
   })
 
@@ -76,6 +77,7 @@ describe('string utilities', () => {
     })
 
     it('returns null on missing input', () => {
+      // @ts-expect-error missing parameter
       expect(translateError(formatMessage)).toBeNull()
     })
   })

--- a/apps/web/tests/utils/webrtc.test.js
+++ b/apps/web/tests/utils/webrtc.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { faker } from '@faker-js/faker'
 import { buildSDPTransform } from '@src/utils'
 import { describe, expect, it } from 'vitest'

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { resolve } from 'node:path'
 
 import atelier from '@atelier-wb/vite-plugin-atelier'

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -230,6 +230,7 @@ _Hints_
 Tail server logs: `journalctl -f -u tabulous -o cat | jq`
 Tail nginx logs: `tail -f /var/log/nginx/access.log`
 Clean logs: `sudo journalctl --vacuum-time=2months`
+Tail logs remotely: `ssh ubuntu@vps-XYZ.vps.ovh.net "journalctl -f -o cat -u tabulous" | jq -R 'fromjson? | .time |= (./1000 | strftime("%Y-%m-%d %H:%M:%S"))'`
 
 ## Tabulous Configuration
 

--- a/package.json
+++ b/package.json
@@ -29,24 +29,27 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@typescript-eslint/eslint-plugin": "^6.2.0",
+    "@typescript-eslint/parser": "^6.2.0",
     "@vitest/coverage-v8": "^0.33.0",
+    "@vitest/expect": "^0.33.0",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "eslint-plugin-svelte3": "^4.0.0",
+    "eslint-plugin-svelte": "^2.32.4",
     "eslint-plugin-vitest": "^0.2.6",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "playwright": "^1.35.1",
-    "prettier": "^2.8.8",
-    "prettier-plugin-svelte": "^2.10.1",
+    "prettier": "^3.0.0",
+    "prettier-plugin-svelte": "^3.0.3",
     "svelte": "^4.0.5",
     "typescript": "^5.1.6",
     "vite": "^4.4.2",
     "vitest": "^0.33.0"
   },
   "lint-staged": {
-    "*.{js,svelte}": "eslint --cache --fix",
-    "*.{js,svelte,css,md}": "prettier --plugin-search-dir=. --write"
+    "*.{js,ts,svelte}": "eslint --cache --fix",
+    "*.{js,ts,svelte,css,md}": "prettier --plugin-search-dir=. --write"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,18 @@ importers:
       '@faker-js/faker':
         specifier: ^8.0.2
         version: 8.0.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.2.0
+        version: 6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/parser':
+        specifier: ^6.2.0
+        version: 6.2.0(eslint@8.44.0)(typescript@5.1.6)
       '@vitest/coverage-v8':
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.33.0)
+      '@vitest/expect':
+        specifier: ^0.33.0
+        version: 0.33.0
       eslint:
         specifier: ^8.44.0
         version: 8.44.0
@@ -19,9 +28,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.44.0)
-      eslint-plugin-svelte3:
-        specifier: ^4.0.0
-        version: 4.0.0(eslint@8.44.0)(svelte@4.0.5)
+      eslint-plugin-svelte:
+        specifier: ^2.32.4
+        version: 2.32.4(eslint@8.44.0)(svelte@4.0.5)
       eslint-plugin-vitest:
         specifier: ^0.2.6
         version: 0.2.6(eslint@8.44.0)(typescript@5.1.6)
@@ -35,11 +44,11 @@ importers:
         specifier: ^1.35.1
         version: 1.35.1
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.0
+        version: 3.0.0
       prettier-plugin-svelte:
-        specifier: ^2.10.1
-        version: 2.10.1(prettier@2.8.8)(svelte@4.0.5)
+        specifier: ^3.0.3
+        version: 3.0.3(prettier@3.0.0)(svelte@4.0.5)
       svelte:
         specifier: ^4.0.5
         version: 4.0.5
@@ -258,6 +267,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.6
         version: 18.2.6
+      '@types/testing-library__jest-dom':
+        specifier: ^5.14.9
+        version: 5.14.9
       '@urql/core':
         specifier: ^4.0.10
         version: 4.0.10(graphql@16.7.1)
@@ -351,6 +363,9 @@ importers:
       svelte:
         specifier: ^4.0.5
         version: 4.0.5
+      svelte-check:
+        specifier: ^3.4.6
+        version: 3.4.6(@babel/core@7.22.5)(postcss@8.4.25)(svelte@4.0.5)
       svelte-htm:
         specifier: ^1.2.0
         version: 1.2.0(svelte@4.0.5)
@@ -363,6 +378,9 @@ importers:
       svelte-portal:
         specifier: ^2.2.0
         version: 2.2.0
+      svelte-windicss-preprocess:
+        specifier: ^4.2.8
+        version: 4.2.8
       v8-to-istanbul:
         specifier: ^9.1.0
         version: 9.1.0
@@ -409,6 +427,12 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+    dev: true
+
+  /@antfu/utils@0.3.0:
+    resolution: {integrity: sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==}
+    dependencies:
+      '@types/throttle-debounce': 2.1.0
     dev: true
 
   /@antfu/utils@0.7.2:
@@ -1451,6 +1475,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@iconify/json@1.1.432:
+    resolution: {integrity: sha512-ZcQKCnJXmeKDKxSu4vOFCYkCv8sjX1OASTMQpzqVzt3ivBBDudAYyXJlO4hgk0X4B2R0IMHRNvRgCAYkKDa2eQ==}
+    dev: true
+
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
     dev: false
@@ -1481,13 +1509,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.4.3
-    dev: true
-
-  /@jest/schemas@29.4.3:
-    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.25.24
     dev: true
 
   /@jest/schemas@29.6.0:
@@ -1524,7 +1545,7 @@ packages:
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.4.3
+      '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 20.4.1
@@ -1720,10 +1741,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sinclair/typebox@0.25.24:
-    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
-    dev: true
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -1824,7 +1841,7 @@ packages:
     dependencies:
       '@adobe/css-tools': 4.2.0
       '@babel/runtime': 7.22.3
-      '@types/testing-library__jest-dom': 5.14.6
+      '@types/testing-library__jest-dom': 5.14.9
       aria-query: 5.1.3
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -1926,7 +1943,7 @@ packages:
     resolution: {integrity: sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==}
     dependencies:
       expect: 29.5.0
-      pretty-format: 29.5.0
+      pretty-format: 29.6.1
     dev: true
 
   /@types/js-levenshtein@1.1.1:
@@ -1961,6 +1978,10 @@ packages:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
+  /@types/pug@2.0.6:
+    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
+    dev: true
+
   /@types/react-dom@18.2.6:
     resolution: {integrity: sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==}
     dependencies:
@@ -1993,10 +2014,14 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
-  /@types/testing-library__jest-dom@5.14.6:
-    resolution: {integrity: sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==}
+  /@types/testing-library__jest-dom@5.14.9:
+    resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
     dependencies:
       '@types/jest': 29.5.1
+    dev: true
+
+  /@types/throttle-debounce@2.1.0:
+    resolution: {integrity: sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==}
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -2009,6 +2034,57 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
+  /@typescript-eslint/eslint-plugin@6.2.0(@typescript-eslint/parser@6.2.0)(eslint@8.44.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 6.2.0(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.2.0
+      '@typescript-eslint/type-utils': 6.2.0(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.2.0(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.2.0
+      debug: 4.3.4
+      eslint: 8.44.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      natural-compare: 1.4.0
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.0.1(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.2.0(eslint@8.44.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.2.0
+      '@typescript-eslint/types': 6.2.0
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.2.0
+      debug: 4.3.4
+      eslint: 8.44.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@5.60.0:
     resolution: {integrity: sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2017,9 +2093,42 @@ packages:
       '@typescript-eslint/visitor-keys': 5.60.0
     dev: true
 
+  /@typescript-eslint/scope-manager@6.2.0:
+    resolution: {integrity: sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.2.0
+      '@typescript-eslint/visitor-keys': 6.2.0
+    dev: true
+
+  /@typescript-eslint/type-utils@6.2.0(eslint@8.44.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.2.0(eslint@8.44.0)(typescript@5.1.6)
+      debug: 4.3.4
+      eslint: 8.44.0
+      ts-api-utils: 1.0.1(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@5.60.0:
     resolution: {integrity: sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@6.2.0:
+    resolution: {integrity: sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree@5.60.0(typescript@5.1.6):
@@ -2036,8 +2145,29 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.3
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.2.0(typescript@5.1.6):
+    resolution: {integrity: sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.2.0
+      '@typescript-eslint/visitor-keys': 6.2.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.1(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -2063,11 +2193,38 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@6.2.0(eslint@8.44.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      '@types/json-schema': 7.0.12
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 6.2.0
+      '@typescript-eslint/types': 6.2.0
+      '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
+      eslint: 8.44.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@5.60.0:
     resolution: {integrity: sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.60.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.2.0:
+    resolution: {integrity: sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.2.0
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -2185,7 +2342,7 @@ packages:
       '@windicss/config': 1.9.0
       debug: 4.3.4
       fast-glob: 3.2.12
-      magic-string: 0.30.0
+      magic-string: 0.30.1
       micromatch: 4.0.5
       windicss: 3.5.6
     transitivePeerDependencies:
@@ -2578,6 +2735,10 @@ packages:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
       node-int64: 0.4.0
+    dev: true
+
+  /buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
 
   /buffer@5.7.1:
@@ -3040,6 +3201,10 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /defu@5.0.1:
+    resolution: {integrity: sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==}
+    dev: true
+
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3061,6 +3226,11 @@ packages:
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
     dev: true
 
   /detect-libc@2.0.1:
@@ -3192,6 +3362,10 @@ packages:
     resolution: {integrity: sha512-A4tCSY43O/mH4rHjG1n0mI4DhK2BmKDr8Lk8PXK/GBB6zxGFGmIW4bbkbTQ2Gi9iNamMZ9vbGrwjZOIeiM7vMw==}
     dev: false
 
+  /es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+    dev: true
+
   /esbuild@0.17.19:
     resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
     engines: {node: '>=12'}
@@ -3292,14 +3466,32 @@ packages:
       eslint: 8.44.0
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@8.44.0)(svelte@4.0.5):
-    resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
+  /eslint-plugin-svelte@2.32.4(eslint@8.44.0)(svelte@4.0.5):
+    resolution: {integrity: sha512-VJ12i2Iogug1jvhwxSlognnfGj76P5gks/V4pUD4SCSVQOp14u47MNP0zAG8AQR3LT0Fi1iUvIFnY4l9z5Rwbg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=8.0.0'
-      svelte: ^3.2.0
+      eslint: ^7.0.0 || ^8.0.0-0
+      svelte: ^3.37.0 || ^4.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      '@jridgewell/sourcemap-codec': 1.4.15
+      debug: 4.3.4
       eslint: 8.44.0
+      esutils: 2.0.3
+      known-css-properties: 0.28.0
+      postcss: 8.4.25
+      postcss-load-config: 3.1.4(postcss@8.4.25)
+      postcss-safe-parser: 6.0.0(postcss@8.4.25)
+      postcss-selector-parser: 6.0.13
+      semver: 7.5.4
       svelte: 4.0.5
+      svelte-eslint-parser: 0.32.2(svelte@4.0.5)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
     dev: true
 
   /eslint-plugin-vitest@0.2.6(eslint@8.44.0)(typescript@5.1.6):
@@ -3505,6 +3697,17 @@ packages:
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
     engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fast-glob@3.2.7:
+    resolution: {integrity: sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==}
+    engines: {node: '>=8'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -4409,7 +4612,7 @@ packages:
       chalk: 4.1.2
       diff-sequences: 29.4.3
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.6.1
     dev: true
 
   /jest-get-type@29.4.3:
@@ -4443,7 +4646,7 @@ packages:
       chalk: 4.1.2
       jest-diff: 29.5.0
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.6.1
     dev: true
 
   /jest-message-util@29.5.0:
@@ -4456,7 +4659,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       micromatch: 4.0.5
-      pretty-format: 29.5.0
+      pretty-format: 29.6.1
       slash: 3.0.0
       stack-utils: 2.0.6
     dev: true
@@ -4491,7 +4694,7 @@ packages:
       jest-message-util: 29.5.0
       jest-util: 29.5.0
       natural-compare: 1.4.0
-      pretty-format: 29.5.0
+      pretty-format: 29.6.1
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -4630,6 +4833,10 @@ packages:
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+    dev: true
+
+  /known-css-properties@0.28.0:
+    resolution: {integrity: sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==}
     dev: true
 
   /kolorist@1.8.0:
@@ -4802,6 +5009,13 @@ packages:
     hasBin: true
     dev: true
 
+  /magic-string@0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
@@ -4940,7 +5154,6 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: false
 
   /minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
@@ -4960,6 +5173,13 @@ packages:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    dev: true
+
+  /mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
     dev: true
 
   /mkdirp@1.0.4:
@@ -5083,6 +5303,10 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
+
+  /natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare@1.4.0:
@@ -5499,6 +5723,23 @@ packages:
       resolve: 1.22.2
     dev: true
 
+  /postcss-load-config@3.1.4(postcss@8.4.25):
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.25
+      yaml: 1.10.2
+    dev: true
+
   /postcss-nested@6.0.1(postcss@8.4.25):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
@@ -5507,6 +5748,24 @@ packages:
     dependencies:
       postcss: 8.4.25
       postcss-selector-parser: 6.0.13
+    dev: true
+
+  /postcss-safe-parser@6.0.0(postcss@8.4.25):
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.25
+    dev: true
+
+  /postcss-scss@4.0.6(postcss@8.4.25):
+    resolution: {integrity: sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.19
+    dependencies:
+      postcss: 8.4.25
     dev: true
 
   /postcss-selector-parser@6.0.13:
@@ -5535,19 +5794,19 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.0.5):
-    resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
+  /prettier-plugin-svelte@3.0.3(prettier@3.0.0)(svelte@4.0.5):
+    resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
-      prettier: ^1.16.4 || ^2.0.0
+      prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
-      prettier: 2.8.8
+      prettier: 3.0.0
       svelte: 4.0.5
     dev: true
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.0.0:
+    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 
@@ -5558,15 +5817,6 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-    dev: true
-
-  /pretty-format@29.5.0:
-    resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.3
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
     dev: true
 
   /pretty-format@29.6.1:
@@ -5768,6 +6018,13 @@ packages:
   /rfdc@1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
 
+  /rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
+
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -5824,6 +6081,15 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  /sander@0.5.1:
+    resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
+    dependencies:
+      es6-promise: 3.3.1
+      graceful-fs: 4.2.11
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
+    dev: true
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5954,6 +6220,16 @@ packages:
     resolution: {integrity: sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==}
     dependencies:
       atomic-sleep: 1.0.0
+
+  /sorcery@0.11.0:
+    resolution: {integrity: sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==}
+    hasBin: true
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      buffer-crc32: 0.2.13
+      minimist: 1.2.8
+      sander: 0.5.1
+    dev: true
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -6112,6 +6388,50 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /svelte-check@3.4.6(@babel/core@7.22.5)(postcss@8.4.25)(svelte@4.0.5):
+    resolution: {integrity: sha512-OBlY8866Zh1zHQTkBMPS6psPi7o2umTUyj6JWm4SacnIHXpWFm658pG32m3dKvKFL49V4ntAkfFHKo4ztH07og==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      chokidar: 3.5.3
+      fast-glob: 3.2.12
+      import-fresh: 3.3.0
+      picocolors: 1.0.0
+      sade: 1.8.1
+      svelte: 4.0.5
+      svelte-preprocess: 5.0.4(@babel/core@7.22.5)(postcss@8.4.25)(svelte@4.0.5)(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
+  /svelte-eslint-parser@0.32.2(svelte@4.0.5):
+    resolution: {integrity: sha512-Ok9D3A4b23iLQsONrjqtXtYDu5ZZ/826Blaw2LeFZVTg1pwofKDG4mz3/GYTax8fQ0plRGHI6j+d9VQYy5Lo/A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+    dependencies:
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.6.0
+      postcss: 8.4.25
+      postcss-scss: 4.0.6(postcss@8.4.25)
+      svelte: 4.0.5
+    dev: true
+
   /svelte-fragment-component@1.2.0(svelte@4.0.5):
     resolution: {integrity: sha512-rRstmz2oAy2Y/7X57tRaIAJdMYsa2K/MOx/YJN/ETb7Bj9U3vjgioz27dMG1hl2vAKFTtQpxDhC31ur7ECwpog==}
     engines: {node: '>=10'}
@@ -6177,6 +6497,65 @@ packages:
 
   /svelte-portal@2.2.0:
     resolution: {integrity: sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==}
+    dev: true
+
+  /svelte-preprocess@5.0.4(@babel/core@7.22.5)(postcss@8.4.25)(svelte@4.0.5)(typescript@5.1.6):
+    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
+    engines: {node: '>= 14.10.0'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
+      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      '@types/pug': 2.0.6
+      detect-indent: 6.1.0
+      magic-string: 0.27.0
+      postcss: 8.4.25
+      sorcery: 0.11.0
+      strip-indent: 3.0.0
+      svelte: 4.0.5
+      typescript: 5.1.6
+    dev: true
+
+  /svelte-windicss-preprocess@4.2.8:
+    resolution: {integrity: sha512-Z6pmFbHqJ19SgCiXiVRC/hlRBgZ/5LksMjPF3ilF/1HESP2L+secuaPjr3xOjJW67iZQpT2YdXzGe+MvdsJ6OQ==}
+    dependencies:
+      '@iconify/json': 1.1.432
+      fast-glob: 3.2.7
+      unconfig: 0.2.2
+      windicss: 3.5.4
+      windicss-runtime-dom: 3.0.0
     dev: true
 
   /svelte@4.0.5:
@@ -6337,6 +6716,15 @@ packages:
       punycode: 2.3.0
     dev: true
 
+  /ts-api-utils@1.0.1(typescript@5.1.6):
+    resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.1.6
+    dev: true
+
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -6389,6 +6777,14 @@ packages:
 
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
+    dev: true
+
+  /unconfig@0.2.2:
+    resolution: {integrity: sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==}
+    dependencies:
+      '@antfu/utils': 0.3.0
+      defu: 5.0.1
+      jiti: 1.18.2
     dev: true
 
   /undefsafe@2.0.5:
@@ -6748,6 +7144,16 @@ packages:
       string-width: 4.2.3
     dev: true
 
+  /windicss-runtime-dom@3.0.0:
+    resolution: {integrity: sha512-a12Uhu71yT1U8w0PzJ3amF9xmC8b1rWFLgXEfI/UyuwUi6D1vUACOO6vb0iY4T4OtP/bJAjQMM7lv3hMWSwLuQ==}
+    dev: true
+
+  /windicss@3.5.4:
+    resolution: {integrity: sha512-x2Iu0a69dtNiKHMkR886lx0WKbZI5GqvXyvGBCJ2VA6rcjKYjnzCA/Ljd6hNQBfqlkSum8J+qAVcCfLzQFI4rQ==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dev: true
+
   /windicss@3.5.6:
     resolution: {integrity: sha512-P1mzPEjgFMZLX0ZqfFht4fhV/FX8DTG7ERG1fBLiWvd34pTLVReS5CVsewKn9PApSgXnVfPWwvq+qUsRwpnwFA==}
     engines: {node: '>= 12'}
@@ -6823,6 +7229,11 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: true
 
   /yaml@2.3.1:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}


### PR DESCRIPTION
### :book: What's in there?

I don't know why I'm punishing myself. But it might be clearer skies where typed code could save me bugs and headaches.
Hence why I've typed all the frontend files that I could.

For svelte components, one may embrace Typescript, but for now I'm reluctant having to "switch language" between svelte files and regular js files.

Are included here:

- chore(wev): adds types to all possible files
- chore(web): migrates from eslint-plugin-svelte3 to eslint-plugin-svelte, alogn with prettier@3
- chore(server): uses GraphQL server types and moves imported types at the top of files
- chore(cli): uses GraphQL server types

### :test_tube: How to test?

Come on, just play with it

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
