### PR TITLE
feat(web): (un)flips snapped mesh on anchors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@
 
 ## UI
 
-- ability to interact with main meshes throught the opened hand (how do we select multiple in hand?)
 - anchorable: flip/unflip on snap
 - hand count on peer pointers/player tab?
 - replay

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 ## Refactor
 
-- try out automerge.js (can it share increments? can it support replay?)
 - replace windicss with a successor (tailwind or UnoCSS)
 - add tests for web/src/utils/peer-connection
 - group candidate target per kind for performance
@@ -201,3 +200,8 @@ For choosing game colors:
 3. make sure player colors have sufficient contrast with table texture/color.
 4. try as much as possible to have player colors with enough distance, to avoid confusion.
 5. black is a great player color! Transparent colors work as well.
+
+[Automerge](https://automerge.org) looked really promising, but isn't a good fit for Tabulous, because the storage format is binary.
+Besides being hard to debug and troubleshoot, it requires many encoding/decoding operations since GraphQL only allows text,
+discards any database migrations or server-side operations (unless rebuilding the document on server-side), and the overall effort of
+refactoring all communciation pipes and storage code does not really worth it.

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,8 @@
 
 ## UI
 
-- anchorable: flip/unflip on snap
-- hand count on peer pointers/player tab?
 - replay
+- hand count on peer pointers/player tab?
 - score card (Mah-jong, Belote)
 - command to reset some mesh state and restart a game (Mah-jong, Belote)
 - "box" space for unusued/undesired meshes

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -115,6 +115,7 @@ type Anchor {
   playerId: ID
   ignoreParts: Boolean
   angle: Float
+  flip: Boolean
 }
 
 type Mesh {
@@ -349,6 +350,7 @@ input AnchorInput {
   playerId: ID
   ignoreParts: Boolean
   angle: Float
+  flip: Boolean
 }
 
 input MeshInput {

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -152,6 +152,7 @@ import { canAccess } from './catalog.js'
  * @property {?string} [snappedId] - id of the mesh currently snapped to this anchor.
  * @property {string} [playerId] - when set, only this player can snap meshes to this anchor.
  * @property {number} [angle] - angle applied to any rotable mesh snapped to the anchor.
+ * @property {boolean} [flip] - flip state applied to any flippable mesh snapped to the anchor.
  * @property {boolean} [ignoreParts=false] - when set, and when snapping a multi-part mesh, takes it barycenter into account.
  */
 /** @typedef {_Anchor & Point & Dimension & Targetable} Anchor */

--- a/apps/web/src/3d/behaviors/anchorable.js
+++ b/apps/web/src/3d/behaviors/anchorable.js
@@ -32,7 +32,7 @@ import {
   getPositionAboveZone,
   getTargetableBehavior
 } from '../utils/behaviors'
-import { AnchorBehaviorName } from './names'
+import { AnchorBehaviorName, FlipBehaviorName } from './names'
 import { TargetBehavior } from './targetable'
 
 /** @typedef {AnchorableState & Required<Pick<AnchorableState, 'duration'|'anchors'>>} RequiredAnchorableState */
@@ -351,6 +351,15 @@ async function snapToAnchor(behavior, snappedId, zone, loading = false) {
     )
     if (!loading) {
       await move
+    }
+    if (
+      zone.flip !== undefined &&
+      snapped.metadata.isFlipped !== undefined &&
+      snapped.metadata.isFlipped !== zone.flip
+    ) {
+      await snapped
+        .getBehaviorByName(FlipBehaviorName)
+        ?.updateState({ isFlipped: zone.flip }, !loading)
     }
   }
 }

--- a/apps/web/src/3d/managers/input.js
+++ b/apps/web/src/3d/managers/input.js
@@ -10,7 +10,6 @@ import { Scene } from '@babylonjs/core/scene.js'
 import { makeLogger } from '../../utils/logger'
 import { distance } from '../../utils/math'
 import { screenToGround } from '../utils/vector'
-import { handManager } from './hand'
 import { selectionManager } from './selection'
 
 const logger = makeLogger('input')
@@ -300,9 +299,7 @@ class InputManager {
             ? event.button
             : undefined,
         // takes mesh with highest elevation, and only when they are pickable
-        mesh: handManager.isPointerInHand(event)
-          ? findPickedMesh(handScene, event)
-          : findPickedMesh(scene, event)
+        mesh: findPickedMesh(handScene, event) ?? findPickedMesh(scene, event)
       }
     }
 

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -78,6 +78,7 @@ fragment mesh on Mesh {
       playerId
       ignoreParts
       angle
+      flip
     }
     duration
   }

--- a/apps/web/src/graphql/signals.graphql
+++ b/apps/web/src/graphql/signals.graphql
@@ -1,4 +1,4 @@
-mutation sendSignal($signal: SignalInput) {
+mutation sendSignal($signal: SignalInput!) {
   sendSignal(signal: $signal) {
     from
   }

--- a/apps/web/src/style.postcss
+++ b/apps/web/src/style.postcss
@@ -1,6 +1,6 @@
 @import 'material-design-icons-iconfont';
 @import '@fontsource/carter-one';
-@import '@fontsource/lexend';
+@import '@fontsource/lexend/300.css';
 
 :root {
   /* 
@@ -82,7 +82,7 @@
   --medium: 300ms;
   --long: 600ms;
 
-  --font-base: LexendVariable, sans-serif;
+  --font-base: Lexend, sans-serif;
   --font-heading: Carter One, cursive;
 
   --card-light: no-repeat -80px -20px

--- a/apps/web/src/utils/peer-connection.js
+++ b/apps/web/src/utils/peer-connection.js
@@ -46,8 +46,6 @@ export class PeerConnection {
   }) {
     /** @type {?string} */
     this.playerId = null
-    /** @type {number} */
-    this.lastMessageId = 0
     /** @type {boolean} */
     this.established = false
     /** @type {RTCDataChannel | undefined} */

--- a/apps/web/tests/3d/behaviors/flippable.test.js
+++ b/apps/web/tests/3d/behaviors/flippable.test.js
@@ -125,6 +125,7 @@ describe('FlipBehavior', () => {
       expectFlipped(mesh)
       expectPosition(mesh, [x, 0.5, z])
       expect(animationEndReceived).toHaveBeenCalledOnce()
+      expect(recordSpy).toHaveBeenCalledOnce()
     })
 
     it('flips mesh anti-clockwise and apply gravity', async () => {
@@ -138,6 +139,27 @@ describe('FlipBehavior', () => {
       expectFlipped(mesh)
       expectPosition(mesh, [x, 0.5, z])
       expect(animationEndReceived).toHaveBeenCalledOnce()
+      expect(recordSpy).toHaveBeenCalledOnce()
+    })
+
+    it('updates flips state', async () => {
+      expectFlipped(mesh, false)
+      await behavior.updateState({ isFlipped: true })
+      expectFlipped(mesh)
+      expect(animationEndReceived).toHaveBeenCalledOnce()
+      expect(recordSpy).not.toHaveBeenCalled()
+    })
+
+    it('updates flips state with no animation', async () => {
+      await mesh.metadata.flip?.()
+      recordSpy.mockClear()
+      animationEndReceived.mockClear()
+      expectFlipped(mesh)
+
+      await behavior.updateState({ isFlipped: false }, false)
+      expectFlipped(mesh, false)
+      expect(animationEndReceived).not.toHaveBeenCalled()
+      expect(recordSpy).not.toHaveBeenCalled()
     })
 
     it('can not flip if locked', async () => {

--- a/apps/web/tests/3d/managers/input.test.js
+++ b/apps/web/tests/3d/managers/input.test.js
@@ -169,7 +169,9 @@ describe('InputManager', () => {
         // x: 1266, y: 615
         { id: 'box6', position: new Vector3(10, 0, -5), scene: handScene },
         // x: 1266, y: 512
-        { id: 'box7', position: new Vector3(10, 0, 0), scene }
+        { id: 'box7', position: new Vector3(10, 0, 0), scene },
+        // x: 1299, y: 616
+        { id: 'box8', position: new Vector3(11, 0, -4.5), scene }
       ].map(({ id, position, scene }) => {
         const mesh = createBox(id, {}, scene)
         mesh.setAbsolutePosition(position)
@@ -200,6 +202,20 @@ describe('InputManager', () => {
       )
     })
 
+    it('picks main mesh throught an open hand', () => {
+      const button = 1
+      const pointer = { x: 1300, y: 616 }
+      const pointerId = 74
+      triggerEvent(pointerDown, { ...pointer, pointerId, button })
+      const event = triggerEvent(pointerUp, { ...pointer, pointerId, button })
+      expectEvents({ taps: 1 })
+      expectsDataWithMesh(
+        taps[0],
+        { long: false, pointers: 1, type: 'tap', button, event },
+        'box8'
+      )
+    })
+
     it('does not pick non-pickable meshes', () => {
       const button = 1
       const pointer = { x: 1048, y: 525 }
@@ -222,7 +238,7 @@ describe('InputManager', () => {
     it('does not pick meshes selected by peers', () => {
       const button = 1
       const pointer = { x: 1048, y: 525 }
-      const pointerId = 71
+      const pointerId = 73
       const otherPlayerId = faker.string.uuid()
       selectionManager.updateColors(
         'currentPlayer',


### PR DESCRIPTION
### :book: What's in there?

Many games have a card reserve and expect players to take a card and reveal it to every one.
Anchors can not flip or unflip snapped mesh to make this very intuitive.

Are included here:

- fix(web): cannot connect with peers.
- fix(web): mesh on table are not interactive through the open hand.
- feat(web): (un)flips snapped mesh on anchors.
- style(web): restores text font.
- refactor(web): RTC data channel already guarantees message ordering.

### :test_tube: How to test?

We have no games yet to demonstrate the main feature.
For others:
1. Open home page
   > normal text font is lexend, not sans-serif (the difference is more obvious on Chrome)
1. Create a playground and invite another peer
3. Connect with the peer
    > Connection will establish successfully
4. Take some cards in hand, then pan the camera so the card stack is "below" the opened hand
5. Click on the card stack through the hand
   > The first card flips

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
