### PR TITLE
feat(web): handles 3d state while replaying

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-during replay: host save
-
 ## Refactor
 
 - hand: reuse playMeshes() and pickMesh() in handDrag()
@@ -16,6 +14,7 @@ during replay: host save
 
 ## UI
 
+- bug: when player reconnects to a multiplayer game, its peers muted/stopped states are reset
 - when hovering target, highlight should have the dragged mesh's shape, not the target shape (what about parts?)
 - hand count on peer pointers/player tab?
 - score card (Mah-jong, Belote)

--- a/TODO.md
+++ b/TODO.md
@@ -14,10 +14,10 @@
 
 ## UI
 
-- bug: when player reconnects to a multiplayer game, its peers muted/stopped states are reset
+- bug: die do not display the same face in multiplayer (states are correct)
 - when hovering target, highlight should have the dragged mesh's shape, not the target shape (what about parts?)
 - hand count on peer pointers/player tab?
-- score card (Mah-jong, Belote)
+- score (Mah-jong, Belote)
 - command to reset some mesh state and restart a game (Mah-jong, Belote)
 - "box" space for unusued/undesired meshes
 - hide/distinguish non-connected participants?

--- a/apps/server/src/graphql/games-resolver.js
+++ b/apps/server/src/graphql/games-resolver.js
@@ -239,18 +239,24 @@ export default {
           const subscription = services.gameListsUpdate
             .pipe(filter(({ playerId }) => playerId === player.id))
             .subscribe(({ games }) => {
-              const game = games.find(({ id }) => id === gameId)
-              if (game) {
-                pubsub.publish({ topic, payload: { receiveGameUpdates: game } })
-                logger.debug(
-                  { res: { topic, game: { id: game.id, kind: game.kind } } },
-                  'sent single game update'
-                )
-              }
+              const game = games.find(({ id }) => id === gameId) ?? null
+              pubsub.publish({ topic, payload: { receiveGameUpdates: game } })
+              logger.debug(
+                {
+                  res: {
+                    topic,
+                    game: { id: gameId, kind: game?.kind, removed: !game }
+                  }
+                },
+                'sent single game update'
+              )
             })
           const queue = await pubsub.subscribe(topic)
           queue.once('close', () => subscription.unsubscribe())
-          logger.debug({ ctx: { topic } }, 'subscribed to single game updates')
+          logger.debug(
+            { ctx: { topic, playerId: player.id } },
+            'subscribed to single game updates'
+          )
           return queue
         }
       )

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -266,6 +266,7 @@ interface HistoryRecord {
   meshId: ID!
   playerId: ID!
   duration: Int
+  fromHand: Boolean
 }
 
 type PlayerAction implements HistoryRecord {
@@ -276,6 +277,7 @@ type PlayerAction implements HistoryRecord {
   argsStr: String
   revertStr: String
   duration: Int
+  fromHand: Boolean
 }
 
 type PlayerMove implements HistoryRecord {
@@ -285,6 +287,7 @@ type PlayerMove implements HistoryRecord {
   pos: [Float]!
   prev: [Float]!
   duration: Int
+  fromHand: Boolean
 }
 
 input GameInput {
@@ -475,6 +478,7 @@ input HistoryRecordInput {
   pos: [Float]
   prev: [Float]
   duration: Int
+  fromHand: Boolean
 }
 
 type GameParameters {

--- a/apps/server/src/graphql/games.graphql
+++ b/apps/server/src/graphql/games.graphql
@@ -512,5 +512,5 @@ extend type Mutation {
 
 extend type Subscription {
   receiveGameListUpdates: [Game!]!
-  receiveGameUpdates(gameId: ID!): Game!
+  receiveGameUpdates(gameId: ID!): Game
 }

--- a/apps/server/src/services/games.js
+++ b/apps/server/src/services/games.js
@@ -225,6 +225,7 @@ import { canAccess } from './catalog.js'
  * @property {number} time - when this record happened (timestamp).
  * @property {string} playerId - who created this record.
  * @property {string} meshId - modified mesh id.
+ * @property {boolean} fromHand - whether this operation happened in this player's hand.
  * @property {number} [duration] - optional animation duration, in milliseconds.
  */
 

--- a/apps/web/src/3d/behaviors/anchorable.js
+++ b/apps/web/src/3d/behaviors/anchorable.js
@@ -6,8 +6,6 @@
  * @typedef {import('@tabulous/server/src/graphql').ActionName} ActionName
  * @typedef {import('@src/3d/behaviors/stackable').StackBehavior} StackBehavior
  * @typedef {import('@src/3d/behaviors/targetable').DropDetails} DropDetails
- * @typedef {import('@src/3d/managers/control').Action} Action
- * @typedef {import('@src/3d/managers/control').Move} Move
  * @typedef {import('@src/3d/managers/move').MoveDetails} MoveDetails
  * @typedef {import('@src/3d/managers/target').SingleDropZone} SingleDropZone
  */
@@ -51,7 +49,7 @@ export class AnchorBehavior extends TargetBehavior {
     this.dropObserver = null
     /** @protected @type {?Observer<MoveDetails>} */
     this.moveObserver = null
-    /** @protected @type {?Observer<Action|Move>}} */
+    /** @protected @type {?Observer<import('@src/3d/managers').ActionOrMove>}} */
     this.actionObserver = null
     /** @internal @type {Map<string, SingleDropZone>} */
     this.zoneBySnappedId = new Map()

--- a/apps/web/src/3d/behaviors/animatable.js
+++ b/apps/web/src/3d/behaviors/animatable.js
@@ -81,7 +81,6 @@ export class AnimateBehavior {
    * @param {?Vector3} rotation - its final rotation (set to null to leave unmodified).
    * @param {number} duration - move duration (in milliseconds).
    * @param {boolean} [gravity=true] - applies gravity at the end.
-   * @returns {Promise<void>}
    */
   async moveTo(to, rotation, duration, gravity = true) {
     const { mesh, moveAnimation, rotateAnimation } = this

--- a/apps/web/src/3d/behaviors/detailable.js
+++ b/apps/web/src/3d/behaviors/detailable.js
@@ -5,7 +5,6 @@
  * @typedef {import('../utils').ScreenPosition} ScreenPosition
  */
 
-import { controlManager } from '../managers/control'
 import {
   attachFunctions,
   attachProperty,
@@ -18,8 +17,11 @@ export class DetailBehavior {
   /**
    * Creates behavior to get details of a mesh.
    * @param {DetailableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = { frontImage: '' }) {
+  constructor(state, managers) {
+    /** @internal */
+    this.managers = managers
     /** @type {?Mesh} mesh - the related mesh. */
     this.mesh = null
     /**  @type {DetailableState} state - the behavior's current state. */
@@ -64,7 +66,7 @@ export class DetailBehavior {
   detail() {
     if (!this.mesh) return
     const stackable = this.mesh.getBehaviorByName(StackBehaviorName)
-    controlManager.onDetailedObservable.notifyObservers({
+    this.managers.control.onDetailedObservable.notifyObservers({
       position: /** @type {ScreenPosition} */ (
         getMeshScreenPosition(this.mesh)
       ),

--- a/apps/web/src/3d/behaviors/drawable.js
+++ b/apps/web/src/3d/behaviors/drawable.js
@@ -10,7 +10,6 @@
 
 import { Animation } from '@babylonjs/core/Animations/animation'
 
-import { handManager } from '../managers/hand'
 import { actionNames } from '../utils/actions'
 import {
   attachFunctions,
@@ -28,9 +27,12 @@ export class DrawBehavior extends AnimateBehavior {
   /**
    * Creates behavior to draw mesh from and to player's hand.
    * @param {DrawableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
+  constructor(state, managers) {
     super()
+    /** @internal */
+    this.managers = managers
     /** @type {RequiredDrawableState} state - the behavior's current state. */
     this.state = /** @type {RequiredDrawableState} */ (state)
     /** @protected @type {Animation} */
@@ -85,9 +87,9 @@ export class DrawBehavior extends AnimateBehavior {
   async draw(state, playerId) {
     if (!this.mesh) return
     if (state && playerId) {
-      await handManager.applyDraw(state, playerId)
+      await this.managers.hand.applyDraw(state, playerId)
     } else {
-      await handManager.draw(this.mesh)
+      await this.managers.hand.draw(this.mesh)
     }
   }
 
@@ -97,7 +99,7 @@ export class DrawBehavior extends AnimateBehavior {
    */
   async play() {
     if (!this.mesh) return
-    await handManager.play(this.mesh)
+    await this.managers.hand.play(this.mesh)
   }
 
   /**
@@ -109,14 +111,13 @@ export class DrawBehavior extends AnimateBehavior {
     if (this.mesh && args.length === 2) {
       const [state, playerId] = args
       if (action === actionNames.play) {
-        await handManager.applyDraw(state, playerId)
+        await this.managers.hand.applyDraw(state, playerId)
       }
     }
   }
 
   /**
    * Runs the animation to move mesh from main scene to hand.
-   * @returns {Promise<void>}
    */
   async animateToHand() {
     const {
@@ -142,7 +143,6 @@ export class DrawBehavior extends AnimateBehavior {
 
   /**
    * Runs the animation to move mesh from hand to main scene
-   * @returns {Promise<void>}
    */
   async animateToMain() {
     const {
@@ -183,12 +183,12 @@ export class DrawBehavior extends AnimateBehavior {
     attachProperty(
       this,
       'drawable',
-      () => this.mesh && !handManager.isManaging(this.mesh)
+      () => this.mesh && !this.managers.hand.isManaging(this.mesh)
     )
     attachProperty(
       this,
       'playable',
-      () => this.mesh && handManager.isManaging(this.mesh)
+      () => this.mesh && this.managers.hand.isManaging(this.mesh)
     )
   }
 }

--- a/apps/web/src/3d/behaviors/flippable.js
+++ b/apps/web/src/3d/behaviors/flippable.js
@@ -6,7 +6,6 @@
  */
 
 import { makeLogger } from '../../utils/logger'
-import { controlManager } from '../managers/control'
 import { actionNames } from '../utils/actions'
 import {
   attachFunctions,
@@ -30,9 +29,12 @@ export class FlipBehavior extends AnimateBehavior {
   /**
    * Creates behavior to make a mesh flippable with animation.
    * @param {FlippableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
+  constructor(state, managers) {
     super()
+    /** @internal */
+    this.managers = managers
     /** @type {RequiredFlippableState} state - the behavior's current state. */
     this.state = /** @type {RequiredFlippableState} */ (state)
   }
@@ -112,7 +114,7 @@ async function internalFlip(
     return
   }
   logger.debug({ mesh }, `start flipping ${mesh.id}`)
-  controlManager.record({
+  behavior.managers.control.record({
     mesh,
     fn: actionNames.flip,
     duration,

--- a/apps/web/src/3d/behaviors/lockable.js
+++ b/apps/web/src/3d/behaviors/lockable.js
@@ -6,8 +6,6 @@
  */
 
 import { makeLogger } from '../../utils/logger'
-import { controlManager } from '../managers/control'
-import { indicatorManager } from '../managers/indicator'
 import { actionNames } from '../utils/actions'
 import { attachFunctions, attachProperty } from '../utils/behaviors'
 import { LockBehaviorName, MoveBehaviorName } from './names'
@@ -20,8 +18,11 @@ export class LockBehavior {
   /**
    * Creates behavior to lock some actions on a mesh, by acting on other behaviors.
    * @param {LockableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
+  constructor(state, managers) {
+    /** @internal */
+    this.managers = managers
     /** @type {?Mesh} mesh - the related mesh. */
     this.mesh = null
     /**  @type {RequiredLockableState} state - the behavior's current state. */
@@ -97,17 +98,17 @@ export class LockBehavior {
 }
 
 function internalToggle(
-  /** @type {LockBehavior} */ { state, mesh },
+  /** @type {LockBehavior} */ { state, mesh, managers },
   isLocal = false
 ) {
   if (mesh) {
-    controlManager.record({
+    managers.control.record({
       mesh,
       fn: actionNames.toggleLock,
       args: [],
       isLocal
     })
-    indicatorManager.registerFeedback({
+    managers.indicator.registerFeedback({
       action: state.isLocked ? 'unlock' : 'lock',
       position: mesh.absolutePosition.asArray()
     })

--- a/apps/web/src/3d/behaviors/movable.js
+++ b/apps/web/src/3d/behaviors/movable.js
@@ -4,7 +4,6 @@
  * @typedef {import('@tabulous/server/src/graphql').MovableState} MovableState
  */
 
-import { moveManager } from '../managers/move'
 import { attachProperty } from '../utils/behaviors'
 import { AnimateBehavior } from './animatable'
 import { MoveBehaviorName } from './names'
@@ -17,9 +16,12 @@ export class MoveBehavior extends AnimateBehavior {
    * When moving mesh, its final position will snap to a virtual grid.
    * A mesh can only be dropped onto zones with the same kind.
    * @param {MovableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
+  constructor(state, managers) {
     super()
+    /** @internal */
+    this.managers = managers
     /** @type {RequiredMovableState} state - the behavior's current state. */
     this.state = /** @type {RequiredMovableState} */ (state)
     /** @type {boolean} enabled - activity status (true by default). */
@@ -42,7 +44,7 @@ export class MoveBehavior extends AnimateBehavior {
     super.attach(mesh)
     mesh.isPickable = true
     this.fromState(this.state)
-    moveManager.registerMovable(this)
+    this.managers.move.registerMovable(this)
   }
 
   /**
@@ -51,7 +53,7 @@ export class MoveBehavior extends AnimateBehavior {
   detach() {
     if (this.mesh) {
       this.mesh.isPickable = false
-      moveManager.unregisterMovable(this)
+      this.managers.move.unregisterMovable(this)
     }
     super.detach()
   }

--- a/apps/web/src/3d/behaviors/randomizable.js
+++ b/apps/web/src/3d/behaviors/randomizable.js
@@ -14,7 +14,6 @@ import { VertexBuffer } from '@babylonjs/core/Buffers/buffer'
 import { Quaternion, Vector3 } from '@babylonjs/core/Maths/math.vector'
 
 import { makeLogger } from '../../utils/logger'
-import { controlManager } from '../managers/control'
 import { actionNames } from '../utils/actions'
 import {
   attachFunctions,
@@ -42,9 +41,12 @@ export class RandomBehavior extends AnimateBehavior {
   /**
    * Creates behavior to make a mesh randomizable: it has a face vaule and this face can be set, or randomly set.
    * @param {RandomizableState & Extras} stateWithExtra - behavior persistent state, with internal parameters provided by the mesh.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(stateWithExtra) {
+  constructor(stateWithExtra, managers) {
     super()
+    /** @internal */
+    this.managers = managers
     /** @type {RequiredRandomizableState} state - the behavior's current state (+ extras) */
     this.state = /** @type {RequiredRandomizableState} */ (stateWithExtra)
     if (!(stateWithExtra.quaternionPerFace instanceof Map)) {
@@ -100,7 +102,6 @@ export class RandomBehavior extends AnimateBehavior {
    * - returns
    * Does nothing if the mesh is already being animated, or can not be set.
    * @param {number} face - desired face value.
-   * @returns {Promise<void>}
    * @throws {Error} if desired face is not withing 1..max.
    */
   async setFace(face) {
@@ -129,7 +130,6 @@ export class RandomBehavior extends AnimateBehavior {
    * - returns
    * Does nothing if the mesh is already being animated.
    * @param {number} [face] - final face value, used when applying random operation from peers
-   * @returns {Promise<void>}
    */
   async random(face) {
     if (!face) {
@@ -360,7 +360,7 @@ async function animate(behavior, isLocal, fn, face, duration, ...animations) {
     { mesh, face, oldFace },
     `starts ${fn} on ${mesh.id} (${oldFace} > ${face})`
   )
-  controlManager.record({
+  behavior.managers.control.record({
     mesh,
     fn,
     args: [face],

--- a/apps/web/src/3d/behaviors/randomizable.js
+++ b/apps/web/src/3d/behaviors/randomizable.js
@@ -319,7 +319,7 @@ function applyRotation(
   mesh.updateVerticesData(VertexBuffer.PositionKind, [...save.positions])
   mesh.updateVerticesData(VertexBuffer.NormalKind, [...save.normals])
   mesh.rotationQuaternion = /** @type {Quaternion} */ (
-    quaternionPerFace.get(face ?? 0)
+    quaternionPerFace.get(face ?? 1)
   ).clone()
   mesh.bakeCurrentTransformIntoVertices()
   mesh.refreshBoundingInfo()

--- a/apps/web/src/3d/behaviors/rotable.js
+++ b/apps/web/src/3d/behaviors/rotable.js
@@ -9,7 +9,6 @@
 import { Vector3 } from '@babylonjs/core/Maths/math'
 
 import { makeLogger } from '../../utils/logger'
-import { controlManager } from '../managers/control'
 import { actionNames } from '../utils/actions'
 import {
   attachFunctions,
@@ -35,10 +34,13 @@ export class RotateBehavior extends AnimateBehavior {
    * It will add to this mesh's metadata:
    * - a `rotate()` function to rotate by 45°.
    * - a rotation `angle` (in radian).
-   * @param {RotableState} state - behavior state.
+   * @param {RotableState} state - rotable state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
+  constructor(state, managers) {
     super()
+    /** @internal */
+    this.managers = managers
     this._state = /** @type {RequiredRotableState} */ (state)
   }
 
@@ -141,7 +143,7 @@ async function internalRotate(
     rotation *= -1
   }
 
-  controlManager.record({
+  behavior.managers.control.record({
     mesh,
     fn: actionNames.rotate,
     args: [rotation],

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -248,11 +248,11 @@ export class StackBehavior extends TargetBehavior {
    * When the base mesh is flipped, re-ordering happens first so the highest mesh doesn't change after flipping.
    */
   async flipAll() {
-    await internalFlip(this)
+    await internalFlipAll(this)
   }
 
   /**
-   * Revert push, pop and reorder actions. Ignores other actions
+   * Revert push, pop, flipAll and reorder actions. Ignores other actions
    * @param {ActionName} action - reverted action.
    * @param {any[]} [args] - reverted arguments.
    */
@@ -301,7 +301,7 @@ export class StackBehavior extends TargetBehavior {
       const [ids, animate] = args
       await internalReorder(this, ids, animate, true)
     } else if (action === actionNames.flipAll) {
-      await internalFlip(this, true)
+      await internalFlipAll(this, true)
     }
   }
 
@@ -657,7 +657,7 @@ async function internalReorder(
   }
 }
 
-async function internalFlip(
+async function internalFlipAll(
   /** @type {StackBehavior} */ behavior,
   isLocal = false
 ) {

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -21,11 +21,6 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 
 import { makeLogger } from '../../utils/logger'
 import { sleep } from '../../utils/time'
-import { controlManager } from '../managers/control'
-import { indicatorManager } from '../managers/indicator'
-import { moveManager } from '../managers/move'
-import { selectionManager } from '../managers/selection'
-import { targetManager } from '../managers/target'
 import { actionNames } from '../utils/actions'
 import {
   animateMove,
@@ -64,13 +59,11 @@ export class StackBehavior extends TargetBehavior {
    * and targetable (it can receive other stackable meshs).
    * Once a mesh is stacked bellow others, it can not be moved independently, and its targets and anchors are disabled.
    * Only the highest mesh on stack can be moved (it is automatically poped out) and be targeted.
-   *
-   * @property {StackableState} state - the behavior's current state.
-   *
    * @param {StackableState} state - behavior state.
+   * @param {import('@src/3d/managers').Managers} managers - current managers.
    */
-  constructor(state = {}) {
-    super()
+  constructor(state = {}, managers) {
+    super({}, managers)
     /** @type {RequiredStackableState} */
     this._state = /** @type {RequiredStackableState} */ (state)
     /** @type {Mesh[]} array of meshes (initially contains this mesh). */
@@ -123,7 +116,7 @@ export class StackBehavior extends TargetBehavior {
       }
     )
 
-    this.moveObserver = moveManager.onMoveObservable.add(({ mesh }) => {
+    this.moveObserver = this.managers.move.onMoveObservable.add(({ mesh }) => {
       // pop the last item if it's dragged, unless:
       // 1. there's only one item
       // 2. the first item is also dragged (we're dragging the whole stack)
@@ -131,13 +124,13 @@ export class StackBehavior extends TargetBehavior {
       if (
         stack.length > 1 &&
         stack[stack.length - 1] === mesh &&
-        !selectionManager.meshes.has(stack[0])
+        !this.managers.selection.meshes.has(stack[0])
       ) {
         this.pop()
       }
     })
 
-    this.actionObserver = controlManager.onActionObservable.add(
+    this.actionObserver = this.managers.control.onActionObservable.add(
       async actionOrMove => {
         const { stack } = this
         if (
@@ -147,7 +140,7 @@ export class StackBehavior extends TargetBehavior {
           stack[stack.length - 1].id === actionOrMove.meshId
         ) {
           const poped = await internalPop(this, 1, false, true)
-          indicatorManager.registerFeedback({
+          this.managers.indicator.registerFeedback({
             action: actionNames.pop,
             position: poped[0].absolutePosition.asArray()
           })
@@ -160,8 +153,8 @@ export class StackBehavior extends TargetBehavior {
    * Detaches this behavior from its mesh, unsubscribing observables
    */
   detach() {
-    controlManager.onActionObservable.remove(this.actionObserver)
-    moveManager.onMoveObservable.remove(this.moveObserver)
+    this.managers.control.onActionObservable.remove(this.actionObserver)
+    this.managers.move.onMoveObservable.remove(this.moveObserver)
     this.onDropObservable?.remove(this.dropObserver)
     super.detach()
   }
@@ -175,7 +168,7 @@ export class StackBehavior extends TargetBehavior {
     const last = this.stack[this.stack.length - 1]
     return last === this.mesh
       ? Boolean(mesh) &&
-          targetManager.canAccept(
+          this.managers.target.canAccept(
             this.dropZone,
             mesh.getBehaviorByName(MoveBehaviorName)?.state.kind
           )
@@ -226,7 +219,7 @@ export class StackBehavior extends TargetBehavior {
           )
         )
       }
-      indicatorManager.registerFeedback({
+      this.managers.indicator.registerFeedback({
         action: actionNames.pop,
         position: poped[0].absolutePosition.asArray()
       })
@@ -296,7 +289,7 @@ export class StackBehavior extends TargetBehavior {
           this.state.duration,
           false
         )
-        indicatorManager.registerFeedback({
+        this.managers.indicator.registerFeedback({
           action: actionNames.pop,
           position: last.absolutePosition.asArray()
         })
@@ -395,7 +388,7 @@ async function internalPush(
   const { angle } = behavior._state
 
   if (!behavior.inhibitControl) {
-    controlManager.record({
+    behavior.managers.control.record({
       mesh: stack[0],
       fn: actionNames.push,
       args: [meshId, immediate],
@@ -404,7 +397,7 @@ async function internalPush(
       revert: [1, immediate, mesh.absolutePosition.asArray(), mesh.rotation.y],
       isLocal
     })
-    moveManager.notifyMove(mesh)
+    behavior.managers.move.notifyMove(mesh)
   }
   const { x, z } = base.mesh.absolutePosition
   // when hydrating, we must break existing stacks, because they are meant to be broken by serialization
@@ -442,7 +435,7 @@ async function internalPush(
   }
   attach()
   if (!behavior.inhibitControl) {
-    indicatorManager.registerFeedback({
+    behavior.managers.indicator.registerFeedback({
       action: actionNames.push,
       position: pushed.absolutePosition.asArray()
     })
@@ -468,7 +461,7 @@ function internalPop(
     const mesh = /** @type {Mesh} */ (stack.pop())
     poped.push(mesh)
     setBase(mesh, null)
-    updateIndicator(mesh, 0)
+    updateIndicator(behavior.managers, mesh, 0)
     // note: no need to enable the poped mesh target: since it was last, it's always enabled
     setStatus(stack, stack.length - 1, true, behavior)
     logger.info(
@@ -480,7 +473,7 @@ function internalPop(
     poped.push(stack[0])
   }
   // note: all mesh in stack are uncontrollable, so we pass the poped mesh id
-  controlManager.record({
+  behavior.managers.control.record({
     mesh: stack[0],
     fn: actionNames.pop,
     args: [count, withMove],
@@ -510,7 +503,7 @@ async function internalReorder(
   const stack = ids.map(id => old[posById.get(id) ?? -1]).filter(Boolean)
   const oldIds = old.map(({ id }) => id)
 
-  controlManager.record({
+  behavior.managers.control.record({
     mesh: old[0],
     fn: actionNames.reorder,
     args: [ids, animate],
@@ -671,7 +664,7 @@ async function internalFlip(
   isLocal = false
 ) {
   const base = behavior.base ?? behavior
-  controlManager.record({
+  behavior.managers.control.record({
     mesh: base.stack[0],
     fn: actionNames.flipAll,
     args: [],
@@ -682,7 +675,9 @@ async function internalFlip(
     invertStack(base)
   }
   await Promise.all(
-    base.stack.map(mesh => controlManager.invokeLocal(mesh, actionNames.flip))
+    base.stack.map(mesh =>
+      behavior.managers.control.invokeLocal(mesh, actionNames.flip)
+    )
   )
   if (!isFlipped) {
     invertStack(base)
@@ -719,7 +714,7 @@ function setStatus(stack, rank, enabled, behavior) {
     movable.enabled = enabled
     logger.info({ mesh }, `${operation} moves for ${mesh.id}`)
   }
-  updateIndicator(mesh, enabled ? stack.length : 0)
+  updateIndicator(behavior.managers, mesh, enabled ? stack.length : 0)
 }
 
 function setBase(
@@ -743,12 +738,16 @@ function setBase(
   return targetable
 }
 
-function updateIndicator(/** @type {Mesh} */ mesh, /** @type {number} */ size) {
+function updateIndicator(
+  /** @type {import('@src/3d/managers').Managers} */ { indicator },
+  /** @type {Mesh} */ mesh,
+  /** @type {number} */ size
+) {
   const id = `${mesh.id}.stack-size`
   if (size > 1) {
-    indicatorManager.registerMeshIndicator({ id, mesh, size })
+    indicator.registerMeshIndicator({ id, mesh, size })
   } else {
-    indicatorManager.unregisterIndicator({ id })
+    indicator.unregisterIndicator({ id })
   }
 }
 

--- a/apps/web/src/3d/behaviors/stackable.js
+++ b/apps/web/src/3d/behaviors/stackable.js
@@ -6,8 +6,6 @@
  * @typedef {import('@tabulous/server/src/graphql').StackableState} StackableState
  * @typedef {import('@src/3d/behaviors/animatable').AnimateBehavior} AnimateBehavior
  * @typedef {import('@src/3d/behaviors/targetable').DropDetails} DropDetails
- * @typedef {import('@src/3d/managers/control').Action} Action
- * @typedef {import('@src/3d/managers/control').Move} Move
  * @typedef {import('@src/3d/managers/move').MoveDetails} MoveDetails
  * @typedef {import('@src/3d/managers/target').SingleDropZone} SingleDropZone
  * @typedef {import('@src/3d/utils').Vector3KeyFrame} Vector3KeyFrame
@@ -76,7 +74,7 @@ export class StackBehavior extends TargetBehavior {
     this.moveObserver = null
     /** @protected @type {?Observer<DropDetails>} */
     this.dropObserver = null
-    /** @protected @type {?Observer<Action|Move>} */
+    /** @protected @type {?Observer<import('@src/3d/managers').ActionOrMove>} */
     this.actionObserver = null
     /** @internal @type {boolean} */
     this.isReordering = false

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -317,8 +317,16 @@ function transferActionsAndSelections(
   /** @type {Engine} */ engine,
   /** @type {Engine} */ simulation
 ) {
+  const original = engine.load
+  engine.load = async (...args) => {
+    const promise = simulation.load(...args)
+    if (!engine.managers.replay.isReplaying) {
+      await original(...args)
+    }
+    await promise
+  }
   rebindMethod(engine, simulation, 'start')
-  rebindMethod(engine, simulation, 'load')
+  rebindMethod(engine, simulation, 'dispose')
   rebindMethod(engine, simulation, 'applyRemoteSelection')
   rebindMethod(engine, simulation, 'applyRemoteAction')
   engine.serialize = simulation.serialize.bind(simulation)

--- a/apps/web/src/3d/engine.js
+++ b/apps/web/src/3d/engine.js
@@ -330,6 +330,8 @@ function transferActionsAndSelections(
   rebindMethod(engine, simulation, 'applyRemoteSelection')
   rebindMethod(engine, simulation, 'applyRemoteAction')
   engine.serialize = simulation.serialize.bind(simulation)
+  simulation.getRenderWidth = engine.getRenderWidth.bind(engine)
+  simulation.getRenderHeight = engine.getRenderHeight.bind(engine)
   engine.managers.control.onActionObservable.add(action => {
     if (!engine.managers.replay.isReplaying) {
       simulation.managers.control.apply(action)

--- a/apps/web/src/3d/managers/control.js
+++ b/apps/web/src/3d/managers/control.js
@@ -13,7 +13,6 @@ import { Observable } from '@babylonjs/core/Misc/observable.js'
 
 import { actionNames } from '../utils/actions'
 import { animateMove } from '../utils/behaviors'
-import { handManager } from './hand'
 
 /**
  * @typedef {object} _Action
@@ -47,14 +46,18 @@ import { handManager } from './hand'
  * @property {string[]} images - list of images for this mesh (could be multiple for stacked meshes).
  */
 
-class ControlManager {
+export class ControlManager {
   /**
    * Creates a manager to remotely control a collection of meshes:
    * - applies actions received to specific meshes
    * - propagates applied actions to observers (with cycle breaker)
    * Clears all observers on scene disposal.
+   * Invokes init() before any other function.
+   * @param {object} params - parameters, including:
+   * @param {Scene} params.scene - main scene.
+   * @param {Scene} params.handScene - scene for meshes in hand.
    */
-  constructor() {
+  constructor({ scene, handScene }) {
     /** @type {Observable<Action|Move>} emits applied actions. */
     this.onActionObservable = new Observable()
     /** @type {Observable<?MeshDetails>} emits when displaying details of a given mesh. */
@@ -62,31 +65,33 @@ class ControlManager {
     /** @type {Observable<Map<String, Mesh>>} emits the list of controlled meshes. */
     this.onControlledObservable = new Observable()
 
-    /** @private @type {?Scene} */
-    this.scene = null
-    /** @private @type {?Scene} */
-    this.handScene = null
-    /** @private @type {Map<string, Mesh>} */
+    /** @internal */
+    this.scene = scene
+    /** @internal */
+    this.handScene = handScene
+    /** @internal @type {Map<string, Mesh>} */
     this.controlables = new Map()
     // prevents loops when applying an received action
-    /** @private @type {Set<string>} */
+    /** @internal @type {Set<string>} */
     this.localKeys = new Set()
-  }
+    /** @internal @type {import('@src/3d/managers').Managers} */
+    this.managers
 
-  /**
-   * Gives a scene to the manager.
-   * @param {object} params - parameters, including:
-   * @param {Scene} params.scene - main scene.
-   * @param {Scene} params.handScene - scene for meshes in hand.
-   */
-  init({ scene, handScene }) {
-    this.scene = scene
-    this.handScene = handScene
     this.scene.onDisposeObservable.addOnce(() => {
       this.onActionObservable.clear()
       this.onDetailedObservable.clear()
       this.onControlledObservable.clear()
     })
+  }
+
+  /**
+   * Initializes with game data and managers
+   *
+   * @param {object} params - parameters, including:
+   * @param {import('@src/3d/managers').Managers} params.managers - current managers.
+   */
+  init({ managers }) {
+    this.managers = managers
   }
 
   /**
@@ -117,7 +122,7 @@ class ControlManager {
 
   /**
    * @param {Mesh} mesh - tested mesh
-   * @returns {boolean} whether this mesh is controlled or not
+   * @returns whether this mesh is controlled or not
    */
   isManaging(mesh) {
     return this.controlables.has(mesh?.id)
@@ -188,7 +193,7 @@ class ControlManager {
     if ('fn' in actionOrMove) {
       const { fn, args } = actionOrMove
       if (fn === actionNames.draw) {
-        await handManager.applyPlay(args[0], args[1])
+        await this.managers.hand.applyPlay(args[0], args[1])
       } else {
         for (const behavior of mesh?.behaviors ?? []) {
           if ('revert' in behavior) {
@@ -220,7 +225,7 @@ class ControlManager {
     if ('fn' in action) {
       const args = action.args || []
       if (action.fn === actionNames.play) {
-        await handManager.applyPlay(args[0], args[1])
+        await this.managers.hand.applyPlay(args[0], args[1])
       } else {
         // @ts-expect-error -- args can not be narrowed
         await mesh?.metadata?.[action.fn]?.(...args)
@@ -237,16 +242,6 @@ class ControlManager {
   }
 }
 
-/**
- * Control manager singleton.
- * @type {ControlManager}
- */
-export const controlManager = new ControlManager()
-
-/**
- * @param {Partial<Pick<Action, 'meshId'|'fn'>>} action - keyed action
- * @returns {string} key for this action
- */
-function getKey(action) {
+function getKey(/** @type {Partial<Pick<Action, 'meshId'|'fn'>>} */ action) {
   return `${action?.meshId}-${action.fn?.toString() || 'pos'}`
 }

--- a/apps/web/src/3d/managers/control.js
+++ b/apps/web/src/3d/managers/control.js
@@ -27,6 +27,8 @@ import { animateMove } from '../utils/behaviors'
  *
  * @typedef {Omit<RecordedMove, 'mesh'> & _Move} Move applied move to a given mesh.
  *
+ * @typedef {Action|Move} ActionOrMove
+ *
  * @typedef {object} RecordedAction applied action to a given mesh:
  * @property {Mesh} mesh - modified mesh.
  * @property {ActionName} fn - name of the applied action.
@@ -58,7 +60,7 @@ export class ControlManager {
    * @param {Scene} params.handScene - scene for meshes in hand.
    */
   constructor({ scene, handScene }) {
-    /** @type {Observable<Action|Move>} emits applied actions. */
+    /** @type {Observable<ActionOrMove>} emits applied actions. */
     this.onActionObservable = new Observable()
     /** @type {Observable<?MeshDetails>} emits when displaying details of a given mesh. */
     this.onDetailedObservable = new Observable()

--- a/apps/web/src/3d/managers/hand.js
+++ b/apps/web/src/3d/managers/hand.js
@@ -12,8 +12,6 @@
  * @typedef {import('@src/3d/behaviors/quantifiable').QuantityBehavior} QuantityBehavior
  * @typedef {import('@src/3d/behaviors/rotable').RotateBehavior} RotateBehavior
  * @typedef {import('@src/3d/behaviors/stackable').StackBehavior} StackBehavior
- * @typedef {import('@src/3d/managers/control').Action} Action
- * @typedef {import('@src/3d/managers/control').Move} Move
  * @typedef {import('@src/3d/managers/input').DragData} DragData
  * @typedef {import('@src/3d/managers/target').DropZone} DropZone
  * @typedef {import('@src/3d/utils').ScreenPosition} ScreenPosition
@@ -181,8 +179,9 @@ export class HandManager {
       },
       {
         observable: this.managers.control.onActionObservable,
-        handle: (/** @type {Action|Move} */ action) =>
-          handleAction(this, action)
+        handle: (
+          /** @type {import('@src/3d/managers').ActionOrMove} */ action
+        ) => handleAction(this, action)
       },
       {
         observable: this.managers.input.onDragObservable,
@@ -216,6 +215,15 @@ export class HandManager {
             this.changes$.next()
           }
         }
+      },
+      {
+        observable: this.managers.replay.onReplayRankObservable,
+        handle: () =>
+          // delay until replay move is over
+          setTimeout(
+            () => this.changes$.next(),
+            this.managers.replay.moveDuration
+          )
       }
     ])) {
       const observer = observable.add(handle)
@@ -388,7 +396,7 @@ export class HandManager {
 
 /**
  * @param {HandManager} manager - manager instance.
- * @param {Action|Move} action - applied action.
+ * @param {import('@src/3d/managers').ActionOrMove} action - applied action.
  */
 function handleAction(manager, action) {
   if (

--- a/apps/web/src/3d/managers/hand.js
+++ b/apps/web/src/3d/managers/hand.js
@@ -50,12 +50,6 @@ import {
   isAboveTable,
   screenToGround
 } from '../utils/vector'
-import { controlManager } from './control'
-import { indicatorManager } from './indicator'
-import { inputManager } from './input'
-import { moveManager } from './move'
-import { selectionManager } from './selection'
-import { targetManager } from './target'
 
 /**
  * @typedef {Required<Pick<Dimension, 'width'|'height'>>} EngineDimension observed dimension of the rendering engine (pixels).
@@ -75,38 +69,57 @@ import { targetManager } from './target'
 
 const logger = makeLogger('hand')
 
-class HandManager {
+export class HandManager {
   /**
    * Creates a manager for the player's hand meshes:
    * - display and organize them in their dedicated scene.
    * - handles actions from and to the main scene.
-   * Is only enabled after having been initialized.
+   * Is starts disabled and must be manually enabled.
+   * Invokes init() before any other function.
+   * @param {object} params - parameters, including:
+   * @param {Scene} params.scene - main scene.
+   * @param {Scene} params.handScene - scene for meshes in hand.
+   * @param {HTMLElement} params.overlay - HTML element defining hand's available height.
+   * @param {number} [params.gap=0.5] - gap between hand meshes, when render width allows it, in 3D coordinates.
+   * @param {number} [params.verticalPadding=1] - vertical padding between meshes and the viewport edges, in 3D coordinates.
+   * @param {number} [params.horizontalPadding=2] - horizontal padding between meshes and the viewport edges, in 3D coordinates.
+   * @param {number} [params.transitionMargin=20] - margin (in pixel) applied to the hand scene border. Meshes dragged within this margin will be drawn or played.
+   * @param {number} [params.duration=100] - duration (in milliseconds) when moving meshes.
    */
-  constructor() {
-    /** @type {Scene} the main scene. */
-    this.scene
-    /** @type {Scene} scene for meshes in hand. */
-    this.handScene
-    /** @type {boolean} whether this manager is enabled. */
+  constructor({
+    scene,
+    handScene,
+    overlay,
+    gap = 0.5,
+    verticalPadding = 0.5,
+    horizontalPadding = 2,
+    transitionMargin = 20,
+    duration = 100
+  }) {
+    /** the main scene. */
+    this.scene = scene
+    /** scene for meshes in hand. */
+    this.handScene = handScene
+    /** whether this manager is enabled. */
     this.enabled = false
-    /** @type {number} gap between hand meshes, when render width allows it, in 3D coordinates. */
-    this.gap = 0
-    /** @type {number} vertical padding between meshes and the viewport edges, in 3D coordinates. */
-    this.verticalPadding = 0
-    /** @type {number} horizontal padding between meshes and the viewport edges, in 3D coordinates. */
-    this.horizontalPadding = 0
-    /** @type {number} duration (in milliseconds) when moving meshes. */
-    this.duration = 100
-    /** @type {number} margin (in pixel) applied to the hand scene border. Meshes dragged within this margin will be drawn or played. */
-    this.transitionMargin = 0
+    /** gap between hand meshes, when render width allows it, in 3D coordinates. */
+    this.gap = gap
+    /** vertical padding between meshes and the viewport edges, in 3D coordinates. */
+    this.verticalPadding = verticalPadding
+    /** horizontal padding between meshes and the viewport edges, in 3D coordinates. */
+    this.horizontalPadding = horizontalPadding
+    /** duration (in milliseconds) when moving meshes. */
+    this.duration = duration
+    /** margin (in pixel) applied to the hand scene border. Meshes dragged within this margin will be drawn or played. */
+    this.transitionMargin = transitionMargin
     /** @type {number} angle applied when playing rotable meshes, due to the player position. */
-    this.angleOnPlay = 0
+    this.angleOnPlay
     /** @type {Observable<HandChange>} emits new state on hand changes. */
     this.onHandChangeObservable = new Observable()
     /** @type {Observable<Boolean>} emits a boolean when dragged may (or not) be dragged to hand. */
     this.onDraggableToHandObservable = new Observable()
-    /** @type {HTMLElement} HTML element defining hand's available height. */
-    this.overlay
+    /** HTML element defining hand's available height. */
+    this.overlay = overlay
     /** @internal @type {Extent} */
     this.extent = {
       height: 0,
@@ -134,45 +147,22 @@ class HandManager {
       }
     })
     /** @internal @type {string} */
-    this.playerId = ''
+    this.playerId
+    /** @internal @type {import('@src/3d/managers').Managers} */
+    this.managers
   }
 
   /**
-   * Gives scenes to the manager.
+   * Initialize with game data
    * @param {object} params - parameters, including:
-   * @param {Scene} params.scene - main scene.
-   * @param {Scene} params.handScene - scene for meshes in hand.
-   * @param {HTMLElement} params.overlay - HTML element defining hand's available height.
+   * @param {import('@src/3d/managers').Managers} params.managers - current managers.
    * @param {string} params.playerId - id of the local player.
-   * @param {number} [params.gap=0.5] - gap between hand meshes, when render width allows it, in 3D coordinates.
-   * @param {number} [params.verticalPadding=1] - vertical padding between meshes and the viewport edges, in 3D coordinates.
-   * @param {number} [params.horizontalPadding=2] - horizontal padding between meshes and the viewport edges, in 3D coordinates.
-   * @param {number} [params.transitionMargin=20] - margin (in pixel) applied to the hand scene border. Meshes dragged within this margin will be drawn or played.
-   * @param {number} [params.duration=100] - duration (in milliseconds) when moving meshes.
    * @param {number} [params.angleOnPlay=0] - angle applied when playing rotable meshes, due to the player position.
    */
-  init({
-    scene,
-    handScene,
-    overlay,
-    playerId,
-    gap = 0.5,
-    verticalPadding = 0.5,
-    horizontalPadding = 2,
-    transitionMargin = 20,
-    duration = 100,
-    angleOnPlay = 0
-  }) {
-    this.scene = scene
-    this.handScene = handScene
-    this.gap = gap
-    this.verticalPadding = verticalPadding
-    this.horizontalPadding = horizontalPadding
-    this.duration = duration
-    this.transitionMargin = transitionMargin
-    this.overlay = overlay
-    this.angleOnPlay = angleOnPlay
+  init({ managers, playerId, angleOnPlay = 0 }) {
+    this.managers = managers
     this.playerId = playerId
+    this.angleOnPlay = angleOnPlay
 
     const engine = this.handScene.getEngine()
     /** @type {(() => void)[]} */
@@ -190,16 +180,16 @@ class HandManager {
         }
       },
       {
-        observable: controlManager.onActionObservable,
+        observable: this.managers.control.onActionObservable,
         handle: (/** @type {Action|Move} */ action) =>
           handleAction(this, action)
       },
       {
-        observable: inputManager.onDragObservable,
+        observable: this.managers.input.onDragObservable,
         handle: (/** @type {DragData} */ action) => handDrag(this, action)
       },
       {
-        observable: handScene.onNewMeshAddedObservable,
+        observable: this.handScene.onNewMeshAddedObservable,
         handle: (/** @type {Mesh} */ added) => {
           // delay because mesh names are set after being constructed
           setTimeout(() => {
@@ -211,7 +201,7 @@ class HandManager {
         }
       },
       {
-        observable: handScene.onMeshRemovedObservable,
+        observable: this.handScene.onMeshRemovedObservable,
         handle: (/** @type {Mesh} */ removed) => {
           if (isSerializable(removed)) {
             logger.info(
@@ -248,7 +238,6 @@ class HandManager {
 
     computeExtent(this, engine)
     storeMeshDimensions(this)
-    this.enabled = true
     layoutMeshs(this)
   }
 
@@ -293,8 +282,8 @@ class HandManager {
     ) {
       return
     }
-    await playMeshes(this, selectionManager.getSelection(playedMesh))
-    selectionManager.clear()
+    await playMeshes(this, this.managers.selection.getSelection(playedMesh))
+    this.managers.selection.clear()
   }
 
   /**
@@ -317,11 +306,11 @@ class HandManager {
       await pickMesh(this, mesh, true)
     } else {
       logger.info({ mesh, playerId }, `another player pick ${mesh.id} in hand`)
-      record(mesh, actionNames.draw, playerId, true)
+      record(mesh, this.managers, actionNames.draw, playerId, true)
       await animateToHand(mesh)
     }
     if (!isSamePlayer) {
-      indicatorManager.registerFeedback({
+      this.managers.indicator.registerFeedback({
         action: actionNames.draw,
         playerId,
         position
@@ -349,23 +338,23 @@ class HandManager {
     if (isSamePlayer) {
       this.handScene.getMeshById(state.id)?.dispose()
     }
-    const mesh = await createMeshFromState(state, this.scene)
+    const mesh = await createMeshFromState(state, this.scene, this.managers)
     logger.info(
       { mesh },
       `${isSamePlayer ? '' : 'another player '}play ${mesh.id} from hand`
     )
     // record should comes before dropping on a zone, but after creating main mesh
-    record(mesh, actionNames.play, playerId, true)
-    const dropZone = targetManager.findDropZone(
+    record(mesh, this.managers, actionNames.play, playerId, true)
+    const dropZone = this.managers.target.findDropZone(
       mesh,
       mesh.getBehaviorByName(MoveBehaviorName)?.state.kind
     )
     if (dropZone) {
-      targetManager.dropOn(dropZone, { immediate: true, isLocal: true })
+      this.managers.target.dropOn(dropZone, { immediate: true, isLocal: true })
     }
     await getDrawable(mesh)?.animateToMain()
     if (!isSamePlayer) {
-      indicatorManager.registerFeedback({
+      this.managers.indicator.registerFeedback({
         action: actionNames.play,
         playerId,
         position: [state.x ?? 0, state.y ?? 0, state.z ?? 0]
@@ -398,12 +387,6 @@ class HandManager {
 }
 
 /**
- * Player's hand manager singleton.
- * @type {HandManager}
- */
-export const handManager = new HandManager()
-
-/**
  * @param {HandManager} manager - manager instance.
  * @param {Action|Move} action - applied action.
  */
@@ -427,8 +410,8 @@ function handleAction(manager, action) {
  * @param {DragData} drag - drag details.
  */
 async function handDrag(manager, { type, mesh, event }) {
-  const { handScene } = manager
-  if (!hasSelectedDrawableMeshes(mesh)) {
+  const { handScene, managers } = manager
+  if (!hasSelectedDrawableMeshes(mesh, managers)) {
     return
   }
 
@@ -443,7 +426,7 @@ async function handDrag(manager, { type, mesh, event }) {
   if (mesh.getScene() === handScene) {
     let moved = manager.moved
     if (type === 'dragStart') {
-      moved = selectionManager.getSelection(mesh)
+      moved = manager.managers.selection.getSelection(mesh)
     } else if (type === 'dragStop') {
       moved = []
     }
@@ -461,16 +444,16 @@ async function handDrag(manager, { type, mesh, event }) {
           { mesh: movedMesh, x, z },
           `play mesh ${movedMesh.id} from hand by dragging`
         )
-        const wasSelected = selectionManager.meshes.has(movedMesh)
+        const wasSelected = managers.selection.meshes.has(movedMesh)
         const mesh = await createMainMesh(manager, movedMesh, { x, z })
         /** @type {?DropZone} */
         let dropZone
         if (droppedList.length) {
           // when first drawn mesh was dropped on player zone, tries to drop others on top of it.
-          dropZone = canDropAbove(droppedList[0], mesh)
+          dropZone = canDropAbove(managers, droppedList[0], mesh)
         } else {
           // can first mesh be dropped on player zone?
-          dropZone = targetManager.findPlayerZone(mesh)
+          dropZone = managers.target.findPlayerZone(mesh)
         }
 
         if (dropZone) {
@@ -489,22 +472,26 @@ async function handDrag(manager, { type, mesh, event }) {
           }
           record(
             mesh,
+            managers,
             actionNames.play,
             manager.playerId,
             false,
             getPositionAboveZone(mesh, dropZone)
           )
-          targetManager.dropOn(dropZone, { immediate: true, isLocal: true })
+          managers.target.dropOn(dropZone, {
+            immediate: true,
+            isLocal: true
+          })
         } else {
           if (wasSelected) {
-            selectionManager.select(mesh)
+            managers.selection.select(mesh)
           }
-          record(mesh, actionNames.play, manager.playerId)
+          record(mesh, managers, actionNames.play, manager.playerId)
         }
       }
       if (saved) {
-        moveManager.exclude(...droppedList)
-        selectionManager.clear()
+        managers.move.exclude(...droppedList)
+        managers.selection.clear()
         // play move animation for local player only
         const current = saved.mesh.absolutePosition.clone()
         saved.mesh.setAbsolutePosition(saved.position)
@@ -514,18 +501,18 @@ async function handDrag(manager, { type, mesh, event }) {
     layoutMeshs(manager)
   } else if (isMainMeshNextToHand(manager, mesh)) {
     if (type !== 'dragStop') {
-      inputManager.stopDrag(event)
+      managers.input.stopDrag(event)
     } else {
       // for replay, is it important we apply actions to highest meshes first,
       // so they could be poped from their stack
-      const drawn = sortByElevation(selectionManager.getSelection(mesh), true)
+      const drawn = sortByElevation(managers.selection.getSelection(mesh), true)
       logger.debug({ drawn }, `dragged meshes into hand`)
       const { x: positionX } = screenToGround(manager.handScene, event)
       const z = -manager.contentDimensions.depth
       const origin = drawn[0].absolutePosition.x
       for (const mesh of drawn) {
         logger.info({ mesh }, `pick mesh ${mesh.id} in hand by dragging`)
-        record(mesh, actionNames.draw, manager.playerId)
+        record(mesh, managers, actionNames.draw, manager.playerId)
         mesh.isPhantom = true
         const x = positionX + mesh.absolutePosition.x - origin
         await createHandMesh(manager, mesh, { x, z })
@@ -562,7 +549,11 @@ async function createMainMesh(manager, handMesh, extraState = {}) {
   transformOnPlay(manager, handMesh)
   const state = handMesh.metadata.serialize()
   handMesh.dispose()
-  return createMeshFromState({ ...state, ...extraState }, manager.scene)
+  return createMeshFromState(
+    { ...state, ...extraState },
+    manager.scene,
+    manager.managers
+  )
 }
 
 /**
@@ -574,11 +565,12 @@ async function createMainMesh(manager, handMesh, extraState = {}) {
 async function createHandMesh(manager, mainMesh, extraState = {}) {
   const state = { ...mainMesh.metadata.serialize(), ...extraState }
   transformOnPick(state)
-  return createMeshFromState(state, manager.handScene)
+  return createMeshFromState(state, manager.handScene, manager.managers)
 }
 
 function record(
   /** @type {Mesh} */ mesh,
+  /** @type {import('@src/3d/managers').Managers} */ managers,
   /** @type {actionNames['play'] | actionNames['draw']} */ fn,
   /** @type {string} */ playerId,
   /** @type {boolean} */ isLocal = false,
@@ -590,7 +582,7 @@ function record(
     state.y = finalPosition.y
     state.z = finalPosition.z
   }
-  controlManager.record({
+  managers.control.record({
     mesh,
     fn,
     args: [state, playerId],
@@ -749,10 +741,13 @@ function transformOnPlay(
 }
 
 /** @returns whether this selected mesh is drawable. */
-function hasSelectedDrawableMeshes(/** @type {?Mesh|undefined} */ mesh) {
+function hasSelectedDrawableMeshes(
+  /** @type {?Mesh|undefined} */ mesh,
+  /** @type {import('@src/3d/managers').Managers} */ managers
+) {
   return (
     Boolean(mesh) &&
-    selectionManager
+    managers.selection
       .getSelection(/** @type {Mesh} */ (mesh))
       .some(mesh => mesh.getBehaviorByName(DrawBehaviorName))
   )
@@ -762,6 +757,7 @@ async function playMeshes(
   /** @type {HandManager} */ manager,
   /** @type {Mesh[]} */ meshes
 ) {
+  const { extent, scene, managers } = manager
   /** @type {?Mesh} */
   let dropped = null
   /** @type {Mesh[]} */
@@ -770,10 +766,10 @@ async function playMeshes(
     logger.info({ mesh: drawnMesh }, `play mesh ${drawnMesh.id} from hand`)
     const screenPosition = {
       x: /** @type {ScreenPosition} */ (getMeshScreenPosition(drawnMesh)).x,
-      y: manager.extent.size.height * 0.5
+      y: extent.size.height * 0.5
     }
-    const position = screenToGround(manager.scene, screenPosition)
-    if (!position || !isAboveTable(manager.scene, screenPosition)) {
+    const position = screenToGround(scene, screenPosition)
+    if (!position || !isAboveTable(scene, screenPosition)) {
       return []
     }
     const mesh = await createMainMesh(manager, drawnMesh, {
@@ -786,10 +782,10 @@ async function playMeshes(
     let dropZone = null
     if (dropped) {
       // when first drawn mesh was dropped on player zone, tries to drop others on top of it.
-      dropZone = canDropAbove(dropped, mesh)
+      dropZone = canDropAbove(managers, dropped, mesh)
     } else {
       // can first mesh be dropped on player zone?
-      dropZone = targetManager.findPlayerZone(mesh)
+      dropZone = managers.target.findPlayerZone(mesh)
       if (dropZone) {
         dropped = mesh
       }
@@ -797,35 +793,40 @@ async function playMeshes(
 
     if (!dropZone) {
       // mesh can not be dropped on player zone nor first mesh, try to stack it.
-      dropZone = findStackZone(mesh)
+      dropZone = findStackZone(managers, mesh)
     }
     if (dropZone) {
       record(
         mesh,
+        managers,
         actionNames.play,
         manager.playerId,
         false,
         getPositionAboveZone(mesh, dropZone)
       )
-      targetManager.dropOn(dropZone, { immediate: true, isLocal: true })
+      managers.target.dropOn(dropZone, { immediate: true, isLocal: true })
     } else {
       // no possible drop: let it lie on the table.
       applyGravity(mesh)
-      record(mesh, actionNames.play, manager.playerId)
+      record(mesh, managers, actionNames.play, manager.playerId)
     }
   }
   await Promise.all(created.map(mesh => getDrawable(mesh)?.animateToMain()))
 }
 
-function findStackZone(/** @type {Mesh} */ mesh) {
+function findStackZone(
+  /** @type {import('@src/3d/managers').Managers} */ managers,
+  /** @type {Mesh} */ mesh
+) {
   mesh.computeWorldMatrix(true)
-  return targetManager.findDropZone(
+  return managers.target.findDropZone(
     mesh,
     mesh.getBehaviorByName(MoveBehaviorName)?.state.kind
   )
 }
 
 function canDropAbove(
+  /** @type {import('@src/3d/managers').Managers} */ managers,
   /** @type {Mesh} */ baseMesh,
   /** @type {Mesh} */ dropped
 ) {
@@ -833,7 +834,7 @@ function canDropAbove(
   dropped.setAbsolutePosition(
     baseMesh.absolutePosition.add(new Vector3(0, 100, 0))
   )
-  const dropZone = findStackZone(dropped)
+  const dropZone = findStackZone(managers, dropped)
   if (dropZone) {
     return dropZone
   }
@@ -848,7 +849,7 @@ async function pickMesh(
   isLocal = false
 ) {
   logger.info({ mesh }, `pick mesh ${mesh.id} in hand`)
-  record(mesh, actionNames.draw, manager.playerId, isLocal)
+  record(mesh, manager.managers, actionNames.draw, manager.playerId, isLocal)
   const { minZ } = manager.extent
   const { width } = manager.contentDimensions
   const { depth } = getDimensions(mesh)

--- a/apps/web/src/3d/managers/index.js
+++ b/apps/web/src/3d/managers/index.js
@@ -1,3 +1,17 @@
+/**
+ * @typedef {object} Managers
+ * @property {import('@src/3d/managers/camera').CameraManager} camera
+ * @property {import('@src/3d/managers/control').ControlManager} control
+ * @property {import('@src/3d/managers/custom-shape').CustomShapeManager} customShape
+ * @property {import('@src/3d/managers/hand').HandManager} hand
+ * @property {import('@src/3d/managers/indicator').IndicatorManager} indicator
+ * @property {import('@src/3d/managers/input').InputManager} input
+ * @property {import('@src/3d/managers/material').MaterialManager} material
+ * @property {import('@src/3d/managers/move').MoveManager} move
+ * @property {import('@src/3d/managers/replay').ReplayManager} replay
+ * @property {import('@src/3d/managers/selection').SelectionManager} selection
+ * @property {import('@src/3d/managers/target').TargetManager} target
+ */
 export * from './camera'
 export * from './control'
 export * from './custom-shape'

--- a/apps/web/src/3d/managers/input.js
+++ b/apps/web/src/3d/managers/input.js
@@ -548,6 +548,7 @@ export class InputManager {
     this.interaction.addEventListener('pointerdown', handlePointerDown)
     this.interaction.addEventListener('pointermove', handlePointerMove)
     this.interaction.addEventListener('pointerup', handlePointerUp)
+    this.interaction.addEventListener('pointerleave', handleBlur)
     this.interaction.addEventListener('wheel', handleWheel, { passive: true })
     this.interaction.addEventListener('keydown', handleKeyDown)
     const cameraObserver =
@@ -557,6 +558,7 @@ export class InputManager {
       this.interaction.removeEventListener('pointerdown', handlePointerDown)
       this.interaction.removeEventListener('pointermove', handlePointerMove)
       this.interaction.removeEventListener('pointerup', handlePointerUp)
+      this.interaction.removeEventListener('pointerleave', handleBlur)
       this.interaction.removeEventListener('wheel', handleWheel)
       this.interaction.removeEventListener('keydown', handleKeyDown)
       managers.camera.onMoveObservable.remove(cameraObserver)

--- a/apps/web/src/3d/managers/material.js
+++ b/apps/web/src/3d/managers/material.js
@@ -35,15 +35,21 @@ KhronosTextureContainer2.URLConfig.wasmMSCTranscoder =
 
 const logger = makeLogger('material')
 
-class MaterialManager {
+export class MaterialManager {
   /**
    * Creates a manager to manage and reuse materials
    * - builds textured or colored material for a given scene
    * - reuse built materials based on their texture file (or color)
    * - allows using the same texture in between hand and main scene
    * - automatically clears cache scene disposal.
+   * @param {object} params - parameters, including:
+   * @param {Scene} params.scene - main scene.
+   * @param {Scene} [params.handScene] - scene for meshes in hand.
+   * @param {string} [params.gameAssetsUrl] - base url hosting the game textures.
+   * @param {string} [params.locale] - locale used to download the game textures.
+   * @param {boolean} [params.isWebGL1] - true if the rendering engine only supports WebGL1.
    */
-  constructor() {
+  constructor({ scene, handScene, gameAssetsUrl, locale, isWebGL1 }) {
     /** @type {Scene} main scene. */
     this.scene
     /** @type {Scene|undefined} hand scene. */
@@ -57,31 +63,22 @@ class MaterialManager {
     /** @internal @type {Map<string, PBRSpecularGlossinessMaterial>} map of material for the hand scene.*/
     this.handMaterialByUrl = new Map()
     /** @internal @type {boolean} */
-    this.isWebGL1 = false
-  }
-
-  /**
-   * Initialize manager with scene and configuration values.
-   * @param {object} params - parameters, including:
-   * @param {Scene} params.scene - main scene.
-   * @param {Scene} [params.handScene] - scene for meshes in hand.
-   * @param {string} [params.gameAssetsUrl] - base url hosting the game textures.
-   * @param {string} [params.locale] - locale used to download the game textures.
-   * @param {boolean} [params.isWebGL1] - true if the rendering engine only supports WebGL1.
-   * @param {Game} [game] - loaded game data.
-   */
-  init({ scene, handScene, gameAssetsUrl, locale, isWebGL1 }, game) {
+    this.isWebGL1 = isWebGL1 === true
     this.scene = scene
     this.handScene = handScene
     this.gameAssetsUrl = gameAssetsUrl ?? ''
     this.locale = locale ?? 'fr'
-    this.isWebGL1 = isWebGL1 === true
     logger.debug('material manager initialized')
     this.clear()
     scene.onDisposeObservable.addOnce(() => this.clear())
-    if (game) {
-      preloadMaterials(this, game)
-    }
+  }
+
+  /**
+   * Initializes with game data.
+   * @param {Game} game - loaded game data.
+   */
+  init(game) {
+    preloadMaterials(this, game)
   }
 
   /**
@@ -133,12 +130,6 @@ class MaterialManager {
 }
 
 /**
- * Material manager singleton.
- * @type {MaterialManager}
- */
-export const materialManager = new MaterialManager()
-
-/**
  * @param {MaterialManager} manager - manager instance.
  * @param {Scene} scene - concerned scene.
  * @returns map of cached materials for this scene.
@@ -149,11 +140,10 @@ function getMaterialCache(manager, scene) {
     : manager.handMaterialByUrl
 }
 
-/**
- * @param {MaterialManager} manager - manager instance.
- * @param {Game} game - parsed game data.
- */
-function preloadMaterials(manager, game) {
+function preloadMaterials(
+  /** @type {MaterialManager} */ manager,
+  /** @type {Game} */ game
+) {
   for (const { texture } of [
     ...(game.meshes ?? []),
     ...(game.hands ?? []).flatMap(({ meshes }) => meshes)

--- a/apps/web/src/3d/managers/replay.js
+++ b/apps/web/src/3d/managers/replay.js
@@ -1,13 +1,4 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Engine} Engine
- * @typedef {import('@babylonjs/core').Observer<Action|Move>} Observer
- * @typedef {import('@src/3d/managers').Action} Action
- * @typedef {import('@src/3d/managers').Move} Move
- * @typedef {import('@tabulous/server/src/graphql').ActionName} ActionName
- * @typedef {import('@tabulous/server/src/graphql').HistoryRecord} HistoryRecord
- */
-
 import { Observable } from '@babylonjs/core/Misc/observable.js'
 
 import { makeLogger } from '../../utils'
@@ -20,22 +11,20 @@ export class ReplayManager {
    * Builds a manager to orchestrate replaying, backward and forward, history records.
    * Invokes init() before any other function.
    * @param {object} params - parameters, including:
-   * @param {Engine} params.engine - 3d engine.
+   * @param {import('@babylonjs/core').Engine} params.engine - 3d engine.
    */
   constructor({ engine }) {
     /** game engin. */
     this.engine = engine
-    /** @type {HistoryRecord[]} list of available history records. */
+    /** @type {import('@tabulous/server/src/graphql').HistoryRecord[]} list of available history records. */
     this.history = []
     /** @type {number} current rank when replaying records */
     this.rank = 0
-    /** @type {ReturnType<Engine['serialize']>?} */
-    this._save = null
-    /** @type {Observable<HistoryRecord[]>} emits when history has changed. */
+    /** @type {Observable<import('@tabulous/server/src/graphql').HistoryRecord[]>} emits when history has changed. */
     this.onHistoryObservable = new Observable()
     /** @type {Observable<number>} emits when the replay ranks is modified. */
     this.onReplayRankObservable = new Observable()
-    /** @type {Observer?} */
+    /** @type {import('@babylonjs/core').Observer<import('@src/3d/managers').ActionOrMove>?} */
     this.actionObserver
     /** @internal avoid concurrent replays */
     this.inhibitReplay = false
@@ -43,6 +32,8 @@ export class ReplayManager {
     this.moveDuration = 200
     /** @internal @type {import('@src/3d/managers').Managers} */
     this.managers
+    /** @internal @type {string} */
+    this.playerId
 
     this.engine.onDisposeObservable.addOnce(() => {
       this.managers?.control.onActionObservable.remove(this.actionObserver)
@@ -57,16 +48,15 @@ export class ReplayManager {
    * @param {object} params - parameters, including:
    * @param {string} params.playerId - id of the local player.
    * @param {import('@src/3d/managers').Managers} params.managers - current managers.
-   * @param {HistoryRecord[]} [params.history] - initial history.
+   * @param {import('@tabulous/server/src/graphql').HistoryRecord[]} [params.history] - initial history.
    */
   init({ managers, history = [], playerId }) {
     this.managers = managers
+    this.playerId = playerId
     this.reset(history)
-    this.actionObserver = managers.control.onActionObservable.add(action => {
-      if (!('isLocal' in action) || !action.isLocal) {
-        this.record(action, playerId)
-      }
-    })
+    this.actionObserver = managers.control.onActionObservable.add(action =>
+      this.record(action)
+    )
     logger.debug({ history, rank: this.rank }, 'replay manager initialized')
   }
 
@@ -75,14 +65,9 @@ export class ReplayManager {
     return this.rank < this.history.length
   }
 
-  /** Serialized engine, if replay is in progress. */
-  get save() {
-    return this.isReplaying ? this._save : null
-  }
-
   /**
    * Reset records and rank, and notifies listeners.
-   * @param {HistoryRecord[]} [history] - history content.
+   * @param {import('@tabulous/server/src/graphql').HistoryRecord[]} [history] - history content.
    */
   reset(history = []) {
     this.history = history
@@ -95,45 +80,51 @@ export class ReplayManager {
    * Record a new action or move into history.
    * It collapses redundant moves together and notifies listeners.
    * Only updates current rank if it was on last.
-   * @param {Action|Move} record - received record.
-   * @param {string} playerId - id of the player who sent the record.
+   * @param {import('@src/3d/managers').ActionOrMove} record - received record.
+   * @param {string} [playerId] - id of the player who sent the record.
    */
-  record(record, playerId) {
-    if (!record.fromHand && ('pos' in record || !record.isLocal)) {
-      logger.debug(
-        { record, history: this.history, rank: this.rank },
-        'adding to the history'
-      )
-      const needsRankUpdate = this.rank === this.history.length
-      /** @type {HistoryRecord} */
-      const result =
-        'fn' in record
-          ? {
-              fn: /** @type {ActionName} */ (record.fn),
-              argsStr: JSON.stringify(record.args),
-              revertStr: record.revert
-                ? JSON.stringify(record.revert)
-                : undefined,
-              meshId: record.meshId,
-              duration: record.duration,
-              time: Date.now(),
-              playerId
-            }
-          : {
-              pos: record.pos,
-              prev: record.prev,
-              meshId: record.meshId,
-              duration: record.duration,
-              time: Date.now(),
-              playerId
-            }
-      this.history = collapseAndAppendHistory(this.history, result)
-      if (needsRankUpdate) {
-        this.rank = this.history.length
-        this.onReplayRankObservable.notifyObservers(this.rank)
-      }
-      this.onHistoryObservable.notifyObservers(this.history)
+  record(record, playerId = this.playerId) {
+    if ('isLocal' in record && record.isLocal) {
+      return
     }
+
+    logger.debug(
+      { record, history: this.history, rank: this.rank },
+      'adding to the history'
+    )
+    const needsRankUpdate = this.rank === this.history.length
+    /** @type {import('@tabulous/server/src/graphql').HistoryRecord} */
+    const result =
+      'fn' in record
+        ? {
+            fn: /** @type {import('@tabulous/server/src/graphql').ActionName} */ (
+              record.fn
+            ),
+            argsStr: JSON.stringify(record.args),
+            revertStr: record.revert
+              ? JSON.stringify(record.revert)
+              : undefined,
+            meshId: record.meshId,
+            duration: record.duration,
+            time: Date.now(),
+            playerId,
+            fromHand: record.fromHand
+          }
+        : {
+            pos: record.pos,
+            prev: record.prev,
+            meshId: record.meshId,
+            duration: record.duration,
+            time: Date.now(),
+            playerId,
+            fromHand: record.fromHand
+          }
+    this.history = collapseAndAppendHistory(this.history, result)
+    if (needsRankUpdate) {
+      this.rank = this.history.length
+      this.onReplayRankObservable.notifyObservers(this.rank)
+    }
+    this.onHistoryObservable.notifyObservers(this.history)
   }
 
   /**
@@ -145,9 +136,6 @@ export class ReplayManager {
       return
     }
     this.inhibitReplay = true
-    if (!this.isReplaying) {
-      this._save = this.engine.serialize()
-    }
     if (untilRank >= 0 && untilRank < this.history.length) {
       const reverting = this.rank > untilRank
       do {
@@ -167,12 +155,19 @@ export class ReplayManager {
 }
 
 /**
- * Apply or revert a given revord.
+ * Apply or revert a given revord, unless it comes from a peer's hand.
  * @param {ReplayManager} manager - current manager.
- * @param {HistoryRecord} record - concerned record.
+ * @param {import('@tabulous/server/src/graphql').HistoryRecord} record - concerned record.
  * @param {boolean} [reverting] - whether the record should be reverted (true) or applied (false).
  */
-async function apply({ moveDuration, managers }, record, reverting = false) {
+async function apply(
+  { moveDuration, managers, playerId },
+  record,
+  reverting = false
+) {
+  if (record.fromHand && record.playerId !== playerId) {
+    return
+  }
   logger.debug({ record, reverting }, 'replaying record')
 
   if ('prev' in record && record.prev) {
@@ -207,43 +202,36 @@ async function apply({ moveDuration, managers }, record, reverting = false) {
 
 /**
  * Appends a record to history. Also handles these cases:
- * - when moving a mesh, if this mesh's previous action is a move by the same player, then collapse moves.
- * - when moving a mesh, if this mesh's previous action is a draw by the same player, then ignore the move.
- * - when playing a mesh, if this mesh's previous action is a move by the same player, then ignore the move.
- * @param {HistoryRecord[]} history - history of records.
- * @param {HistoryRecord} added - candidate record to add.
+ * - when moving a mesh, if this mesh's previous action is a move by the same player in the same scene, then collapse moves.
+ * - when moving a mesh, if this mesh's previous action is a draw by the same player, then ignore the move on table.
+ * @param {import('@tabulous/server/src/graphql').HistoryRecord[]} history - history of records.
+ * @param {import('@tabulous/server/src/graphql').HistoryRecord} added - candidate record to add.
  * @returns the collapsed history.
  */
 function collapseAndAppendHistory(history, added) {
   let add = true
-  if (
-    'pos' in added ||
-    added.fn === actionNames.draw ||
-    added.fn === actionNames.play
-  ) {
+  if ('pos' in added) {
     const previousIdx = history.findLastIndex(
       record => record.meshId === added.meshId
     )
     if (previousIdx >= 0) {
       const previous = history[previousIdx]
-      if ('pos' in added) {
-        if ('pos' in previous && previous.playerId === added.playerId) {
-          // collapses moves together: updates `prev` but keeps `pos`
-          added.prev = previous.prev
-          history.splice(previousIdx, 1)
-        } else if (
-          'fn' in previous &&
-          previous.fn === actionNames.draw &&
-          previous.playerId === added.playerId
-        ) {
-          // ignore moves after draw
-          add = false
-        }
-      } else if (added.fn === actionNames.play) {
-        if ('pos' in previous && previous.playerId === added.playerId) {
-          // ignore moves before play
-          history.splice(previousIdx, 1)
-        }
+      if (
+        'pos' in previous &&
+        previous.playerId === added.playerId &&
+        previous.fromHand === added.fromHand
+      ) {
+        // collapses moves together: updates `prev` but keeps `pos`
+        added.prev = previous.prev
+        history.splice(previousIdx, 1)
+      } else if (
+        'fn' in previous &&
+        previous.fn === actionNames.draw &&
+        previous.playerId === added.playerId &&
+        !added.fromHand
+      ) {
+        // ignore moves after draw
+        add = false
       }
     }
   }

--- a/apps/web/src/3d/managers/replay.js
+++ b/apps/web/src/3d/managers/replay.js
@@ -12,8 +12,9 @@ export class ReplayManager {
    * Invokes init() before any other function.
    * @param {object} params - parameters, including:
    * @param {import('@babylonjs/core').Engine} params.engine - 3d engine.
+   * @param {number} [params.moveDuration] - duration applied to moved meshes, in ms.
    */
-  constructor({ engine }) {
+  constructor({ engine, moveDuration = 200 }) {
     /** game engin. */
     this.engine = engine
     /** @type {import('@tabulous/server/src/graphql').HistoryRecord[]} list of available history records. */
@@ -29,7 +30,7 @@ export class ReplayManager {
     /** @internal avoid concurrent replays */
     this.inhibitReplay = false
     /** @internal */
-    this.moveDuration = 200
+    this.moveDuration = moveDuration
     /** @internal @type {import('@src/3d/managers').Managers} */
     this.managers
     /** @internal @type {string} */

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -1,10 +1,4 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').LinesMesh} LinesMesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils').ScreenPosition} ScreenPosition
- */
-
 import { Axis, Space } from '@babylonjs/core/Maths/math.axis.js'
 import { Color3, Color4 } from '@babylonjs/core/Maths/math.color.js'
 import { Quaternion, Vector3 } from '@babylonjs/core/Maths/math.vector.js'
@@ -29,8 +23,8 @@ export class SelectionManager {
    * - clear previous selection
    * Invokes init() before any other function.
    * @param {object} params - parameters, including:
-   * @param {Scene} params.scene - scene attached to.
-   * @param {Scene} params.handScene - scene for meshes in hand.
+   * @param {import('@babylonjs/core').Scene} params.scene - scene attached to.
+   * @param {import('@babylonjs/core').Scene} params.handScene - scene for meshes in hand.
    */
   constructor({ scene, handScene }) {
     // we need to keep this set immutable, because it is referenced when adding to it
@@ -48,7 +42,7 @@ export class SelectionManager {
     this.color
     /** @internal @type {string} */
     this.playerId
-    /** @internal @type {?LinesMesh} */
+    /** @internal @type {?import('@babylonjs/core').LinesMesh} */
     this.box = null
     /** @internal @type {boolean} */
     this.skipNotify = false
@@ -82,8 +76,8 @@ export class SelectionManager {
 
   /**
    * Draws selection box between two points (in screen coordinates)
-   * @param {ScreenPosition} start - selection box's start screen position.
-   * @param {ScreenPosition} end - selection box's end screen position.
+   * @param {import('@src/3d/utils').ScreenPosition} start - selection box's start screen position.
+   * @param {import('@src/3d/utils').ScreenPosition} end - selection box's end screen position.
    */
   drawSelectionBox(start, end) {
     logger.debug({ start, end }, `draw selection box`)

--- a/apps/web/src/3d/managers/selection.js
+++ b/apps/web/src/3d/managers/selection.js
@@ -46,6 +46,8 @@ export class SelectionManager {
     this.handScene = handScene
     /** @type {Color4} current player color, for selection */
     this.color
+    /** @internal @type {string} */
+    this.playerId
     /** @internal @type {?LinesMesh} */
     this.box = null
     /** @internal @type {boolean} */
@@ -67,6 +69,7 @@ export class SelectionManager {
    * @param {Map<string, string>} params.colorByPlayerId - map of hexadecimal color strings used for selection box, and selected mesh overlay, by player id.
    */
   init({ managers, playerId, colorByPlayerId }) {
+    this.playerId = playerId
     this.managers = managers
     this.colorByPlayerId = new Map(
       [...colorByPlayerId.entries()].map(([playerId, color]) => [
@@ -248,9 +251,12 @@ export class SelectionManager {
    * Applies selection from peer players: highlight selected meshes with the player's own color.
    * Ignores meshes that are part of current player's selection.
    * @param {string[]} meshIds - ids of selected meshes.
-   * @param {string} playerId - id of the peer selecting these meshes.s.
+   * @param {string} [playerId] - id of the peer selecting these meshes (default to current player).
    */
   apply(meshIds, playerId) {
+    if (!playerId) {
+      return
+    }
     const color = this.colorByPlayerId.get(playerId)
     if (!color) {
       return

--- a/apps/web/src/3d/meshes/box.js
+++ b/apps/web/src/3d/meshes/box.js
@@ -1,15 +1,7 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder.js'
 
-import { controlManager } from '../managers/control'
-import { materialManager } from '../managers/material'
 import { registerBehaviors, serializeBehaviors } from '../utils/behaviors'
 import { applyInitialTransform, setExtras } from '../utils/mesh'
 
@@ -23,9 +15,10 @@ import { applyInitialTransform, setExtras } from '../utils/mesh'
  *   5. negative Z (0°)
  *   6. positive Z (180°)
  * By default, boxes have a dimension of 1.
- * @param {Omit<SerializedMesh, 'shape'>} params - box parameters.
- * @param {Scene} scene - scene for the created mesh.
- * @returns {Mesh} the created box mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - box parameters.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
+ * @returns the created box mesh.
  */
 export function createBox(
   {
@@ -48,6 +41,7 @@ export function createBox(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const mesh = CreateBox(
@@ -61,7 +55,7 @@ export function createBox(
     scene
   )
   mesh.name = 'box'
-  materialManager.configure(mesh, texture)
+  managers.material.configure(mesh, texture)
   applyInitialTransform(mesh, transform)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
@@ -85,8 +79,8 @@ export function createBox(
     }
   })
 
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
-  controlManager.registerControlable(mesh)
+  managers.control.registerControlable(mesh)
   return mesh
 }

--- a/apps/web/src/3d/meshes/card.js
+++ b/apps/web/src/3d/meshes/card.js
@@ -1,15 +1,7 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder.js'
 
-import { controlManager } from '../managers/control'
-import { materialManager } from '../managers/material'
 import { registerBehaviors, serializeBehaviors } from '../utils/behaviors'
 import { applyInitialTransform, setExtras } from '../utils/mesh'
 
@@ -18,8 +10,9 @@ import { applyInitialTransform, setExtras } from '../utils/mesh'
  * Cards are boxes whith a given width, height and depth. Only top and back faces UVs can be specified
  * By default, the card dimension follows American poker card standard (beetween 1.39 & 1.41).
  * A card's texture must have 2 faces, back then front, aligned horizontally.
- * @param {Omit<SerializedMesh, 'shape'>} params - card parameters.
- * @param {Scene} scene - scene for the created mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - card parameters.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
  * @returns the created card mesh.
  */
 export function createCard(
@@ -39,6 +32,7 @@ export function createCard(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const mesh = CreateBox(
@@ -60,7 +54,7 @@ export function createCard(
     scene
   )
   mesh.name = 'card'
-  materialManager.configure(mesh, texture)
+  managers.material.configure(mesh, texture)
   applyInitialTransform(mesh, transform)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
@@ -84,8 +78,8 @@ export function createCard(
     }
   })
 
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
-  controlManager.registerControlable(mesh)
+  managers.control.registerControlable(mesh)
   return mesh
 }

--- a/apps/web/src/3d/meshes/die.js
+++ b/apps/web/src/3d/meshes/die.js
@@ -1,11 +1,4 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@tabulous/server/src/graphql').RandomizableState} RandomizableState
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Matrix, Quaternion } from '@babylonjs/core/Maths/math.vector'
 
 import { toRad } from '../../utils/math'
@@ -16,9 +9,10 @@ import { createCustom } from './custom'
 /**
  * Creates a die, which could have from 4, 6, or 8 faces.
  * By default, dices have a diameter of 1, and 6 faces.
- * @param {Omit<SerializedMesh, 'shape'>} params - die parameters.
- * @param {Scene} scene - scene for the created mesh.
- * @returns {Promise<Mesh>} the created die mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - die parameters.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
+ * @returns the created die mesh.
  */
 export async function createDie(
   {
@@ -32,6 +26,7 @@ export async function createDie(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const mesh = await createCustom(
@@ -43,6 +38,7 @@ export async function createDie(
       z,
       file: getDieModelFile(faces)
     },
+    managers,
     scene
   )
 
@@ -74,7 +70,7 @@ export async function createDie(
     max: faces,
     quaternionPerFace: getQuaternions(faces)
   }
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
   return mesh
 }
@@ -82,7 +78,7 @@ export async function createDie(
 /**
  * Computes the model file url for a given die.
  * @param {number} faces - number of faces for this die (4, 6, 8).
- * @returns {string} url of the model file.
+ * @returns url of the model file.
  * @throws {Error} if the desired number of faces is not supported.
  */
 export function getDieModelFile(faces) {

--- a/apps/web/src/3d/meshes/index.js
+++ b/apps/web/src/3d/meshes/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 export * from './box'
 export * from './card'
 export * from './custom'

--- a/apps/web/src/3d/meshes/prism.js
+++ b/apps/web/src/3d/meshes/prism.js
@@ -1,15 +1,7 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder.js'
 
-import { controlManager } from '../managers/control'
-import { materialManager } from '../managers/material'
 import { registerBehaviors, serializeBehaviors } from '../utils/behaviors'
 import { applyInitialTransform, setExtras } from '../utils/mesh'
 
@@ -17,9 +9,10 @@ import { applyInitialTransform, setExtras } from '../utils/mesh'
  * Creates a prism, with a given number of base edge (starting at 3).
  * A prism's texture must have edges + 2 faces, starting with back and ending with front, aligned horizontally.
  * By default, prisms have 6 edges and a width of 3.
- * @param {Omit<SerializedMesh, 'shape'>} params - prism parameters.
- * @param {Scene} scene - scene for the created mesh.
- * @returns {Mesh} the created prism mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - prism parameters.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
+ * @returns the created prism mesh.
  */
 export function createPrism(
   {
@@ -39,6 +32,7 @@ export function createPrism(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const mesh = CreateCylinder(
@@ -52,7 +46,7 @@ export function createPrism(
     scene
   )
   mesh.name = 'prism'
-  materialManager.configure(mesh, texture)
+  managers.material.configure(mesh, texture)
   applyInitialTransform(mesh, transform)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
@@ -77,8 +71,8 @@ export function createPrism(
     }
   })
 
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
-  controlManager.registerControlable(mesh)
+  managers.control.registerControlable(mesh)
   return mesh
 }

--- a/apps/web/src/3d/meshes/round-token.js
+++ b/apps/web/src/3d/meshes/round-token.js
@@ -1,15 +1,7 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder.js'
 
-import { controlManager } from '../managers/control'
-import { materialManager } from '../managers/material'
 import { registerBehaviors, serializeBehaviors } from '../utils/behaviors'
 import { applyInitialTransform, setExtras } from '../utils/mesh'
 
@@ -18,9 +10,10 @@ import { applyInitialTransform, setExtras } from '../utils/mesh'
  * Tokens are cylinders, so their position is their center.
  * A token's texture must have 3 faces, back then edge then front, aligned horizontally.
  * By default tokens have a diameter of 2.
- * @param {Omit<SerializedMesh, 'shape'>} params - token parameters.
- * @param {Scene} scene - scene for the created mesh.
- * @returns {Mesh} the created token mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - token parameters.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @returns the created token mesh.
  */
 export function createRoundToken(
   {
@@ -39,6 +32,7 @@ export function createRoundToken(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const mesh = CreateCylinder(
@@ -52,7 +46,7 @@ export function createRoundToken(
     scene
   )
   mesh.name = 'roundToken'
-  materialManager.configure(mesh, texture)
+  managers.material.configure(mesh, texture)
   applyInitialTransform(mesh, transform)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
@@ -76,8 +70,8 @@ export function createRoundToken(
     }
   })
 
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
-  controlManager.registerControlable(mesh)
+  managers.control.registerControlable(mesh)
   return mesh
 }

--- a/apps/web/src/3d/meshes/rounded-tile.js
+++ b/apps/web/src/3d/meshes/rounded-tile.js
@@ -1,18 +1,10 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@src/3d/utils/behaviors').SerializedMesh} SerializedMesh
- */
-
 import { Axis } from '@babylonjs/core/Maths/math.axis.js'
 import { Vector3, Vector4 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateBox } from '@babylonjs/core/Meshes/Builders/boxBuilder.js'
 import { CreateCylinder } from '@babylonjs/core/Meshes/Builders/cylinderBuilder.js'
 import { CSG } from '@babylonjs/core/Meshes/csg.js'
 
-import { controlManager } from '../managers/control'
-import { materialManager } from '../managers/material'
 import { registerBehaviors, serializeBehaviors } from '../utils/behaviors'
 import { applyInitialTransform, setExtras } from '../utils/mesh'
 
@@ -21,9 +13,10 @@ import { applyInitialTransform, setExtras } from '../utils/mesh'
  * Tiles are boxes, so their position is their center.
  * A tile's texture must have 2 faces, back then front, aligned horizontally.
  * By default tiles have a width and depth of 3 with a border radius of 0.4.
- * @param {Omit<SerializedMesh, 'shape'>} params - token parameters.
- * @param {Scene} scene - scene for the created mesh.
- * @returns {Mesh} the created tile mesh.
+ * @param {Omit<import('@src/3d/utils/behaviors').SerializedMesh, 'shape'>} params - token parameters.
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene for the created mesh.
+ * @returns the created tile mesh.
  */
 export function createRoundedTile(
   {
@@ -47,6 +40,7 @@ export function createRoundedTile(
     transform = undefined,
     ...behaviorStates
   },
+  managers,
   scene
 ) {
   const tileMesh = CreateBox(
@@ -75,7 +69,7 @@ export function createRoundedTile(
   tileCSG.subtractInPlace(makeCornerMesh(cornerParams, false, false))
   const mesh = tileCSG.toMesh(id, undefined, scene)
   mesh.name = 'roundedTile'
-  materialManager.configure(mesh, texture)
+  managers.material.configure(mesh, texture)
   applyInitialTransform(mesh, transform)
   mesh.setAbsolutePosition(new Vector3(x, y, z))
   mesh.isPickable = false
@@ -101,17 +95,17 @@ export function createRoundedTile(
     }
   })
 
-  registerBehaviors(mesh, behaviorStates)
+  registerBehaviors(mesh, behaviorStates, managers)
 
-  controlManager.registerControlable(mesh)
+  managers.control.registerControlable(mesh)
   return mesh
 }
 
 /**
- * @param {Required<Pick<SerializedMesh, 'borderRadius'|'width'|'height'|'depth'> & { faceUV: Vector4 }>} cornerParams - corner parameters
+ * @param {Required<Pick<import('@src/3d/utils/behaviors').SerializedMesh, 'borderRadius'|'width'|'height'|'depth'> & { faceUV: Vector4 }>} cornerParams - corner parameters
  * @param {boolean} isTop  - whether if this corner is on the top or the bottom.
  * @param {boolean} isLeft - whether if this corner is on the left or the right.
- * @returns {CSG} Constructive Solid Geometry built for this corner.
+ * @returns Constructive Solid Geometry built for this corner.
  */
 function makeCornerMesh(
   { borderRadius, width, height, depth, faceUV },

--- a/apps/web/src/3d/utils/actions.js
+++ b/apps/web/src/3d/utils/actions.js
@@ -56,7 +56,7 @@ export const buttonIds = {
  * Parse game data to build a map of supported action names by their shortcuts.
  * @param {SerializedMesh[]} meshes - serialized meshes to be analyzed.
  * @param {Translate} translate - translation
- * @returns {Map<string, ActionName[]>} map of supported action names by shortcut.
+ * @returns map of supported action names by shortcut.
  */
 export function buildActionNamesByKey(meshes, translate) {
   /** @type {Map<string, ActionName[]>} */

--- a/apps/web/src/3d/utils/behaviors.js
+++ b/apps/web/src/3d/utils/behaviors.js
@@ -51,7 +51,7 @@ import { setExtras } from './mesh'
 
 const animationLogger = makeLogger('animatable')
 
-/** @type {?[BehaviorNames, { new (state: ?): Behavior }][]} */
+/** @type {?[BehaviorNames, { new (state: ?, managers: import('@src/3d/managers').Managers): Behavior }][]} */
 let constructors = null
 
 function getConstructors() {
@@ -80,11 +80,12 @@ function getConstructors() {
  * and attach it to the mesh.
  * @param {Mesh} mesh - the modified mesh.
  * @param {BehaviorState} params - parameters, which may contain behavior specific states.
+ * @param {import('@src/3d/managers').Managers} managers - current managers
  */
-export function registerBehaviors(mesh, params) {
+export function registerBehaviors(mesh, params, managers) {
   for (const [name, constructor] of getConstructors()) {
     if (params[name]) {
-      mesh.addBehavior(new constructor(params[name]), true)
+      mesh.addBehavior(new constructor(params[name], managers), true)
     }
   }
 }
@@ -284,7 +285,6 @@ export function attachFunctions(behavior, ...functionNames) {
  * @param {AnimateBehavior} behavior - animated behavior.
  * @param {?() => void} onEnd - function invoked when all animations have completed.
  * @param {AnimationSpec[]} animationSpecs - list of animation specs.
- * @returns {Promise<void>}
  */
 export function runAnimation({ mesh, frameRate }, onEnd, ...animationSpecs) {
   if (!mesh) {

--- a/apps/web/src/3d/utils/behaviors.js
+++ b/apps/web/src/3d/utils/behaviors.js
@@ -139,7 +139,7 @@ export function animateMove(
     return movable.moveTo(
       absolutePosition,
       rotation,
-      mesh.getEngine().isSimulation ? 0 : duration,
+      mesh.getEngine().simulation === null ? 0 : duration,
       withGravity
     )
   } else {
@@ -321,7 +321,11 @@ export function runAnimation({ mesh, frameRate }, onEnd, ...animationSpecs) {
   const wasHittable = mesh.isHittable
   mesh.isHittable = false
   mesh.animationInProgress = true
-  animationLogger.debug({ mesh, animations }, `starts animations on ${mesh.id}`)
+  const speed = mesh.getEngine().simulation === null ? 100 : 1
+  animationLogger.debug(
+    { mesh, animations, speed },
+    `starts animations on ${mesh.id}`
+  )
   return new Promise(resolve =>
     mesh
       .getScene()
@@ -331,7 +335,7 @@ export function runAnimation({ mesh, frameRate }, onEnd, ...animationSpecs) {
         0,
         lastFrame,
         false,
-        mesh.getEngine().isSimulation ? 100 : 1,
+        speed,
         () => {
           animationLogger.debug(
             { mesh, animations, wasPickable, wasHittable },

--- a/apps/web/src/3d/utils/gravity.js
+++ b/apps/web/src/3d/utils/gravity.js
@@ -31,7 +31,7 @@ export const altitudeGap = 0.01
  * Return the altitude of a mesh center if it was lying on the ground
  * @template {AbstractMesh} T
  * @param {T} mesh - dested mesh.
- * @returns {number} resulting y coordinage.
+ * @returns resulting y coordinage.
  */
 export function getGroundAltitude(mesh) {
   return -mesh.getBoundingInfo().minimum.y
@@ -41,7 +41,7 @@ export function getGroundAltitude(mesh) {
  * Returns the absolute altitude (Y axis) above a given mesh, including minimum spacing.
  * @template {AbstractMesh} T
  * @param {T} mesh - related mesh.
- * @returns {number} resulting Y coordinate.
+ * @returns resulting Y coordinate.
  */
 export function getAltitudeAbove(mesh) {
   return mesh.getBoundingInfo().boundingBox.maximumWorld.y + altitudeGap
@@ -53,7 +53,7 @@ export function getAltitudeAbove(mesh) {
  * @template {AbstractMesh} T
  * @param {T} meshBelow - foundation to put the mesh on.
  * @param {T} meshAbove - positionned over the other mesh.
- * @returns {number} resulting Y coordinate.
+ * @returns resulting Y coordinate.
  */
 export function getCenterAltitudeAbove(meshBelow, meshAbove) {
   meshBelow.computeWorldMatrix(true)
@@ -65,7 +65,7 @@ export function getCenterAltitudeAbove(meshBelow, meshAbove) {
  * It'll check all other meshes in the same scene to identify the ones below (partial overlap is supported).
  * Does not run any animation, and change its absolute position.
  * @param {Mesh} mesh - applied mesh.
- * @returns {Vector3} the mesh's new absolute position
+ * @returns the mesh's new absolute position
  */
 export function applyGravity(mesh) {
   logger.info(
@@ -98,7 +98,7 @@ export function applyGravity(mesh) {
  * @template {AbstractMesh} T
  * @param {T} mesh - checked mesh.
  * @param {T} target - other mesh.
- * @returns {boolean} true when mesh is hovering the target.
+ * @returns true when mesh is hovering the target.
  */
 export function isAbove(mesh, target) {
   return findBelow(mesh, [target]).length === 1
@@ -110,7 +110,7 @@ export function isAbove(mesh, target) {
  * @template {AbstractMesh} T
  * @param {Iterable<T>} [meshes] - array of meshes to order.
  * @param {boolean} [highestFirst = false] - false to return highest first.
- * @returns {T[]} sorted array.
+ * @returns sorted array.
  */
 export function sortByElevation(meshes, highestFirst = false) {
   return [...(meshes ?? [])].sort((a, b) =>
@@ -124,7 +124,7 @@ export function sortByElevation(meshes, highestFirst = false) {
  * @template {AbstractMesh} T
  * @param {T} mesh - reference mesh.
  * @param {T[]} candidates - list of candidate meshes to consider.
- * @returns {T[]} candidate meshes bellow the reference mesh.
+ * @returns candidate meshes bellow the reference mesh.
  */
 function findBelow(mesh, candidates) {
   const results = []
@@ -146,7 +146,7 @@ function findBelow(mesh, candidates) {
 /**
  * @param {Geometry} geometryA - first considered geometry.
  * @param {Geometry} geometryB - second considered geometry.
- * @returns {boolean} whether these geometry instersect.
+ * @returns whether these geometry instersect.
  */
 function intersectGeometries(geometryA, geometryB) {
   const circleA = 'center' in geometryA ? geometryA : null
@@ -169,7 +169,7 @@ function intersectGeometries(geometryA, geometryB) {
  * @template {AbstractMesh} T
  * @param {T} mesh - reference mesh.
  * @param {BoundingBox} boundingBox - bounding box to build geometry for.
- * @returns {Geometry} bounding box's geomertry object.
+ * @returns bounding box's geomertry object.
  */
 function buildGeometry(mesh, boundingBox) {
   const rectangle = buildGroundRectangle(boundingBox)
@@ -179,7 +179,7 @@ function buildGeometry(mesh, boundingBox) {
 /**
  * @param {BoundingBox} reference - reference bounding box.
  * @param {BoundingBox} tested - tested bounding box.
- * @returns {boolean} whether tested bounding box is below the reference.
+ * @returns whether tested bounding box is below the reference.
  */
 function isGloballyBelow(reference, tested) {
   return tested.maximumWorld.y <= reference.minimumWorld.y

--- a/apps/web/src/3d/utils/lights.js
+++ b/apps/web/src/3d/utils/lights.js
@@ -29,15 +29,14 @@ import { TableId } from './table.js'
  * @param {object} params - parameters, including:
  * @param {Scene} params.scene - main scene.
  * @param {Scene} params.handScene - hand scene.
- * @param {boolean} [params.isWebGL1] - true if the rendering engine only supports WebGL1.
  * @returns {LightResult} an object containing created light and shadowGenerator.
  */
-export function createLights({ scene, handScene, isWebGL1 }) {
+export function createLights({ scene, handScene }) {
   const light = makeDirectionalLight(scene)
   const ambientLight = makeAmbientLight(scene)
 
   const shadowGenerator = new ShadowGenerator(1024, light)
-  shadowGenerator.usePercentageCloserFiltering = !isWebGL1
+  shadowGenerator.usePercentageCloserFiltering = scene.getEngine().version !== 1
   // https://forum.babylonjs.com/t/shadow-darkness-darker-than-0/22837
   // @ts-expect-error _darkness is private
   shadowGenerator._darkness = -1.5

--- a/apps/web/src/3d/utils/mesh.js
+++ b/apps/web/src/3d/utils/mesh.js
@@ -47,7 +47,7 @@ export function isAnimationInProgress(mesh) {
  * @template {AbstractMesh} M
  * @param {M} container - container that may contain the mesh.
  * @param {M} mesh - tested mesh.
- * @returns {boolean} true if container contains mesh, false otherwise.
+ * @returns true if container contains mesh, false otherwise.
  */
 export function isContaining(container, mesh) {
   container.computeWorldMatrix(true)
@@ -71,7 +71,7 @@ export function isContaining(container, mesh) {
  * **Requires a fresh world matrix**.
  * @template {AbstractMesh} T
  * @param {T} mesh - sized mesh.
- * @returns {{ width: number, height: number, depth: number }} mesh's dimensions.
+ * @returns mesh's dimensions.
  */
 export function getDimensions(mesh) {
   mesh.computeWorldMatrix(true)

--- a/apps/web/src/3d/utils/scene.js
+++ b/apps/web/src/3d/utils/scene.js
@@ -1,8 +1,5 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Engine} Engine
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- */
+/** @typedef {import('@babylonjs/core').Mesh} Mesh */
 
 import { Scene } from '@babylonjs/core/scene.js'
 
@@ -11,7 +8,7 @@ import { Scene } from '@babylonjs/core/scene.js'
  */
 export class ExtendedScene extends Scene {
   /**
-   * @param {Engine} engine - rendering engine.
+   * @param {import('@babylonjs/core').Engine} engine - rendering engine.
    * @param {?} [options] - scene options.
    * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#constructor
    */
@@ -42,7 +39,7 @@ export class ExtendedScene extends Scene {
   /**
    * @param {Mesh} mesh - removed mesh.
    * @param {boolean} [recursive] - whether to remove children meshes as well.
-   * @returns {number} removed mesh index.
+   * @returns removed mesh index.
    * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#removeMesh
    */
   removeMesh(mesh, recursive) {
@@ -52,7 +49,7 @@ export class ExtendedScene extends Scene {
 
   /**
    * @param {string} id - searched mesh id.
-   * @returns {?Mesh} found mesh.
+   * @returns found mesh.
    * @see https://doc.babylonjs.com/typedoc/classes/babylon.scene#getMeshByID
    */
   getMeshById(id) {

--- a/apps/web/src/3d/utils/table.js
+++ b/apps/web/src/3d/utils/table.js
@@ -1,28 +1,20 @@
 // @ts-check
-/**
- * @typedef {import('@babylonjs/core').Scene} Scene
- * @typedef {import('@babylonjs/core').Material} Material
- * @typedef {import('@babylonjs/core').Mesh} Mesh
- * @typedef {import('@babylonjs/core').Texture} Texture
- * @typedef {import('@tabulous/server/src/graphql').TableSpec} TableSpec
- */
-
 import { Vector3 } from '@babylonjs/core/Maths/math.vector.js'
 import { CreateGround } from '@babylonjs/core/Meshes/Builders/groundBuilder.js'
-
-import { materialManager } from '../managers/material'
 
 export const TableId = 'table'
 
 /**
  * Creates ground mesh to act as table, that received shadows but can not receive rays.
  * Table is always 0.01 unit bellow (Y axis) origin.
- * @param {TableSpec|undefined} tableSpec - table parameters
- * @param {Scene} scene - scene to host the table (default to last scene).
- * @returns {Mesh} the created table ground.
+ * @param {import('@tabulous/server/src/graphql').TableSpec|undefined} tableSpec - table parameters
+ * @param {import('@src/3d/managers').Managers} managers - current managers.
+ * @param {import('@babylonjs/core').Scene} scene - scene to host the table (default to last scene).
+ * @returns the created table ground.
  */
 export function createTable(
   { width = 400, height = 400, texture } = {},
+  managers,
   scene
 ) {
   const table = CreateGround(TableId, { width: width, height: height }, scene)
@@ -30,10 +22,11 @@ export function createTable(
   table.receiveShadows = true
   table.isPickable = false
   if (texture) {
-    table.material = materialManager.buildOnDemand(texture, scene)
-    const material = /** @type {Material & { diffuseTexture: Texture? }} */ (
-      table.material
-    )
+    table.material = managers.material.buildOnDemand(texture, scene)
+    const material =
+      /** @type {import('@babylonjs/core').Material & { diffuseTexture: import('@babylonjs/core').Texture? }} */ (
+        table.material
+      )
     if (material.diffuseTexture) {
       material.diffuseTexture.uScale = 5
       material.diffuseTexture.vScale = 5

--- a/apps/web/src/3d/utils/vector.js
+++ b/apps/web/src/3d/utils/vector.js
@@ -30,7 +30,7 @@ let table = null
  * Useful to know where on the ground a player has clicked.
  * @param {Scene} scene - current scene.
  * @param {ScreenPosition} position - screen position.
- * @returns {Vector3} 3D point on the ground plane (Y axis) for this position, if any.
+ * @returns 3D point on the ground plane (Y axis) for this position, if any.
  */
 export function screenToGround(scene, { x, y }) {
   return /** @type {Vector3} */ (
@@ -42,7 +42,7 @@ export function screenToGround(scene, { x, y }) {
  * Indicates whether a screen position (2D, DOM) is above the table mesh.
  * @param {Scene} scene - current scene.
  * @param {ScreenPosition} position - screen position.
- * @returns {boolean} true if the point is within the table area, false otherwise.
+ * @returns true if the point is within the table area, false otherwise.
  */
 export function isAboveTable(scene, { x, y }) {
   /* istanbul ignore next */
@@ -58,7 +58,7 @@ export function isAboveTable(scene, { x, y }) {
  * Indicates whether a world position (3D, scene) is above the table mesh.
  * @param {Scene} scene - current scene.
  * @param {Vector3} position - 3D position.
- * @returns {boolean} true if the point is within the table area, false otherwise.
+ * @returns true if the point is within the table area, false otherwise.
  */
 export function isPositionAboveTable(scene, position) {
   /* istanbul ignore next */
@@ -77,7 +77,7 @@ export function isPositionAboveTable(scene, position) {
  * @template {AbstractMesh} T
  * @param {T?} [mesh] - the tested mesh.
  * @param {[number, number, number]} [offset = [0, 0, 0]] - optional offset (3D coordinates) applied.
- * @returns {ScreenPosition|null} this mesh's screen position.
+ * @returns this mesh's screen position.
  */
 export function getMeshScreenPosition(mesh, offset = [0, 0, 0]) {
   if (!mesh || !mesh.getScene()?.activeCamera) {
@@ -115,7 +115,7 @@ export function getScreenPosition(scene, position) {
  * @template {AbstractMesh} T
  * @param {Vector3} absolutePosition - absolute position to convert.
  * @param {T} mesh - mesh into which position is converted.
- * @returns {Vector3} the converted position in mesh's local space.
+ * @returns the converted position in mesh's local space.
  */
 export function convertToLocal(absolutePosition, mesh) {
   if (!mesh.parent) {
@@ -130,7 +130,7 @@ export function convertToLocal(absolutePosition, mesh) {
  * Returns mesh local rotation in world space.
  * @template {Node} T
  * @param {T} mesh - related mesh.
- * @returns {Vector3} absolute rotation (Euler angles).
+ * @returns absolute rotation (Euler angles).
  */
 export function getAbsoluteRotation(mesh) {
   const rotation = Quaternion.Identity()

--- a/apps/web/src/components/Aside/VideoCommands.svelte
+++ b/apps/web/src/components/Aside/VideoCommands.svelte
@@ -21,9 +21,6 @@
   function toggleMic() {
     if ($stream$) {
       muted = !muted
-      for (const track of $stream$.getAudioTracks()) {
-        track.enabled = !muted
-      }
       recordStreamChange({ muted, stopped })
     }
   }
@@ -31,9 +28,6 @@
   function toggleVideo() {
     if ($stream$) {
       stopped = !stopped
-      for (const track of $stream$.getVideoTracks()) {
-        track.enabled = !stopped
-      }
       recordStreamChange({ muted, stopped })
     }
   }

--- a/apps/web/src/components/Discussion/Container.svelte
+++ b/apps/web/src/components/Discussion/Container.svelte
@@ -22,6 +22,8 @@
   export let replayRank = 0
   /** @type {Map<string, Player>} a map of player details by their id. */
   export let playerById
+  /** @type {string} id of the current player */
+  export let currentPlayerId
 
   /** @type {import('svelte').EventDispatcher<{ sendMessage: { text: string }, replay: number }>} */
   const dispatch = createEventDispatcher()
@@ -74,14 +76,14 @@
     {#each items as item}
       {#if 'playerId' in item}
         {@const player = playerById.get(item.playerId)}
-        {#if 'rank' in item}<HistoryRecord
-            {player}
-            {item}
-            isActive={item.rank === replayRank}
-            on:click={() =>
-              dispatch('replay', /** @type {{rank: number}} */ (item).rank)}
-          />
-        {:else}<Message {player} {item} />{/if}
+        {#if 'rank' in item}{#if !item.fromHand || currentPlayerId === item.playerId}<HistoryRecord
+              {player}
+              {item}
+              isActive={item.rank === replayRank}
+              on:click={() =>
+                dispatch('replay', /** @type {{rank: number}} */ (item).rank)}
+            />
+          {/if}{:else}<Message {player} {item} />{/if}
       {:else}
         <Day time={item.time} />
       {/if}

--- a/apps/web/src/components/FriendList/Container.svelte
+++ b/apps/web/src/components/FriendList/Container.svelte
@@ -138,6 +138,7 @@
       {history}
       {replayRank}
       {playerById}
+      currentPlayerId={user.id}
       on:sendMessage
       on:replay
     />

--- a/apps/web/src/graphql/games.graphql
+++ b/apps/web/src/graphql/games.graphql
@@ -165,6 +165,7 @@ fragment fullGame on Game {
     playerId
     meshId
     duration
+    fromHand
     ... on PlayerAction {
       fn
       argsStr

--- a/apps/web/src/locales/en.yaml
+++ b/apps/web/src/locales/en.yaml
@@ -47,7 +47,7 @@ labels:
   friendship-proposed: 'Request sent to {username}'
   friendship-requested: '{username} wish to join your friend list'
   game-authors: 'Designer(s): '
-  game-deleted-by-owner: This owner deleted this game
+  game-deleted-by-owner: The owner deleted this game
   game-deleted: Deleted game!
   game-designers: 'Artist(s): '
   game-min-age: '{minAge}+'
@@ -94,6 +94,7 @@ labels:
   host: host
   last-updated: 'Last update: { published, date, date-only }'
   lobby-deleted: 'Deleted lobby!'
+  lobby-deleted-by-owner: The owner deleted this lobby
   lobby-description: Invites your friends and decide which game to play.
   lobby-instructions: To promote this lobby to a game, pick any game from the catalog.
   log-in: Connection

--- a/apps/web/src/locales/fr.yaml
+++ b/apps/web/src/locales/fr.yaml
@@ -112,6 +112,7 @@ labels:
   host: hôte
   last-updated: 'Dernière mise à jour : { published, date, date-only }'
   lobby-deleted: 'Salon supprimé !'
+  lobby-deleted-by-owner: Le·a propriétaire a supprimé ce salon
   lobby-description: Invitez vos ami·e·s puis décidez à quel jeu jouer.
   lobby-instructions: Pour transformer ce salon en jeu, choisissez un de vos jeux disponibles.
   log-in: Connexion

--- a/apps/web/src/routes/[[lang=lang]]/home/+page.svelte
+++ b/apps/web/src/routes/[[lang=lang]]/home/+page.svelte
@@ -155,6 +155,9 @@
     return joinGame({
       gameId: game.id,
       .../** @type {DeepRequired<PlayerWithTurnCredentials>} */ (data.session),
+      onDeletion: () => {
+        toastInfo({ contentKey: 'labels.lobby-deleted-by-owner' })
+      },
       onPromotion: promoted => {
         handleSelectGame(
           /** @type {CustomEvent<LightGame>} */ ({ detail: promoted })

--- a/apps/web/src/stores/game-manager.js
+++ b/apps/web/src/stores/game-manager.js
@@ -716,6 +716,7 @@ function handlePeerDisconnection(/** @type {JoinGameContext} */ params) {
     const playingIds = playingIds$.value.filter(id => id !== playerId)
     playingIds$.next(playingIds)
     if (isCurrentHost(playerId) && isNextHost(currentPlayerId, playingIds)) {
+      // TODO do not unsubscribe subscribePeerStatusesAndGameUpdates, and only others before taking host role.
       unsubscribeCurrentGame()
       currentGameSubscriptions.push(
         ...subscribePeerStatusesAndGameUpdates(params),

--- a/apps/web/src/stores/peer-channels.js
+++ b/apps/web/src/stores/peer-channels.js
@@ -49,8 +49,11 @@ let subscriptions = []
 /** @type {?{ player: Player }} */
 let current = null
 /** @type {Stream} */
-let local
-resetLocalState()
+let local = {
+  stream: null,
+  muted: false,
+  stopped: false
+}
 
 /**
  * Emits last data sent to another player
@@ -89,7 +92,6 @@ export async function openChannels(player, turnCredentials, gameId) {
   current = { player }
   logger.info({ player }, 'initializing peer communication')
 
-  resetLocalState()
   subscriptions = [
     localStreamChange$.pipe(auditTime(10)).subscribe(state => {
       Object.assign(local, state)
@@ -286,7 +288,7 @@ function unwire(/** @type {string} */ id) {
   refreshConnected()
   if (connections.size === 0) {
     releaseMediaStream()
-    resetLocalState()
+    local.stream = null
   }
   lastDisconnectedId$.next(id)
 }
@@ -302,13 +304,5 @@ function buildStreamHandler(/** @type {string} */ playerId) {
     logger.debug({ from: playerId }, `receiving stream from ${playerId}`)
     connections.get(playerId)?.setRemote({ stream })
     refreshConnected()
-  }
-}
-
-function resetLocalState() {
-  local = {
-    stream: null,
-    muted: false,
-    stopped: false
   }
 }

--- a/apps/web/src/types/@babylonjs.d.ts
+++ b/apps/web/src/types/@babylonjs.d.ts
@@ -14,7 +14,7 @@ import type {
   StackBehavior,
   TargetBehavior
 } from '@src/3d/behaviors'
-import type { Managers } from '@src/3d/managers'
+import type { ActionOrMove, Managers } from '@src/3d/managers'
 import type { Behavior } from '@src/3d/utils'
 import type { Game } from '@src/graphql'
 import type { GameWithSelections } from '@src/stores'
@@ -40,6 +40,8 @@ declare module '@babylonjs/core' {
   interface Engine {
     /** indicates whether the engine is still loading data and materials. */
     isLoading: boolean
+    /** simulator bound to this engine, when relevant. */
+    simulation: Engine | null
     /** a map of action ids by (localized) keystroke. */
     actionNamesByKey: Map<string, ActionName[]>
     /** a map of action ids by(mouse / finger) button. */
@@ -74,6 +76,22 @@ declare module '@babylonjs/core' {
       handMeshes: SerializedMesh[]
       history: HistoryRecord[]
     }
+    /**
+     * Applies a remote mesh selection from a peer player, unless replaying history.
+     * @param selectedIds - selected mesh ids.
+     * @param playerId - id of the selecting player.
+     */
+    applyRemoteSelection(selectedIds: string[], playerId: string): void
+
+    /**
+     * Applies a remote move or action from a peer player, unless replaying history.
+     * @param actionOrMove - action or move from a peer.
+     * @param playerId - id of the peer player.
+     */
+    applyRemoteAction(
+      actionOrMove: ActionOrMove,
+      playerId: string
+    ): Promise<void>
   }
 
   interface AbstractMesh {

--- a/apps/web/src/types/@babylonjs.d.ts
+++ b/apps/web/src/types/@babylonjs.d.ts
@@ -14,6 +14,7 @@ import type {
   StackBehavior,
   TargetBehavior
 } from '@src/3d/behaviors'
+import type { Managers } from '@src/3d/managers'
 import type { Behavior } from '@src/3d/utils'
 import type { Game } from '@src/graphql'
 import type { GameWithSelections } from '@src/stores'
@@ -47,6 +48,8 @@ declare module '@babylonjs/core' {
     onLoadingObservable: Observable<boolean>
     /** emits just before disposing the engien, to allow synchronous access to its content. */
     onBeforeDisposeObservable: Observable<void>
+    /** managers configures with this engine. */
+    managers: Managers
     /** starts the renderig loop. */
     start(): void
     /**

--- a/apps/web/src/types/vitest.d.ts
+++ b/apps/web/src/types/vitest.d.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-unused-vars */
 import type { AbstractMesh } from '@babylonjs/core'
-import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+import type {
+  Assertion,
+  AsymmetricMatchersContaining,
+  SpyInstance
+} from 'vitest'
 
 interface CustomMatchers<R = unknown> {
   toEqualWithAngle<E extends { angle: number }>(expected: E): R
@@ -10,4 +14,5 @@ interface CustomMatchers<R = unknown> {
 declare module 'vitest' {
   interface Assertion<T = ?> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining extends CustomMatchers {}
+  type Spy<T extends Function> = SpyInstance<Parameters<T>, ReturnType<T>>
 }

--- a/apps/web/src/utils/game-interaction.js
+++ b/apps/web/src/utils/game-interaction.js
@@ -3,8 +3,6 @@
  * @typedef {import('@babylonjs/core').Engine} Engine
  * @typedef {import('@babylonjs/core').Mesh} Mesh
  * @typedef {import('rxjs').Subscription} Subscription
- * @typedef {import('@src/3d/managers/control').Action} Action
- * @typedef {import('@src/3d/managers/control').Move} Move
  * @typedef {import('@src/3d/managers/control').MeshDetails} MeshDetails
  * @typedef {import('@src/3d/managers/input').TapData} TapData
  * @typedef {import('@src/3d/managers/input').DragData} DragData
@@ -135,7 +133,7 @@ export function attachInputs({ engine, hoverDelay, actionMenuProps$ }) {
   const hovers$ = new Subject()
   /** @type {Subject<MeshDetails>} */
   const details$ = new Subject()
-  /** @type {Subject<Action|Move>} */
+  /** @type {Subject<import('@src/3d/managers').ActionOrMove>} */
   const behaviorAction$ = new Subject()
   /** @type {Subject<number>} */
   const replayRank$ = new Subject()

--- a/apps/web/tests/3d/behaviors/anchorable.test.js
+++ b/apps/web/tests/3d/behaviors/anchorable.test.js
@@ -6,10 +6,6 @@
  * @typedef {import('@src/3d/managers').RecordedAction} RecordedAction
  * @typedef {import('@tabulous/server/src/graphql').Anchor} Anchor
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
@@ -64,7 +60,7 @@ describe('AnchorBehavior', () => {
   let scene
   /** @type {import('@src/3d/managers').Managers} */
   let managers
-  /** @type {SpyInstance<Parameters<import('@src/3d/managers').IndicatorManager['registerFeedback']>, void>} */
+  /** @type {import('vitest').Spy<import('@src/3d/managers').IndicatorManager['registerFeedback']>} */
   let registerFeedbackSpy
   /** @type {?Observer} */
   let moveObserver

--- a/apps/web/tests/3d/behaviors/anchorable.test.js
+++ b/apps/web/tests/3d/behaviors/anchorable.test.js
@@ -50,10 +50,13 @@ import {
 } from '../../test-utils'
 
 describe('AnchorBehavior', () => {
-  configures3dTestEngine(created => {
-    scene = created.scene
-    managers = created.managers
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      managers = created.managers
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   const actionRecorded = vi.fn()
   const moveRecorded = vi.fn()

--- a/apps/web/tests/3d/behaviors/animatable.test.js
+++ b/apps/web/tests/3d/behaviors/animatable.test.js
@@ -20,7 +20,7 @@ describe('AnimateBehavior', () => {
   const animationEndReceived = vi.fn()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   it('has initial state', () => {

--- a/apps/web/tests/3d/behaviors/detailable.test.js
+++ b/apps/web/tests/3d/behaviors/detailable.test.js
@@ -29,9 +29,12 @@ describe('DetailBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => {
-    managers = created.managers
-  })
+  configures3dTestEngine(
+    created => {
+      managers = created.managers
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   const onDetailsReceived = vi.fn()
   /** @type {?Observer} */

--- a/apps/web/tests/3d/behaviors/drawable.test.js
+++ b/apps/web/tests/3d/behaviors/drawable.test.js
@@ -32,14 +32,17 @@ let playerId
 const actionRecorded = vi.fn()
 const animationEndReceived = vi.fn()
 
-configures3dTestEngine(created => {
-  scene = created.scene
-  handScene = created.handScene
-  managers = created.managers
-  playerId = created.playerId
-  managers.control.onActionObservable.add(actionRecorded)
-  managers.hand.enabled = true
-})
+configures3dTestEngine(
+  created => {
+    scene = created.scene
+    handScene = created.handScene
+    managers = created.managers
+    playerId = created.playerId
+    managers.control.onActionObservable.add(actionRecorded)
+    managers.hand.enabled = true
+  },
+  { isSimulation: globalThis.use3dSimulation }
+)
 
 beforeEach(() => {
   vi.clearAllMocks()

--- a/apps/web/tests/3d/behaviors/flippable.test.js
+++ b/apps/web/tests/3d/behaviors/flippable.test.js
@@ -28,7 +28,9 @@ let animationEndReceived
 /** @type {import('@src/3d/managers').Managers} */
 let managers
 
-configures3dTestEngine(created => (managers = created.managers))
+configures3dTestEngine(created => (managers = created.managers), {
+  isSimulation: globalThis.use3dSimulation
+})
 
 beforeAll(() => {
   managers.control.onActionObservable.add(data => actionRecorded(data))

--- a/apps/web/tests/3d/behaviors/lockable.test.js
+++ b/apps/web/tests/3d/behaviors/lockable.test.js
@@ -32,10 +32,13 @@ describe('LockBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    managers = created.managers
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      managers = created.managers
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeAll(() => {
     managers.control.onActionObservable.add(actionRecorded)

--- a/apps/web/tests/3d/behaviors/lockable.test.js
+++ b/apps/web/tests/3d/behaviors/lockable.test.js
@@ -5,10 +5,6 @@
  * @typedef {import('@src/3d/behaviors').MoveBehavior} MoveBehavior
  * @typedef {import('@src/3d/utils').BehaviorNames} BehaviorNames
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { faker } from '@faker-js/faker'
 import {
@@ -25,7 +21,7 @@ import { configures3dTestEngine, expectMeshFeedback } from '../../test-utils'
 describe('LockBehavior', () => {
   const actionRecorded = vi.fn()
 
-  /** @type {SpyInstance<Parameters<import('@src/3d/managers').IndicatorManager['registerFeedback']>, void>} */
+  /** @type {import('vitest').Spy<import('@src/3d/managers').IndicatorManager['registerFeedback']>} */
   let registerFeedbackSpy
   /** @type {Scene} */
   let scene

--- a/apps/web/tests/3d/behaviors/movable.test.js
+++ b/apps/web/tests/3d/behaviors/movable.test.js
@@ -13,7 +13,9 @@ describe('MoveBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => (managers = created.managers))
+  configures3dTestEngine(created => (managers = created.managers), {
+    isSimulation: globalThis.use3dSimulation
+  })
 
   it('has initial state', () => {
     const state = {

--- a/apps/web/tests/3d/behaviors/movable.test.js
+++ b/apps/web/tests/3d/behaviors/movable.test.js
@@ -5,13 +5,15 @@
 
 import { faker } from '@faker-js/faker'
 import { MoveBehavior, MoveBehaviorName } from '@src/3d/behaviors'
-import { moveManager } from '@src/3d/managers'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { configures3dTestEngine, createBox } from '../../test-utils'
 
 describe('MoveBehavior', () => {
-  configures3dTestEngine()
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+
+  configures3dTestEngine(created => (managers = created.managers))
 
   it('has initial state', () => {
     const state = {
@@ -20,7 +22,7 @@ describe('MoveBehavior', () => {
       duration: faker.number.int(999),
       partCenters: [{ x: faker.number.int(999), z: faker.number.int(999) }]
     }
-    const behavior = new MoveBehavior(state)
+    const behavior = new MoveBehavior(state, managers)
     const mesh = createBox('box', {})
     mesh.isPickable = false
 
@@ -36,20 +38,20 @@ describe('MoveBehavior', () => {
 
   it('registers mesh into MoveManager', () => {
     const mesh = createBox('box', {})
-    expect(moveManager.isManaging(mesh)).toBe(false)
+    expect(managers.move.isManaging(mesh)).toBe(false)
 
-    mesh.addBehavior(new MoveBehavior(), true)
-    expect(moveManager.isManaging(mesh)).toBe(true)
+    mesh.addBehavior(new MoveBehavior({}, managers), true)
+    expect(managers.move.isManaging(mesh)).toBe(true)
   })
 
   it('can not restore state without mesh', () => {
-    expect(() => new MoveBehavior().fromState()).toThrow(
+    expect(() => new MoveBehavior({}, managers).fromState()).toThrow(
       'Can not restore state without mesh'
     )
   })
 
   it('handles detaching without mesh', () => {
-    expect(() => new MoveBehavior().detach()).not.toThrowError()
+    expect(() => new MoveBehavior({}, managers).detach()).not.toThrowError()
   })
 
   describe('given attached to a mesh', () => {
@@ -59,7 +61,7 @@ describe('MoveBehavior', () => {
     let behavior
 
     beforeEach(() => {
-      behavior = new MoveBehavior()
+      behavior = new MoveBehavior({}, managers)
       mesh = createBox('box', {})
       mesh.addBehavior(behavior, true)
     })
@@ -71,9 +73,9 @@ describe('MoveBehavior', () => {
     })
 
     it('unregisters mesh from MoveManager upon disposal', () => {
-      expect(moveManager.isManaging(mesh)).toBe(true)
+      expect(managers.move.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(moveManager.isManaging(mesh)).toBe(false)
+      expect(managers.move.isManaging(mesh)).toBe(false)
     })
 
     it('can hydrate from state', () => {

--- a/apps/web/tests/3d/behaviors/quantifiable.test.js
+++ b/apps/web/tests/3d/behaviors/quantifiable.test.js
@@ -11,7 +11,6 @@ import {
   QuantityBehavior,
   QuantityBehaviorName
 } from '@src/3d/behaviors'
-import { controlManager, moveManager, selectionManager } from '@src/3d/managers'
 import { createBox, createRoundToken } from '@src/3d/meshes'
 import { getTargetableBehavior } from '@src/3d/utils'
 import {
@@ -39,12 +38,16 @@ describe('QuantityBehavior', () => {
   const actionRecorded = vi.fn()
   /** @type {Scene} */
   let scene
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
 
-  configures3dTestEngine(created => (scene = created.scene))
+  configures3dTestEngine(created => {
+    scene = created.scene
+    managers = created.managers
+  })
 
   beforeAll(() => {
-    moveManager.init({ scene })
-    controlManager.onActionObservable.add(data => actionRecorded(data))
+    managers.control.onActionObservable.add(data => actionRecorded(data))
   })
 
   beforeEach(() => {
@@ -58,7 +61,7 @@ describe('QuantityBehavior', () => {
       kinds: [],
       quantity: faker.number.int(999)
     }
-    const behavior = new QuantityBehavior(state)
+    const behavior = new QuantityBehavior(state, managers)
 
     expect(behavior.name).toEqual(QuantityBehaviorName)
     expect(behavior.state).toEqual(state)
@@ -67,14 +70,14 @@ describe('QuantityBehavior', () => {
   })
 
   it('can not restore state without mesh', () => {
-    expect(() => new QuantityBehavior().fromState({ duration: 100 })).toThrow(
-      'Can not restore state without mesh'
-    )
+    expect(() =>
+      new QuantityBehavior({}, managers).fromState({ duration: 100 })
+    ).toThrow('Can not restore state without mesh')
   })
 
   it('can hydrate with default state', () => {
-    const behavior = new QuantityBehavior()
-    const mesh = createBox({ id: 'box0', texture: '' }, scene)
+    const behavior = new QuantityBehavior({}, managers)
+    const mesh = createBox({ id: 'box0', texture: '' }, managers, scene)
     mesh.addBehavior(behavior, true)
 
     behavior.fromState()
@@ -90,8 +93,8 @@ describe('QuantityBehavior', () => {
 
   it('can not increment', () => {
     expect(
-      new QuantityBehavior().canIncrement?.(
-        createBox({ id: 'box1', texture: '' }, scene)
+      new QuantityBehavior({}, managers).canIncrement?.(
+        createBox({ id: 'box1', texture: '' }, managers, scene)
       )
     ).toBe(false)
   })
@@ -116,13 +119,14 @@ describe('QuantityBehavior', () => {
             quantifiable: { duration: 10 },
             movable: {}
           },
+          managers,
           scene
         )
       )
       behavior = /** @type {QuantityBehavior} */ (getTargetableBehavior(mesh))
     })
 
-    afterEach(() => moveManager.stop())
+    afterEach(() => managers.move.stop())
 
     it('attaches metadata to its mesh', () => {
       expectQuantity(mesh, 1)
@@ -175,6 +179,7 @@ describe('QuantityBehavior', () => {
       mesh.removeBehavior(behavior)
       mesh = createRoundToken(
         { id: 'roundToken', texture: '', diameter },
+        managers,
         scene
       )
       mesh.addBehavior(behavior, true)
@@ -243,8 +248,8 @@ describe('QuantityBehavior', () => {
       ]
       await mesh.metadata.increment?.([other3.id, other2.id, other1.id])
       expectQuantity(mesh, 9)
-      expectQuantityIndicator(other1, 0)
-      expectQuantityIndicator(other3, 0)
+      expectQuantityIndicator(managers, other1, 0)
+      expectQuantityIndicator(managers, other3, 0)
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'increment',
@@ -551,7 +556,7 @@ describe('QuantityBehavior', () => {
       behavior.fromState({ quantity })
       expectQuantity(mesh, quantity)
 
-      moveManager.start(mesh, { x: 0, y: 0 })
+      managers.move.start(mesh, { x: 0, y: 0 })
       await sleep()
 
       expect(scene.meshes.length).toBe(meshCount + 2)
@@ -585,8 +590,8 @@ describe('QuantityBehavior', () => {
         prev: [0, 0, 0],
         fromHand: false
       })
-      expect(moveManager.isMoving(mesh)).toBe(false)
-      expect(moveManager.isMoving(created)).toBe(true)
+      expect(managers.move.isMoving(mesh)).toBe(false)
+      expect(managers.move.isMoving(created)).toBe(true)
     })
 
     it('does not decrement when moving selected mesh', async () => {
@@ -594,9 +599,9 @@ describe('QuantityBehavior', () => {
       const meshCount = scene.meshes.length
       behavior.fromState({ quantity })
       expectQuantity(mesh, quantity)
-      selectionManager.select(mesh)
+      managers.selection.select(mesh)
 
-      moveManager.start(mesh, { x: 0, y: 0 })
+      managers.move.start(mesh, { x: 0, y: 0 })
       await sleep()
 
       expect(scene.meshes.length).toBe(meshCount)
@@ -608,7 +613,7 @@ describe('QuantityBehavior', () => {
         prev: [0, 0, 0],
         fromHand: false
       })
-      expect(moveManager.isMoving(mesh)).toBe(true)
+      expect(managers.move.isMoving(mesh)).toBe(true)
     })
 
     it('can revert decrement meshes', async () => {
@@ -683,12 +688,12 @@ describe('QuantityBehavior', () => {
       expect(mesh.metadata.canIncrement?.(meshes[2])).toBe(false)
     })
   })
-})
 
-function expectQuantity(
-  /** @type {Mesh} */ mesh,
-  /** @type {number} */ quantity
-) {
-  expect(mesh.metadata?.quantity).toBe(quantity)
-  expectQuantityIndicator(mesh, quantity)
-}
+  function expectQuantity(
+    /** @type {Mesh} */ mesh,
+    /** @type {number} */ quantity
+  ) {
+    expect(mesh.metadata?.quantity).toBe(quantity)
+    expectQuantityIndicator(managers, mesh, quantity)
+  }
+})

--- a/apps/web/tests/3d/behaviors/quantifiable.test.js
+++ b/apps/web/tests/3d/behaviors/quantifiable.test.js
@@ -41,10 +41,13 @@ describe('QuantityBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    managers = created.managers
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      managers = created.managers
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeAll(() => {
     managers.control.onActionObservable.add(data => actionRecorded(data))

--- a/apps/web/tests/3d/behaviors/randomizable.test.js
+++ b/apps/web/tests/3d/behaviors/randomizable.test.js
@@ -25,30 +25,33 @@ describe('RandomBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(async created => {
-    scene = created.scene
-    managers = created.managers
-    vi.spyOn(global, 'fetch').mockImplementation(file =>
-      Promise.resolve(
-        new Response(
-          file.toString().endsWith(getDieModelFile(8))
-            ? die8Data
-            : file.toString().endsWith(getDieModelFile(6))
-            ? die6Data
-            : die4Data
+  configures3dTestEngine(
+    async created => {
+      scene = created.scene
+      managers = created.managers
+      vi.spyOn(global, 'fetch').mockImplementation(file =>
+        Promise.resolve(
+          new Response(
+            file.toString().endsWith(getDieModelFile(8))
+              ? die8Data
+              : file.toString().endsWith(getDieModelFile(6))
+              ? die6Data
+              : die4Data
+          )
         )
       )
-    )
-    await managers.customShape.init({
-      id: 'game',
-      created: Date.now(),
-      meshes: [
-        { id: 'die4', shape: 'die', faces: 4, texture: '' },
-        { id: 'die6', shape: 'die', faces: 6, texture: '' },
-        { id: 'die8', shape: 'die', faces: 8, texture: '' }
-      ]
-    })
-  })
+      await managers.customShape.init({
+        id: 'game',
+        created: Date.now(),
+        meshes: [
+          { id: 'die4', shape: 'die', faces: 4, texture: '' },
+          { id: 'die6', shape: 'die', faces: 6, texture: '' },
+          { id: 'die8', shape: 'die', faces: 8, texture: '' }
+        ]
+      })
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeAll(() => {
     managers.control.onActionObservable.add(actionRecorded)

--- a/apps/web/tests/3d/behaviors/rotable.test.js
+++ b/apps/web/tests/3d/behaviors/rotable.test.js
@@ -29,7 +29,9 @@ describe('RotateBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => (managers = created.managers))
+  configures3dTestEngine(created => (managers = created.managers), {
+    isSimulation: globalThis.use3dSimulation
+  })
 
   const actionRecorded = vi.fn()
   /** @type {Mock} */

--- a/apps/web/tests/3d/behaviors/stackable.test.js
+++ b/apps/web/tests/3d/behaviors/stackable.test.js
@@ -55,7 +55,9 @@ import {
 } from '../../test-utils'
 
 describe('StackBehavior', () => {
-  configures3dTestEngine(created => (managers = created.managers))
+  configures3dTestEngine(created => (managers = created.managers), {
+    isSimulation: globalThis.use3dSimulation
+  })
 
   const actionRecorded = vi.fn()
   const moveRecorded = vi.fn()

--- a/apps/web/tests/3d/behaviors/stackable.test.js
+++ b/apps/web/tests/3d/behaviors/stackable.test.js
@@ -25,12 +25,6 @@ import {
   StackBehaviorName
 } from '@src/3d/behaviors'
 import { StackBehavior } from '@src/3d/behaviors/stackable'
-import {
-  controlManager,
-  handManager,
-  indicatorManager,
-  moveManager
-} from '@src/3d/managers'
 import { getAnimatableBehavior, getTargetableBehavior } from '@src/3d/utils'
 import {
   afterAll,
@@ -61,33 +55,32 @@ import {
 } from '../../test-utils'
 
 describe('StackBehavior', () => {
-  configures3dTestEngine(created => (scene = created.scene))
+  configures3dTestEngine(created => (managers = created.managers))
 
   const actionRecorded = vi.fn()
   const moveRecorded = vi.fn()
-  /** @type {Scene} */
-  let scene
-  /** @type {SpyInstance<Parameters<typeof indicatorManager['registerFeedback']>, void>} */
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+  /** @type {SpyInstance<Parameters<import('@src/3d/managers').IndicatorManager['registerFeedback']>, void>} */
   let registerFeedbackSpy
   /** @type {?Observer} */
   let moveObserver
 
   beforeAll(() => {
-    moveObserver = moveManager.onMoveObservable.add(moveRecorded)
-    controlManager.onActionObservable.add(data => actionRecorded(data))
-    indicatorManager.init({ scene })
+    moveObserver = managers.move.onMoveObservable.add(moveRecorded)
+    managers.control.onActionObservable.add(data => actionRecorded(data))
   })
 
   beforeEach(() => {
     vi.clearAllMocks()
-    registerFeedbackSpy = vi.spyOn(indicatorManager, 'registerFeedback')
-    vi.spyOn(handManager, 'draw').mockImplementation(async mesh => {
-      controlManager.record({ mesh, fn: 'draw', args: [] })
+    registerFeedbackSpy = vi.spyOn(managers.indicator, 'registerFeedback')
+    vi.spyOn(managers.hand, 'draw').mockImplementation(async mesh => {
+      managers.control.record({ mesh, fn: 'draw', args: [] })
     })
   })
 
   afterAll(() => {
-    moveManager.onMoveObservable.remove(moveObserver)
+    managers.move.onMoveObservable.remove(moveObserver)
   })
 
   it('has initial state', () => {
@@ -98,7 +91,7 @@ describe('StackBehavior', () => {
       stackIds: [],
       angle: faker.number.int(999)
     }
-    const behavior = new StackBehavior(state)
+    const behavior = new StackBehavior(state, managers)
 
     expect(behavior.name).toEqual(StackBehaviorName)
     expect(behavior.state).toEqual(state)
@@ -111,13 +104,13 @@ describe('StackBehavior', () => {
   })
 
   it('can not restore state without mesh', () => {
-    expect(() => new StackBehavior().fromState({ duration: 100 })).toThrow(
-      'Can not restore state without mesh'
-    )
+    expect(() =>
+      new StackBehavior({}, managers).fromState({ duration: 100 })
+    ).toThrow('Can not restore state without mesh')
   })
 
   it('can hydrate with default state', () => {
-    const behavior = new StackBehavior()
+    const behavior = new StackBehavior({}, managers)
     const mesh = createBox('box0', {})
     mesh.addBehavior(behavior, true)
 
@@ -130,25 +123,30 @@ describe('StackBehavior', () => {
     })
     expect(behavior.mesh).toEqual(mesh)
     expect(mesh.metadata.stack).toEqual([mesh])
-    expectStackIndicator(mesh)
+    expectStackIndicator(managers, mesh)
     expect(actionRecorded).not.toHaveBeenCalled()
     expect(registerFeedbackSpy).not.toHaveBeenCalled()
   })
 
   it('can hydrate with stacked mesh', () => {
     const stacked = createBox('box1', {})
-    stacked.addBehavior(new StackBehavior(), true)
+    stacked.addBehavior(new StackBehavior({}, managers), true)
 
     const mesh = createBox('box0', {})
-    mesh.addBehavior(new StackBehavior({ stackIds: [stacked.id] }), true)
-    expectStacked([mesh, stacked])
+    mesh.addBehavior(
+      new StackBehavior({ stackIds: [stacked.id] }, managers),
+      true
+    )
+    expectStacked(managers, [mesh, stacked])
     expectMoveRecorded(moveRecorded)
     expect(actionRecorded).not.toHaveBeenCalled()
     expect(registerFeedbackSpy).not.toHaveBeenCalled()
   })
 
   it('can not push mesh', () => {
-    expect(new StackBehavior().canPush(createBox('box1', {}))).toBe(false)
+    expect(new StackBehavior({}, managers).canPush(createBox('box1', {}))).toBe(
+      false
+    )
   })
 
   describe('given attached to a mesh', () => {
@@ -168,20 +166,23 @@ describe('StackBehavior', () => {
         const id = `box${rank}`
         const box = createBox(id, {})
         box.setAbsolutePosition(new Vector3(rank, rank, rank))
-        box.addBehavior(new StackBehavior({ duration: 10 }), true)
-        box.addBehavior(new FlipBehavior({ duration: 100 }), true)
-        box.addBehavior(new RotateBehavior({ duration: 100 }), true)
-        box.addBehavior(new MoveBehavior(), true)
+        box.addBehavior(new StackBehavior({ duration: 10 }, managers), true)
+        box.addBehavior(new FlipBehavior({ duration: 100 }, managers), true)
+        box.addBehavior(new RotateBehavior({ duration: 100 }, managers), true)
+        box.addBehavior(new MoveBehavior({}, managers), true)
         box.addBehavior(
-          new AnchorBehavior({
-            anchors: [
-              { id: `${id}-1`, x: -0.5 },
-              { id: `${id}-2`, x: 0.5 }
-            ]
-          })
+          new AnchorBehavior(
+            {
+              anchors: [
+                { id: `${id}-1`, x: -0.5 },
+                { id: `${id}-2`, x: 0.5 }
+              ]
+            },
+            managers
+          )
         )
-        box.addBehavior(new DrawBehavior(), true)
-        controlManager.registerControlable(box)
+        box.addBehavior(new DrawBehavior({}, managers), true)
+        managers.control.registerControlable(box)
         return box
       })
 
@@ -194,7 +195,7 @@ describe('StackBehavior', () => {
         enabled: true,
         ignoreParts: true
       })
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(behavior.state.duration).toEqual(10)
       expect(behavior.state.extent).toEqual(2)
       expect(mesh.metadata).toEqual(
@@ -227,7 +228,7 @@ describe('StackBehavior', () => {
         priority,
         ignoreParts: true
       })
-      expectStacked([mesh, box1, box3])
+      expectStacked(managers, [mesh, box1, box3])
       expect(behavior.state.duration).toEqual(duration)
       expect(behavior.state.extent).toEqual(extent)
       expect(mesh.metadata).toEqual(
@@ -267,7 +268,7 @@ describe('StackBehavior', () => {
       const { boundingBox } = behavior.zones[0].mesh.getBoundingInfo()
       expect(boundingBox.extendSize.x * 2).toBeCloseTo(diameter)
       expect(boundingBox.extendSize.z * 2).toBeCloseTo(diameter)
-      expectStacked([mesh, box1, box3])
+      expectStacked(managers, [mesh, box1, box3])
       expect(behavior.state.duration).toEqual(duration)
       expect(behavior.state.extent).toEqual(extent)
       expect(mesh.metadata).toEqual(
@@ -285,10 +286,10 @@ describe('StackBehavior', () => {
 
     it('can hydrate with its own state', () => {
       behavior.fromState({ stackIds: ['box2', 'box1'] })
-      expectStacked([mesh, box2, box1])
+      expectStacked(managers, [mesh, box2, box1])
 
       behavior.fromState({ stackIds: ['box2', 'box1'] })
-      expectStacked([mesh, box2, box1])
+      expectStacked(managers, [mesh, box2, box1])
       expect(actionRecorded).not.toHaveBeenCalled()
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -304,7 +305,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds, angle: 0 })
       expectRotated(box3, 0)
       expectZone(behavior, { extent: 2, enabled: false, ignoreParts: true })
-      expectStacked([mesh, box1, box3])
+      expectStacked(managers, [mesh, box1, box3])
       expect(actionRecorded).not.toHaveBeenCalled()
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -313,18 +314,18 @@ describe('StackBehavior', () => {
       const angle = Math.PI * 0.5
       await mesh.getBehaviorByName(RotateBehaviorName)?.rotate()
       behavior.fromState({ stackIds: [], angle: 0 })
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expectRotated(mesh, angle)
       expectRotated(box1, 0)
       await mesh.metadata.push?.(box1.id)
       await mesh.metadata.push?.(box3.id)
-      expectStacked([mesh, box1, box3])
+      expectStacked(managers, [mesh, box1, box3])
       expectRotated(mesh, angle)
       expectRotated(box1, angle)
       expectRotated(box3, angle)
 
       behavior.fromState({ stackIds: [box1.id, box3.id], angle: 0 })
-      expectStacked([mesh, box1, box3])
+      expectStacked(managers, [mesh, box1, box3])
       expectRotated(mesh, angle)
       expectRotated(box1, angle)
       expectRotated(box3, angle)
@@ -338,9 +339,9 @@ describe('StackBehavior', () => {
       const priority = faker.number.int(999)
       expect(box1.absolutePosition).toEqual(Vector3.FromArray([1, 1, 1]))
       expect(box3.absolutePosition).toEqual(Vector3.FromArray([3, 3, 3]))
-      mesh.addBehavior(new LockBehavior({ isLocked: true }), true)
-      box1.addBehavior(new LockBehavior({ isLocked: true }), true)
-      box3.addBehavior(new LockBehavior({ isLocked: true }), true)
+      mesh.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
+      box1.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
+      box3.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
 
       behavior.fromState({ duration, extent, stackIds, kinds, priority })
       expectZone(behavior, {
@@ -350,7 +351,7 @@ describe('StackBehavior', () => {
         priority,
         ignoreParts: true
       })
-      expectStacked([mesh, box1, box3], false)
+      expectStacked(managers, [mesh, box1, box3], false)
       expect(behavior.state.duration).toEqual(duration)
       expect(behavior.state.extent).toEqual(extent)
       expect(mesh.metadata).toEqual(
@@ -367,12 +368,12 @@ describe('StackBehavior', () => {
     })
 
     it('pushes new mesh on stack', async () => {
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       const position = [1, 1, 1]
       expect(box1.absolutePosition).toEqual(Vector3.FromArray(position))
 
       await mesh.metadata.push?.(box1.id)
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       expectRotated(box1, 0)
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
@@ -392,7 +393,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box2', 'box1'] })
 
       await box2.metadata.push?.(box3.id)
-      expectStacked([mesh, box2, box1, box3])
+      expectStacked(managers, [mesh, box2, box1, box3])
       expectRotated(box1, 0)
       expectRotated(box2, 0)
       expectRotated(box3, 0)
@@ -425,13 +426,13 @@ describe('StackBehavior', () => {
         .getBehaviorByName(FlipBehaviorName)
         ?.fromState({ duration: 100, isFlipped: true })
       behavior.fromState({ angle })
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(box1.absolutePosition).toEqual(Vector3.FromArray([1, 1, 1]))
 
       await mesh.metadata.push?.(box1.id)
       expectRotated(box1, baseAngle - angle)
       expectFlipped(box1)
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'push',
@@ -447,13 +448,13 @@ describe('StackBehavior', () => {
     })
 
     it('does not enable locked mesh when pushing', async () => {
-      box1.addBehavior(new LockBehavior({ isLocked: true }), true)
-      expectStacked([mesh])
+      box1.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
+      expectStacked(managers, [mesh])
       expectInteractible(mesh, true)
       expectInteractible(box1, true, false)
 
       await mesh.metadata.push?.(box1.id)
-      expectStacked([mesh, box1], false)
+      expectStacked(managers, [mesh, box1], false)
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'push',
@@ -481,7 +482,7 @@ describe('StackBehavior', () => {
         zone: targetable.zones[0]
       })
       await sleep(behavior.state.duration)
-      expectStacked([mesh, box2, box1, box3])
+      expectStacked(managers, [mesh, box2, box1, box3])
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'push',
@@ -507,15 +508,15 @@ describe('StackBehavior', () => {
 
     it('pushes a stack of meshes on stack', async () => {
       behavior.fromState({ stackIds: ['box1'] })
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
 
       box2
         .getBehaviorByName(StackBehaviorName)
         ?.fromState({ stackIds: ['box3'] })
-      expectStacked([box2, box3])
+      expectStacked(managers, [box2, box3])
 
       await mesh.metadata.push?.(box2.id)
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'push',
@@ -534,16 +535,16 @@ describe('StackBehavior', () => {
       const position = [2, 2, 2]
       const angle = Math.PI * 0.5
       behavior.fromState({ stackIds: ['box1', 'box2'] })
-      expectStacked([mesh, box1, box2])
+      expectStacked(managers, [mesh, box1, box2])
       expectRotated(mesh, 0)
       expectPosition(mesh, [0, 0, 0])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
       await behavior.revert('push', [1, false, position, angle])
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       expectRotated(mesh, 0)
-      expectStacked([box2])
+      expectStacked(managers, [box2])
       expectRotated(box2, angle)
       expectPosition(box2, position)
       expect(registerFeedbackSpy).toHaveBeenCalledOnce()
@@ -561,16 +562,16 @@ describe('StackBehavior', () => {
     it('can revert a stack of pushed mesh', async () => {
       const position = [3, 3, 3]
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       expectRotated(mesh, 0)
       expectPosition(mesh, [0, 0, 0])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
       await behavior.revert('push', [2, false, position, undefined])
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       expectRotated(mesh, 0)
-      expectStacked([box2, box3])
+      expectStacked(managers, [box2, box3])
       expectRotated(box2, 0)
       expectPosition(box2, position)
       expect(registerFeedbackSpy).toHaveBeenCalledOnce()
@@ -588,16 +589,16 @@ describe('StackBehavior', () => {
     it('can immediately revert pushed mesh', async () => {
       const position = [1, 1, 1]
       behavior.fromState({ stackIds: ['box1'] })
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       expectRotated(mesh, 0)
       expectPosition(mesh, [0, 0, 0])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
       await behavior.revert('push', [1, true, position, undefined])
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expectRotated(mesh, 0)
-      expectStacked([box1])
+      expectStacked(managers, [box1])
       expectRotated(box1, 0)
       expectPosition(box1, position)
       expect(registerFeedbackSpy).toHaveBeenCalledOnce()
@@ -615,7 +616,7 @@ describe('StackBehavior', () => {
 
     it('can not pop an empty stack', async () => {
       expect(await mesh.metadata.pop?.()).toEqual([])
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(actionRecorded).not.toHaveBeenCalled()
       expectMoveRecorded(moveRecorded)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
@@ -628,7 +629,7 @@ describe('StackBehavior', () => {
       expect(poped?.id).toBe('box3')
       expectInteractible(poped)
       expect(poped.parent?.id).toBeUndefined()
-      expectStacked([mesh, box2, box1])
+      expectStacked(managers, [mesh, box2, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -638,13 +639,13 @@ describe('StackBehavior', () => {
         fromHand: false,
         isLocal: false
       })
-      expectStackIndicator(poped)
+      expectStackIndicator(managers, poped)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
       ;[poped] = (await mesh.metadata.pop?.()) ?? []
       expect(poped?.id).toBe('box1')
       expectInteractible(poped)
       expect(poped.parent?.id).toBeUndefined()
-      expectStacked([mesh, box2])
+      expectStacked(managers, [mesh, box2])
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenNthCalledWith(2, {
         fn: 'pop',
@@ -654,13 +655,13 @@ describe('StackBehavior', () => {
         fromHand: false,
         isLocal: false
       })
-      expectStackIndicator(poped)
+      expectStackIndicator(managers, poped)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
       ;[poped] = (await mesh.metadata.pop?.()) ?? []
       expect(poped?.id).toBe('box2')
       expectInteractible(poped)
       expect(poped.parent?.id).toBeUndefined()
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(actionRecorded).toHaveBeenCalledTimes(3)
       expect(actionRecorded).toHaveBeenNthCalledWith(3, {
         fn: 'pop',
@@ -670,7 +671,7 @@ describe('StackBehavior', () => {
         fromHand: false,
         isLocal: false
       })
-      expectStackIndicator(poped)
+      expectStackIndicator(managers, poped)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
       expectMoveRecorded(moveRecorded)
     })
@@ -685,7 +686,7 @@ describe('StackBehavior', () => {
       expect(poped?.id).toBe('box3')
       expect(poped.parent?.id).toBeUndefined()
       expectInteractible(poped)
-      expectStacked([mesh, box2, box1])
+      expectStacked(managers, [mesh, box2, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -715,7 +716,7 @@ describe('StackBehavior', () => {
       expect(poped2?.id).toBe('box1')
       expectInteractible(poped2)
       expect(poped2.parent?.id).toBeUndefined()
-      expectStacked([mesh, box2])
+      expectStacked(managers, [mesh, box2])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -750,7 +751,7 @@ describe('StackBehavior', () => {
       expect(poped2.parent?.id).toBeUndefined()
       expect(poped3.parent?.id).toBeUndefined()
       expect(poped4.parent?.id).toBeUndefined()
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -771,7 +772,7 @@ describe('StackBehavior', () => {
       expect(poped?.id).toBe('box2')
       expectInteractible(poped)
       expect(poped.parent?.id).toBeUndefined()
-      expectStacked([mesh, box3, box1])
+      expectStacked(managers, [mesh, box3, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -788,10 +789,10 @@ describe('StackBehavior', () => {
     it('pops dragged meshes', async () => {
       behavior.fromState({ stackIds: ['box3', 'box1', 'box2'] })
 
-      moveManager.notifyMove(box2)
+      managers.move.notifyMove(box2)
       expectInteractible(box2)
       expect(box2.parent?.id).toBeUndefined()
-      expectStacked([mesh, box3, box1])
+      expectStacked(managers, [mesh, box3, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -810,7 +811,7 @@ describe('StackBehavior', () => {
       box2.metadata.draw?.()
       expectInteractible(box2)
       expect(box2.parent?.id).toBeUndefined()
-      expectStacked([mesh, box3, box1])
+      expectStacked(managers, [mesh, box3, box1])
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'draw',
@@ -837,7 +838,7 @@ describe('StackBehavior', () => {
       box3.isPickable = false
       box3.metadata.draw?.()
       expectInteractible(box3, false, false)
-      expectStacked([mesh, box3, box1, box2])
+      expectStacked(managers, [mesh, box3, box1, box2])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'draw',
@@ -851,7 +852,7 @@ describe('StackBehavior', () => {
     })
 
     it('does not enable locked mesh when poping', async () => {
-      box3.addBehavior(new LockBehavior({ isLocked: true }), true)
+      box3.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
       expectInteractible(box3, true, false)
       behavior.fromState({ stackIds: ['box2', 'box1', 'box3'] })
 
@@ -859,7 +860,7 @@ describe('StackBehavior', () => {
       expect(poped?.id).toBe('box3')
       expectInteractible(poped, true, false)
       expect(poped.parent?.id).toBeUndefined()
-      expectStacked([mesh, box2, box1])
+      expectStacked(managers, [mesh, box2, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'pop',
@@ -869,7 +870,7 @@ describe('StackBehavior', () => {
         fromHand: false,
         isLocal: false
       })
-      expectStackIndicator(poped)
+      expectStackIndicator(managers, poped)
       expectMoveRecorded(moveRecorded)
       expectMeshFeedback(registerFeedbackSpy, 'pop', poped)
     })
@@ -883,12 +884,12 @@ describe('StackBehavior', () => {
         poped.getBehaviorByName(RotateBehaviorName)?.state.angle
       )
       expectRotated(poped, angle)
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
       await behavior.revert('pop', [[poped.id], true])
-      expectStacked([mesh, box1, box2])
+      expectStacked(managers, [mesh, box1, box2])
       expectRotated(box2, 0)
       expect(registerFeedbackSpy).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledOnce()
@@ -911,12 +912,12 @@ describe('StackBehavior', () => {
       expectPosition(poped1, position1)
       const position2 = [2.5, 0.5, 0]
       expectPosition(poped2, position2)
-      expectStacked([mesh, box1])
+      expectStacked(managers, [mesh, box1])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
       await behavior.revert('pop', [[poped2.id, poped1.id], false])
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       expect(registerFeedbackSpy).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenNthCalledWith(
@@ -945,11 +946,11 @@ describe('StackBehavior', () => {
 
     it('reorders stack to given order', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
 
       await mesh.metadata.reorder?.(['box3', 'box2', 'box1', 'box0'], false)
 
-      expectStacked([box3, box2, box1, mesh])
+      expectStacked(managers, [box3, box2, box1, mesh])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'reorder',
@@ -965,11 +966,11 @@ describe('StackBehavior', () => {
 
     it('reorders with animation', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
 
       await mesh.metadata.reorder?.(['box2', 'box0', 'box3', 'box1'])
 
-      expectStacked([box2, mesh, box3, box1])
+      expectStacked(managers, [box2, mesh, box3, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'reorder',
@@ -989,11 +990,11 @@ describe('StackBehavior', () => {
         anchors: [{ id: '1', x: -0.5, snappedId: 'box0' }]
       })
       expectSnapped(box3, mesh)
-      expectStacked([mesh, box1, box2], true, 'box3')
+      expectStacked(managers, [mesh, box1, box2], true, 'box3')
 
       await mesh.metadata.reorder?.(['box1', 'box0', 'box2'])
 
-      expectStacked([box1, mesh, box2], true, 'box3')
+      expectStacked(managers, [box1, mesh, box2], true, 'box3')
       expectSnapped(box3, box1)
 
       expect(actionRecorded).toHaveBeenCalledWith({
@@ -1021,7 +1022,7 @@ describe('StackBehavior', () => {
       mesh.metadata.reorder?.(['box4', 'box3', 'box2', 'box1'])
       await firstReordering
 
-      expectStacked([box2, mesh, box3, box1])
+      expectStacked(managers, [box2, mesh, box3, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'reorder',
@@ -1039,7 +1040,7 @@ describe('StackBehavior', () => {
 
       box3.metadata.reorder?.(['box0', 'box1', 'box2', 'box3'], false)
 
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'reorder',
@@ -1057,7 +1058,7 @@ describe('StackBehavior', () => {
 
       mesh.metadata.reorder?.(['box3', 'box0', 'box2', 'box1'], false)
 
-      expectStacked([box3, mesh, box2, box1])
+      expectStacked(managers, [box3, mesh, box2, box1])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'reorder',
@@ -1072,7 +1073,7 @@ describe('StackBehavior', () => {
 
     it('can revert reordered meshes', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       registerFeedbackSpy.mockClear()
       actionRecorded.mockClear()
 
@@ -1080,7 +1081,7 @@ describe('StackBehavior', () => {
         ['box3', 'box2', 'box1', 'box0'],
         false
       ])
-      expectStacked([box3, box2, box1, mesh])
+      expectStacked(managers, [box3, box2, box1, mesh])
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
@@ -1097,7 +1098,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
       await mesh.metadata.flipAll?.()
-      expectStacked([box3, box2, box1, mesh])
+      expectStacked(managers, [box3, box2, box1, mesh])
       expect(actionRecorded).toHaveBeenCalledTimes(6)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'flipAll',
@@ -1156,7 +1157,7 @@ describe('StackBehavior', () => {
       expectFlipped(mesh, true)
       actionRecorded.mockClear()
       await mesh.metadata.flipAll?.()
-      expectStacked([box3, box2, box1, mesh])
+      expectStacked(managers, [box3, box2, box1, mesh])
       expect(actionRecorded).toHaveBeenCalledTimes(6)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'flipAll',
@@ -1211,7 +1212,7 @@ describe('StackBehavior', () => {
 
     it('flips an entire stack of one', async () => {
       await mesh.metadata.flipAll?.()
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expectFlipped(mesh, true)
       expect(actionRecorded).toHaveBeenCalledTimes(2)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
@@ -1235,10 +1236,10 @@ describe('StackBehavior', () => {
 
     it('flips the entire stack from peer', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
-      controlManager.apply({ fn: 'flipAll', meshId: mesh.id, args: [] })
+      managers.control.apply({ fn: 'flipAll', meshId: mesh.id, args: [] })
 
       await sleep(200)
-      expectStacked([box3, box2, box1, mesh])
+      expectStacked(managers, [box3, box2, box1, mesh])
       expectMoveRecorded(moveRecorded)
       expect(registerFeedbackSpy).not.toHaveBeenCalled()
     })
@@ -1251,7 +1252,7 @@ describe('StackBehavior', () => {
       expectSnapped(box3, mesh)
 
       await mesh.metadata.flipAll?.()
-      expectStacked([box2, box1, mesh], true, 'box3')
+      expectStacked(managers, [box2, box1, mesh], true, 'box3')
       expectSnapped(box3, box2)
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'flipAll',
@@ -1301,7 +1302,7 @@ describe('StackBehavior', () => {
       behavior.fromState({ stackIds: ['box1', 'box2', 'box3'] })
 
       await mesh.metadata.rotate?.()
-      expectStacked([mesh, box1, box2, box3])
+      expectStacked(managers, [mesh, box1, box2, box3])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenNthCalledWith(1, {
         fn: 'rotate',
@@ -1318,7 +1319,7 @@ describe('StackBehavior', () => {
 
     it('rotates an entire stack of one', async () => {
       await mesh.metadata.rotate?.()
-      expectStacked([mesh])
+      expectStacked(managers, [mesh])
       expect(actionRecorded).toHaveBeenCalledOnce()
       expect(actionRecorded).toHaveBeenCalledWith({
         fn: 'rotate',
@@ -1369,7 +1370,7 @@ describe('StackBehavior', () => {
 
     it('can push on top of a stacked the entire stack', async () => {
       behavior.fromState({ stackIds: ['box1', 'box2'] })
-      expectStacked([mesh, box1, box2])
+      expectStacked(managers, [mesh, box1, box2])
       expect(mesh.metadata.canPush?.(box3)).toBe(true)
     })
   })

--- a/apps/web/tests/3d/behaviors/targetable.test.js
+++ b/apps/web/tests/3d/behaviors/targetable.test.js
@@ -5,20 +5,22 @@
 
 import { faker } from '@faker-js/faker'
 import { TargetBehavior, TargetBehaviorName } from '@src/3d/behaviors'
-import { indicatorManager, targetManager } from '@src/3d/managers'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { configures3dTestEngine, createBox } from '../../test-utils'
 
 describe('TargetBehavior', () => {
-  configures3dTestEngine()
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+
+  configures3dTestEngine(created => (managers = created.managers))
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   it('has initial state', () => {
-    const behavior = new TargetBehavior()
+    const behavior = new TargetBehavior({}, managers)
     const mesh = createBox('box', {})
 
     expect(behavior.name).toEqual(TargetBehaviorName)
@@ -30,7 +32,7 @@ describe('TargetBehavior', () => {
   })
 
   it('adds zones', () => {
-    const behavior = new TargetBehavior()
+    const behavior = new TargetBehavior({}, managers)
     const mesh1 = createBox('box1', {})
     const zone1 = behavior.addZone(mesh1, { extent: 1.2 })
     expect(behavior.zones).toEqual([zone1])
@@ -75,21 +77,21 @@ describe('TargetBehavior', () => {
     const meshId = 'box1'
     const playerId = faker.string.uuid()
     const id = `${playerId}.drop-zone.${meshId}`
-    expect(indicatorManager.isManaging({ id })).toBe(false)
-    const behavior = new TargetBehavior()
+    expect(managers.indicator.isManaging({ id })).toBe(false)
+    const behavior = new TargetBehavior({}, managers)
     const mesh = createBox(meshId, {})
     const zone = behavior.addZone(mesh, { playerId, extent: 1 })
     expect(behavior.zones).toEqual([zone])
     expect(zone).toEqual(
       expect.objectContaining({ mesh, enabled: true, priority: 0, playerId })
     )
-    expect(indicatorManager.isManaging({ id })).toBe(true)
+    expect(managers.indicator.isManaging({ id })).toBe(true)
     behavior.removeZone(zone)
-    expect(indicatorManager.isManaging({ id })).toBe(false)
+    expect(managers.indicator.isManaging({ id })).toBe(false)
   })
 
   it('removes added zone and disposes their mesh', () => {
-    const behavior = new TargetBehavior()
+    const behavior = new TargetBehavior({}, managers)
     const mesh = createBox('box', {})
     const zone = behavior.addZone(mesh, { extent: 1.2 })
     expect(behavior.zones).toEqual([zone])
@@ -100,7 +102,7 @@ describe('TargetBehavior', () => {
   })
 
   it('can not remove random zone', () => {
-    const behavior = new TargetBehavior()
+    const behavior = new TargetBehavior({}, managers)
     const mesh = createBox('box', {})
 
     behavior.removeZone({
@@ -121,14 +123,14 @@ describe('TargetBehavior', () => {
     let behavior
 
     beforeEach(() => {
-      behavior = new TargetBehavior()
+      behavior = new TargetBehavior({}, managers)
       mesh = createBox('box', {})
       mesh.addBehavior(behavior, true)
     })
 
     it('registers to the target manager', () => {
       expect(behavior.mesh).toEqual(mesh)
-      expect(targetManager.isManaging(mesh)).toBe(true)
+      expect(managers.target.isManaging(mesh)).toBe(true)
     })
 
     it('unregisteres from manager and removes zones upon detaching', () => {
@@ -143,7 +145,7 @@ describe('TargetBehavior', () => {
         kinds: ['box', 'card'],
         enabled: false
       })
-      expect(indicatorManager.isManaging({ id })).toBe(true)
+      expect(managers.indicator.isManaging({ id })).toBe(true)
 
       mesh.dispose()
       expect(behavior.mesh).toBeNull()
@@ -151,7 +153,7 @@ describe('TargetBehavior', () => {
       expect(mesh1.isDisposed()).toBe(true)
       expect(mesh2.isDisposed()).toBe(true)
       expect(behavior.zones).toEqual([])
-      expect(indicatorManager.isManaging({ id })).toBe(false)
+      expect(managers.indicator.isManaging({ id })).toBe(false)
     })
   })
 })

--- a/apps/web/tests/3d/behaviors/targetable.test.js
+++ b/apps/web/tests/3d/behaviors/targetable.test.js
@@ -13,7 +13,9 @@ describe('TargetBehavior', () => {
   /** @type {import('@src/3d/managers').Managers} */
   let managers
 
-  configures3dTestEngine(created => (managers = created.managers))
+  configures3dTestEngine(created => (managers = created.managers), {
+    isSimulation: globalThis.use3dSimulation
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/tests/3d/engine.test.js
+++ b/apps/web/tests/3d/engine.test.js
@@ -12,7 +12,6 @@ import { Logger } from '@babylonjs/core/Misc/logger'
 import { faker } from '@faker-js/faker'
 import { createEngine } from '@src/3d'
 import { DrawBehaviorName } from '@src/3d/behaviors'
-import { createCard } from '@src/3d/meshes'
 import { sleep } from '@src/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -40,8 +39,7 @@ describe('createEngine()', () => {
   it('initializes engine with parameters', () => {
     const longTapDelay = faker.number.int(999)
     engine = createEngine({
-      // @ts-expect-error -- different constructor signatures
-      Engine: NullEngine,
+      makeEngine: () => new NullEngine(),
       canvas,
       interaction,
       hand,
@@ -56,9 +54,11 @@ describe('createEngine()', () => {
     expect(engine.actionNamesByButton).toEqual(new Map([]))
     expect(engine.actionNamesByKey).toEqual(new Map([]))
   })
-  // TODO input manager stopAll()
 
-  describe('given an engine', () => {
+  describe.each([
+    { title: 'real engine', canvas, makeEngine: () => new NullEngine() },
+    { title: 'simulation engine' }
+  ])('given a $title', ({ canvas, makeEngine }) => {
     /** @type {?Observer} */
     let loadingObserver
     const colorByPlayerId = new Map([[playerId, '#f0f']])
@@ -67,12 +67,10 @@ describe('createEngine()', () => {
     beforeEach(() => {
       vi.clearAllMocks()
       engine = createEngine({
-        // @ts-expect-error different constructor signatures
-        Engine: NullEngine,
+        makeEngine,
         canvas,
         interaction,
         hand,
-        doubleTapDelay: 100,
         longTapDelay: 200,
         translate
       })
@@ -81,6 +79,22 @@ describe('createEngine()', () => {
 
     afterEach(() => {
       engine.onLoadingObservable.remove(loadingObserver)
+    })
+
+    it('enables material managers and lights according to its nature', () => {
+      const isSimulation = !canvas
+      expect(engine.managers.material.disabled).toBe(isSimulation)
+      const ambientLight = engine.scenes[0].getLightByName('ambient')
+      const sunLight = engine.scenes[1].getLightByName('sun')
+      if (isSimulation) {
+        expect(engine.simulation).toBeNull()
+        expect(ambientLight).toBeNull()
+        expect(sunLight).toBeNull()
+      } else {
+        expect(engine.simulation).toBeInstanceOf(NullEngine)
+        expect(ambientLight).toBeDefined()
+        expect(sunLight).toBeDefined()
+      }
     })
 
     it('can load() game data, including colors and peers selections', async () => {
@@ -110,6 +124,7 @@ describe('createEngine()', () => {
       engine.scenes[1].onDataLoadedObservable.notifyObservers(engine.scenes[1])
       expect(engine.scenes[1].getMeshById(mesh.id)).toBeDefined()
       expect(engine.isLoading).toBe(false)
+      expect(engine.managers.input.enabled).toBe(Boolean(canvas))
       expect(engine.managers.selection.color).toEqual(
         Color4.FromHexString(
           /** @type {string} */ (colorByPlayerId.get(playerId))
@@ -129,11 +144,18 @@ describe('createEngine()', () => {
       expect(applySelection).toHaveBeenCalledTimes(2)
     })
 
-    it('can serialize() game data', () => {
-      createCard(
-        { id: 'card3', texture: 'https://elyse.biz' },
-        engine.managers,
-        engine.scenes[1]
+    it('can serialize() game data', async () => {
+      const id = 'card3'
+      const texture = 'https://elyse.biz'
+      await engine.load(
+        {
+          id: '',
+          created: Date.now(),
+          meshes: [{ id, texture, shape: 'card' }],
+          hands: []
+        },
+        { playerId, colorByPlayerId, preferences: { playerId } },
+        false
       )
       expect(engine.serialize()).toEqual({
         meshes: [
@@ -142,7 +164,7 @@ describe('createEngine()', () => {
             depth: 4.25,
             height: 0.01,
             id: 'card3',
-            texture: 'https://elyse.biz',
+            texture,
             faceUV: [
               [0.5, 1, 0, 0],
               [0.5, 0, 1, 1]
@@ -264,22 +286,32 @@ describe('createEngine()', () => {
         true
       )
 
-      expect(engine.actionNamesByButton).toMatchInlineSnapshot(`
-        Map {
-          "button1" => [
-            "rotate",
-            "pop",
-          ],
-          "button2" => [
-            "random",
-          ],
-        }
-      `)
+      expect(engine.actionNamesByButton).toEqual(
+        new Map([
+          ['button1', ['rotate', 'pop']],
+          ['button2', ['random']]
+        ])
+      )
     })
 
     describe('given some loaded meshes', () => {
+      const duration = 200
+      /** @type {Engine} */
+      let simulation
+      /** @type {import('vitest').Spy<import('@src/3d/managers').ControlManager['apply']>} */
+      let apply
+      /** @type {import('vitest').Spy<import('@src/3d/managers').SelectionManager['apply']>} */
+      let applySelection
+      /** @type {import('vitest').Spy<import('@src/3d/managers').ReplayManager['record']>} */
+      let record
+      /** @type {import('vitest').Spy<import('@src/3d/managers').ControlManager['apply']>} */
+      let simulationApply
+      /** @type {import('vitest').Spy<import('@src/3d/managers').SelectionManager['apply']>} */
+      let simulationApplySelection
+      /** @type {import('vitest').Spy<import('@src/3d/managers').ReplayManager['record']>} */
+      let simulationRecord
+
       beforeEach(async () => {
-        const duration = 200
         await engine.load(
           {
             id: '',
@@ -313,6 +345,18 @@ describe('createEngine()', () => {
           true
         )
         engine.start()
+        record = vi.spyOn(engine.managers.replay, 'record')
+        apply = vi.spyOn(engine.managers.control, 'apply')
+        applySelection = vi.spyOn(engine.managers.selection, 'apply')
+        if (engine.simulation) {
+          simulation = engine.simulation
+          simulationApply = vi.spyOn(simulation.managers.control, 'apply')
+          simulationRecord = vi.spyOn(simulation.managers.replay, 'record')
+          simulationApplySelection = vi.spyOn(
+            simulation.managers.selection,
+            'apply'
+          )
+        }
       })
 
       it('removes drawn mesh from main scene', async () => {
@@ -347,40 +391,363 @@ describe('createEngine()', () => {
       })
 
       it('has action names mapped by button and shortcut', () => {
-        expect(engine.actionNamesByButton).toMatchInlineSnapshot(`
-          Map {
-            "button1" => [
-              "flip",
-              "random",
-            ],
-            "button2" => [
-              "rotate",
-            ],
-          }
-        `)
-        expect(engine.actionNamesByKey).toMatchInlineSnapshot(`
-          Map {
-            "shortcuts.drawOrPlay" => [
-              "draw",
-              "play",
-            ],
-            "shortcuts.reorder" => [
-              "reorder",
-            ],
-            "shortcuts.flip" => [
-              "flip",
-            ],
-            "shortcuts.push" => [
-              "push",
-              "increment",
-            ],
-            "shortcuts.pop" => [
-              "pop",
-              "decrement",
-            ],
-          }
-        `)
+        expect(engine.actionNamesByButton).toEqual(
+          new Map([
+            ['button1', ['flip', 'random']],
+            ['button2', ['rotate']]
+          ])
+        )
+        expect(engine.actionNamesByKey).toEqual(
+          new Map([
+            ['shortcuts.drawOrPlay', ['draw', 'play']],
+            ['shortcuts.reorder', ['reorder']],
+            ['shortcuts.flip', ['flip']],
+            ['shortcuts.push', ['push', 'increment']],
+            ['shortcuts.pop', ['pop', 'decrement']]
+          ])
+        )
       })
+
+      it('applies remote action', async () => {
+        /** @type {import('@src/3d/managers').Action} */
+        const action = {
+          fn: 'flip',
+          meshId: 'card3',
+          fromHand: false,
+          args: []
+        }
+        await engine.applyRemoteAction(action, peerId2)
+        expect(record).toHaveBeenNthCalledWith(1, action, peerId2)
+        expect(record).toHaveBeenNthCalledWith(2, {
+          ...action,
+          isLocal: true,
+          duration: 500
+        })
+        expect(record).toHaveBeenCalledTimes(2)
+        expect(apply).toHaveBeenCalledWith(action)
+        expect(apply).toHaveBeenCalledOnce()
+        expect(record).toHaveBeenCalledBefore(apply)
+      })
+
+      it('applies remote selection', () => {
+        const meshIds = ['box3']
+        engine.applyRemoteSelection(meshIds, peerId2)
+        expect(applySelection).toHaveBeenCalledWith(meshIds, peerId2)
+        expect(applySelection).toHaveBeenCalledOnce()
+      })
+
+      describe('given replaying', () => {
+        beforeEach(() => {
+          vi.spyOn(
+            engine.managers.replay,
+            'isReplaying',
+            'get'
+          ).mockReturnValue(true)
+        })
+
+        it('does not apply remote action', async () => {
+          /** @type {import('@src/3d/managers').Action} */
+          const action = {
+            fn: 'flip',
+            meshId: 'card3',
+            fromHand: false,
+            args: []
+          }
+          await engine.applyRemoteAction(action, peerId2)
+          expect(record).toHaveBeenNthCalledWith(1, action, peerId2)
+          expect(record).toHaveBeenCalledOnce()
+          expect(apply).not.toHaveBeenCalled()
+        })
+
+        it('does not apply remote selection when replaying', async () => {
+          engine.applyRemoteSelection(['box3'], peerId2)
+          expect(applySelection).not.toHaveBeenCalled()
+        })
+      })
+
+      if (canvas) {
+        it('updates simulation on remote action', async () => {
+          const state = engine.serialize()
+          /** @type {import('@src/3d/managers').Action} */
+          const action = {
+            fn: 'flip',
+            meshId: 'card3',
+            fromHand: false,
+            args: []
+          }
+          await engine.applyRemoteAction(action, peerId2)
+          expect(simulationRecord).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ isLocal: true })
+          )
+          expect(simulationRecord).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ isLocal: true })
+          )
+          expect(simulationRecord).toHaveBeenNthCalledWith(3, action, peerId2)
+          expect(simulationRecord).toHaveBeenCalledTimes(3)
+          expect(simulationApply).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ isLocal: true })
+          )
+          expect(simulationApply).toHaveBeenNthCalledWith(2, action)
+          expect(simulationApply).toHaveBeenCalledTimes(2)
+          expect(record).toHaveBeenNthCalledWith(1, action, peerId2)
+          expect(record).toHaveBeenCalledTimes(2)
+          expect(apply).toHaveBeenCalledWith(action)
+          expect(apply).toHaveBeenCalledOnce()
+          expect(engine.serialize()).toEqual({
+            handMeshes: [],
+            history: [
+              {
+                ...action,
+                args: undefined,
+                argsStr: '[]',
+                playerId: peerId2,
+                time: expect.any(Number)
+              }
+            ],
+            meshes: [
+              ...state.meshes.slice(0, 2),
+              {
+                ...state.meshes[2],
+                flippable: { duration: 500, isFlipped: true },
+                y: expect.numberCloseTo(0, 2)
+              }
+            ]
+          })
+        })
+
+        it('updates simulation on local action', async () => {
+          const state = engine.serialize()
+          /** @type {import('@src/3d/managers').Action} */
+          const action = {
+            fn: 'flip',
+            meshId: 'card3',
+            fromHand: false,
+            duration: 500,
+            isLocal: false,
+            args: []
+          }
+          engine.scenes[1].getMeshById('card3')?.metadata.flip?.()
+          expect(record).toHaveBeenCalledWith(action)
+          expect(record).toHaveBeenCalledOnce()
+          expect(apply).not.toHaveBeenCalled()
+          expect(simulationRecord).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ isLocal: true })
+          )
+          expect(simulationRecord).toHaveBeenNthCalledWith(2, action)
+          expect(simulationRecord).toHaveBeenCalledTimes(2)
+          expect(simulationApply).toHaveBeenCalledWith(action)
+          expect(simulationApply).toHaveBeenCalledOnce()
+          expect(engine.serialize()).toEqual({
+            handMeshes: [],
+            history: [
+              {
+                ...action,
+                isLocal: undefined,
+                args: undefined,
+                argsStr: '[]',
+                playerId,
+                time: expect.any(Number)
+              }
+            ],
+            meshes: [
+              ...state.meshes.slice(0, 2),
+              {
+                ...state.meshes[2],
+                flippable: { duration: 500, isFlipped: true },
+                y: expect.numberCloseTo(0, 2)
+              }
+            ]
+          })
+        })
+
+        it('udpates simulation with remote selection', () => {
+          const meshIds = ['box1', 'box3']
+          engine.applyRemoteSelection(meshIds, peerId1)
+          expect(simulationApplySelection).toHaveBeenCalledWith(
+            meshIds,
+            peerId1
+          )
+          expect(simulationApplySelection).toHaveBeenCalledOnce()
+        })
+
+        it('updates simulation with selected meshes', () => {
+          const mesh = /** @type {import('@babylonjs/core').Mesh} */ (
+            engine.scenes[1].getMeshById('card1')
+          )
+          engine.managers.selection.select(mesh)
+          engine.managers.selection.unselect(mesh)
+          expect(applySelection).not.toHaveBeenCalled()
+          expect(simulationApplySelection).toHaveBeenNthCalledWith(
+            1,
+            ['card1'],
+            playerId
+          )
+          expect(simulationApplySelection).toHaveBeenNthCalledWith(
+            2,
+            [],
+            playerId
+          )
+          expect(simulationApplySelection).toHaveBeenCalledTimes(2)
+        })
+
+        it('updates simulation on load', async () => {
+          expect(engine.scenes[1].getMeshById('card3')).toBeDefined()
+          expect(simulation.scenes[1].getMeshById('card3')).toBeDefined()
+          const state = engine.serialize()
+          await engine.load(
+            {
+              id: '',
+              created: Date.now(),
+              meshes: [
+                {
+                  id: 'card1',
+                  shape: 'card',
+                  texture: '',
+                  drawable: { duration }
+                },
+                {
+                  id: 'card2',
+                  shape: 'card',
+                  texture: '',
+                  drawable: { duration },
+                  stackable: {},
+                  quantifiable: {}
+                }
+              ],
+              hands: []
+            },
+            { playerId, colorByPlayerId, preferences: { playerId } }
+          )
+          expect(engine.scenes[1].getMeshById('card3')).toBeNull()
+          expect(simulation.scenes[1].getMeshById('card3')).toBeNull()
+          expect(engine.serialize()).toEqual({
+            ...state,
+            meshes: state.meshes.slice(0, -1)
+          })
+        })
+
+        describe('given replaying', () => {
+          beforeEach(() => {
+            vi.spyOn(
+              engine.managers.replay,
+              'isReplaying',
+              'get'
+            ).mockReturnValue(true)
+          })
+
+          it('updates simulation on remote action', async () => {
+            const state = engine.serialize()
+            /** @type {import('@src/3d/managers').Action} */
+            const action = {
+              fn: 'flip',
+              meshId: 'card3',
+              fromHand: false,
+              args: []
+            }
+            await engine.applyRemoteAction(action, peerId2)
+            expect(simulationRecord).toHaveBeenNthCalledWith(1, action, peerId2)
+            expect(simulationRecord).toHaveBeenNthCalledWith(
+              2,
+              expect.objectContaining({ isLocal: true })
+            )
+            expect(simulationRecord).toHaveBeenCalledTimes(2)
+            expect(simulationApply).toHaveBeenCalledWith(action)
+            expect(simulationApply).toHaveBeenCalledOnce()
+            expect(engine.serialize()).toEqual({
+              handMeshes: [],
+              history: [
+                {
+                  ...action,
+                  args: undefined,
+                  argsStr: '[]',
+                  playerId: peerId2,
+                  time: expect.any(Number)
+                }
+              ],
+              meshes: [
+                ...state.meshes.slice(0, 2),
+                {
+                  ...state.meshes[2],
+                  flippable: { duration: 500, isFlipped: true },
+                  y: expect.numberCloseTo(0, 2)
+                }
+              ]
+            })
+            expect(record).toHaveBeenCalledWith(action, peerId2)
+            expect(record).toHaveBeenCalledOnce()
+            expect(apply).not.toHaveBeenCalled()
+          })
+
+          it('does not update simulation on local action', async () => {
+            const state = engine.serialize()
+            engine.scenes[1].getMeshById('card3')?.metadata.flip?.()
+            expect(record).toHaveBeenCalledWith({
+              fn: 'flip',
+              duration: 500,
+              meshId: 'card3',
+              fromHand: false,
+              isLocal: false,
+              args: []
+            })
+            expect(record).toHaveBeenCalledOnce()
+            expect(apply).not.toHaveBeenCalled()
+            expect(simulationRecord).not.toHaveBeenCalled()
+            expect(simulationApply).not.toHaveBeenCalled()
+            expect(engine.serialize()).toEqual(state)
+          })
+
+          it('updates simulation with remote selection', () => {
+            const meshIds = ['box1', 'box3']
+            engine.applyRemoteSelection(meshIds, peerId1)
+            expect(simulationApplySelection).toHaveBeenCalledWith(
+              meshIds,
+              peerId1
+            )
+            expect(simulationApplySelection).toHaveBeenCalledOnce()
+            expect(applySelection).not.toHaveBeenCalledOnce()
+          })
+
+          it('only loads simulation', async () => {
+            expect(engine.scenes[1].getMeshById('card3')).toBeDefined()
+            expect(simulation.scenes[1].getMeshById('card3')).toBeDefined()
+            const state = engine.serialize()
+            await engine.load(
+              {
+                id: '',
+                created: Date.now(),
+                meshes: [
+                  {
+                    id: 'card1',
+                    shape: 'card',
+                    texture: '',
+                    drawable: { duration }
+                  },
+                  {
+                    id: 'card2',
+                    shape: 'card',
+                    texture: '',
+                    drawable: { duration },
+                    stackable: {},
+                    quantifiable: {}
+                  }
+                ],
+                hands: []
+              },
+              { playerId, colorByPlayerId, preferences: { playerId } }
+            )
+            expect(engine.scenes[1].getMeshById('card3')).toBeDefined()
+            expect(simulation.scenes[1].getMeshById('card3')).toBeNull()
+            expect(engine.serialize()).toEqual({
+              ...state,
+              meshes: state.meshes.slice(0, -1)
+            })
+          })
+        })
+      }
     })
   })
 })

--- a/apps/web/tests/3d/managers/control.test.js
+++ b/apps/web/tests/3d/managers/control.test.js
@@ -43,16 +43,19 @@ describe('ControlManager', () => {
   /** @type {string} */
   let playerId
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    handScene = created.handScene
-    managers = created.managers
-    playerId = created.playerId
-    manager = managers.control
-    managers.hand.enabled = true
-    manager.onActionObservable.add(action => actions.push(action))
-    manager.onControlledObservable.add(controlledChangeReceived)
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      handScene = created.handScene
+      managers = created.managers
+      playerId = created.playerId
+      manager = managers.control
+      managers.hand.enabled = true
+      manager.onActionObservable.add(action => actions.push(action))
+      manager.onControlledObservable.add(controlledChangeReceived)
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/tests/3d/managers/control.test.js
+++ b/apps/web/tests/3d/managers/control.test.js
@@ -12,12 +12,7 @@
 
 import { faker } from '@faker-js/faker'
 import { AnchorBehavior, FlipBehavior, MoveBehavior } from '@src/3d/behaviors'
-import {
-  controlManager as manager,
-  handManager,
-  indicatorManager
-} from '@src/3d/managers'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { configures3dTestEngine, createBox } from '../../test-utils'
 
@@ -41,46 +36,41 @@ describe('ControlManager', () => {
   /** @type {SpyInstance<Parameters<AnchorBehavior['revert']>, Promise<void>>} */
   let revertSpy
   const controlledChangeReceived = vi.fn()
-  const playerId = 'player-id-1'
-  const handOverlay = document.createElement('div')
-  const renderWidth = 480
-  const renderHeight = 350
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+  /** @type {import('@src/3d/managers').ControlManager} */
+  let manager
+  /** @type {string} */
+  let playerId
 
-  configures3dTestEngine(
-    created => {
-      scene = created.scene
-      handScene = created.handScene
-      handManager.init({ ...created, playerId, overlay: handOverlay })
-    },
-    { renderWidth, renderHeight }
-  )
-
-  beforeAll(() => {
-    vi.spyOn(window, 'getComputedStyle').mockImplementation(
-      () =>
-        /** @type {CSSStyleDeclaration} */ ({
-          height: `${renderHeight / 4}px`
-        })
-    )
-    indicatorManager.init({ scene })
+  configures3dTestEngine(created => {
+    scene = created.scene
+    handScene = created.handScene
+    managers = created.managers
+    playerId = created.playerId
+    manager = managers.control
+    managers.hand.enabled = true
     manager.onActionObservable.add(action => actions.push(action))
     manager.onControlledObservable.add(controlledChangeReceived)
   })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     actions = []
 
     mesh = createBox('box1', {}, scene)
-    mesh.addBehavior(new MoveBehavior(), true)
+    mesh.addBehavior(new MoveBehavior({}, managers), true)
     anchorable = createBox('box2', {})
-    const anchorableBehavior = new AnchorBehavior({
-      anchors: [{ id: 'anchor-0', width: 1, height: 1, depth: 0.5 }]
-    })
+    const anchorableBehavior = new AnchorBehavior(
+      {
+        anchors: [{ id: 'anchor-0', width: 1, height: 1, depth: 0.5 }]
+      },
+      managers
+    )
     anchorable.addBehavior(anchorableBehavior, true)
-    anchorable.addBehavior(new FlipBehavior(), true)
+    anchorable.addBehavior(new FlipBehavior({}, managers), true)
     handMesh = createBox('hand-box', {}, handScene)
-    handMesh.addBehavior(new MoveBehavior(), true)
+    handMesh.addBehavior(new MoveBehavior({}, managers), true)
     snapSpy = vi.spyOn(anchorable.metadata, 'snap')
     flipSpy = vi.spyOn(anchorable.metadata, 'flip')
     revertSpy = vi.spyOn(anchorableBehavior, 'revert')
@@ -88,7 +78,6 @@ describe('ControlManager', () => {
     manager.registerControlable(mesh)
     manager.registerControlable(handMesh)
     manager.registerControlable(anchorable)
-    manager.init({ scene, handScene })
     controlledChangeReceived.mockReset()
   })
 
@@ -143,7 +132,7 @@ describe('ControlManager', () => {
   describe('apply()', () => {
     it('ignores uncontrolled mesh', async () => {
       const mesh = createBox('box', {})
-      mesh.addBehavior(new FlipBehavior(), true)
+      mesh.addBehavior(new FlipBehavior({}, managers), true)
       const flipSpy = vi.spyOn(mesh.metadata, 'flip')
 
       await manager.apply({ meshId: mesh.id, fn: 'flip', args: [] })

--- a/apps/web/tests/3d/managers/control.test.js
+++ b/apps/web/tests/3d/managers/control.test.js
@@ -5,10 +5,6 @@
  * @typedef {import('@src/3d/managers/control').Action} Action
  * @typedef {import('@src/3d/managers/control').Move} Move
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { faker } from '@faker-js/faker'
 import { AnchorBehavior, FlipBehavior, MoveBehavior } from '@src/3d/behaviors'
@@ -29,11 +25,11 @@ describe('ControlManager', () => {
   let handMesh
   /** @type {Mesh} */
   let anchorable
-  /** @type {SpyInstance<Parameters<AnchorBehavior['snap']>, Promise<void>>} */
+  /** @type {import('vitest').Spy<AnchorBehavior['snap']>} */
   let snapSpy
-  /** @type {SpyInstance<Parameters<FlipBehavior['flip']>, Promise<void>>} */
+  /** @type {import('vitest').Spy<FlipBehavior['flip']>} */
   let flipSpy
-  /** @type {SpyInstance<Parameters<AnchorBehavior['revert']>, Promise<void>>} */
+  /** @type {import('vitest').Spy<AnchorBehavior['revert']>} */
   let revertSpy
   const controlledChangeReceived = vi.fn()
   /** @type {import('@src/3d/managers').Managers} */

--- a/apps/web/tests/3d/managers/custom-shape.test.js
+++ b/apps/web/tests/3d/managers/custom-shape.test.js
@@ -1,9 +1,4 @@
 // @ts-check
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
-
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -44,7 +39,7 @@ describe('CustomShapeManager', () => {
     Object.keys(fixtures).map(key => [key, btoa(JSON.stringify(fixtures[key]))])
   )
 
-  /** @type {SpyInstance<any[], void>} */
+  /** @type {import('vitest').Spy<logger['error']>} */
   let error
   const server = setupServer(
     rest.get(`${gameAssetsUrl}/:name`, ({ params }, res, ctx) => {

--- a/apps/web/tests/3d/managers/custom-shape.test.js
+++ b/apps/web/tests/3d/managers/custom-shape.test.js
@@ -8,7 +8,7 @@ import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 import { faker } from '@faker-js/faker'
-import { customShapeManager as manager } from '@src/3d/managers'
+import { CustomShapeManager } from '@src/3d/managers'
 import { getDieModelFile } from '@src/3d/meshes'
 import { makeLogger } from '@src/utils'
 import { rest } from 'msw'
@@ -54,10 +54,12 @@ describe('CustomShapeManager', () => {
     })
   )
 
+  const manager = new CustomShapeManager({ gameAssetsUrl })
+
   beforeAll(() => server.listen())
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     server.resetHandlers()
     error = vi.spyOn(logger, 'error')
     vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -82,12 +84,12 @@ describe('CustomShapeManager', () => {
         )
       )
       await manager.init({
-        gameAssetsUrl,
+        id: 'game',
+        created: Date.now(),
         meshes: [
           { id: '', texture: '', shape: 'custom', file },
           { id: '', texture: '', shape: 'die', faces: 4 }
-        ],
-        hands: undefined
+        ]
       })
       expect(manager.get(file)).toEqual(expectedData.pawn)
       expect(manager.get(getDieModelFile(4))).toEqual(expectedData.die)
@@ -109,8 +111,8 @@ describe('CustomShapeManager', () => {
         )
       )
       await manager.init({
-        gameAssetsUrl,
-        meshes: undefined,
+        id: 'game',
+        created: Date.now(),
         hands: [
           {
             playerId: '1',
@@ -139,7 +141,8 @@ describe('CustomShapeManager', () => {
         )
       )
       await manager.init({
-        gameAssetsUrl,
+        id: 'game',
+        created: Date.now(),
         meshes: [
           { id: '', texture: '', shape: 'card', file: file1 },
           { id: '', texture: '', shape: 'custom', file: file2 }
@@ -154,7 +157,8 @@ describe('CustomShapeManager', () => {
       const file = `/${faker.lorem.word()}`
       await expect(
         manager.init({
-          gameAssetsUrl,
+          id: 'game',
+          created: Date.now(),
           meshes: [{ id: '', texture: '', shape: 'custom', file: file }],
           hands: undefined
         })
@@ -174,7 +178,8 @@ describe('CustomShapeManager', () => {
         })
       )
       await manager.init({
-        gameAssetsUrl,
+        id: 'game',
+        created: Date.now(),
         meshes: [
           { id: '', texture: '', shape: 'custom', file: file },
           { id: '', texture: '', shape: 'custom', file: file }
@@ -189,7 +194,8 @@ describe('CustomShapeManager', () => {
       const id = faker.string.uuid()
       await expect(
         manager.init({
-          gameAssetsUrl,
+          id: 'game',
+          created: Date.now(),
           meshes: [{ id, texture: '', shape: 'custom' }],
           hands: undefined
         })
@@ -200,7 +206,8 @@ describe('CustomShapeManager', () => {
       const id = faker.string.uuid()
       await expect(
         manager.init({
-          gameAssetsUrl,
+          id: 'game',
+          created: Date.now(),
           meshes: [{ id, texture: '', shape: 'die' }],
           hands: undefined
         })
@@ -215,10 +222,11 @@ describe('CustomShapeManager', () => {
     const knightPath = '/knight.obj'
 
     beforeEach(async () => {
-      vi.resetAllMocks()
+      vi.clearAllMocks()
       server.resetHandlers()
       await manager.init({
-        gameAssetsUrl,
+        id: 'game',
+        created: Date.now(),
         meshes: [
           { id: '', texture: '', shape: 'custom', file: pawnPath },
           { id: '', texture: '', shape: 'custom', file: avatarPath }
@@ -235,7 +243,8 @@ describe('CustomShapeManager', () => {
           )
         )
         await manager.init({
-          gameAssetsUrl,
+          id: 'game',
+          created: Date.now(),
           meshes: [{ id: '', texture: '', shape: 'custom', file: diePath }],
           hands: undefined
         })
@@ -255,7 +264,8 @@ describe('CustomShapeManager', () => {
           )
         )
         await manager.init({
-          gameAssetsUrl,
+          id: 'game',
+          created: Date.now(),
           meshes: [{ id: '', texture: '', shape: 'custom', file: knightPath }],
           hands: undefined
         })
@@ -271,7 +281,7 @@ describe('CustomShapeManager', () => {
       })
 
       it('throws on unknown file', () => {
-        const file = faker.image.abstract()
+        const file = faker.image.url()
         expect(() => manager.get(file)).toThrow(
           `${file} must be cached with init()`
         )

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -621,6 +621,14 @@ describe('HandManager', () => {
         expect(getPositions(handCards)).toEqual(positions)
       })
 
+      it('lays out hand when replaying history', async () => {
+        managers.replay.onReplayRankObservable.notifyObservers(1)
+        await waitForLayout(managers.hand)
+        expectPosition(handCards[1], [-unitWidth, 0.005, computeZ()])
+        expectPosition(handCards[0], [0, 0.005, computeZ()])
+        expectPosition(handCards[2], [unitWidth, 0.005, computeZ()])
+      })
+
       it('does not lay out hand when rotating mesh in main scene', async () => {
         const positions = getPositions(handCards)
         cards[2].metadata.rotate?.()

--- a/apps/web/tests/3d/managers/hand.test.js
+++ b/apps/web/tests/3d/managers/hand.test.js
@@ -8,10 +8,6 @@
  * @typedef {import('@src/3d/behaviors').DrawBehavior} DrawBehavior
  * @typedef {import('@tabulous/server/src/graphql').Mesh} SerializableMesh
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
@@ -57,7 +53,7 @@ describe('HandManager', () => {
   let actionObserver
   /** @type {Vector3} */
   let savedCameraPosition
-  /** @type {SpyInstance<Parameters<import('@src/3d/managers').IndicatorManager['registerFeedback']>, void>} */
+  /** @type {import('vitest').Spy<import('@src/3d/managers').IndicatorManager['registerFeedback']>} */
   let registerFeedbackSpy
   /** @type {import('@src/3d/managers').Managers} */
   let managers

--- a/apps/web/tests/3d/managers/indicator.test.js
+++ b/apps/web/tests/3d/managers/indicator.test.js
@@ -10,16 +10,8 @@
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
-import { indicatorManager as manager } from '@src/3d/managers'
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi
-} from 'vitest'
+import { IndicatorManager } from '@src/3d/managers'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   configures3dTestEngine,
@@ -31,337 +23,339 @@ import {
 describe('IndicatorManager', () => {
   /** @type {Scene} */
   let scene
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+  const changeReceived = vi.fn()
+  /** @type {Mesh} */
+  let mesh
 
-  configures3dTestEngine(created => (scene = created.scene))
+  configures3dTestEngine(created => {
+    scene = created.scene
+    managers = created.managers
+    managers.indicator.onChangeObservable.add(changeReceived)
+  })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
+    mesh = createBox(faker.string.uuid(), {}, scene)
   })
 
   it('has initial state', async () => {
-    expect(manager.onChangeObservable).toBeDefined()
+    expect(managers.indicator.scene).toEqual(scene)
+    expect(managers.indicator.onChangeObservable).toBeDefined()
   })
 
-  describe('init()', () => {
-    it('sets scenes', () => {
-      manager.init({ scene })
-      expect(manager.scene).toEqual(scene)
-      expect(manager.onChangeObservable).toBeDefined()
+  describe('registerMeshIndicator()', () => {
+    it('registers a mesh', () => {
+      const indicator = { id: mesh.id, mesh, size: 1 }
+      expect(managers.indicator.isManaging(indicator)).toBe(false)
+
+      expect(managers.indicator.registerMeshIndicator(indicator)).toEqual(
+        indicator
+      )
+      expect(managers.indicator.isManaging(indicator)).toBe(true)
+      expect(managers.indicator.getById(indicator.id)).toEqual(indicator)
+      expectChanged([
+        { id: mesh.id, screenPosition: { x: 1024, y: 500.85 }, size: 1 }
+      ])
+    })
+
+    it('automatically unregisters a mesh upon disposal', () => {
+      const indicator = { id: mesh.id, mesh, size: 1 }
+      managers.indicator.registerMeshIndicator(indicator)
+      expect(managers.indicator.isManaging(indicator)).toBe(true)
+      expectChanged([
+        { id: mesh.id, screenPosition: { x: 1024, y: 500.85 }, size: 1 }
+      ])
+
+      mesh.dispose()
+      expect(managers.indicator.isManaging(indicator)).toBe(false)
+      expectChanged([])
     })
   })
 
-  describe('given initialised', () => {
-    /** @type {Mesh} */
-    let mesh
-    const changeReceived = vi.fn()
+  describe('registerPointerIndicator()', () => {
+    afterEach(() => managers.indicator.pruneUnusedPointers([]))
 
-    beforeAll(() => {
-      manager.init({ scene })
-      manager.onChangeObservable.add(changeReceived)
+    it('registers a new pointer', () => {
+      const playerId = faker.string.uuid()
+      const position = [-10, 0, -5]
+      const id = `pointer-${playerId}`
+      expect(managers.indicator.isManaging({ id })).toBe(false)
+
+      const indicator = managers.indicator.registerPointerIndicator(
+        playerId,
+        position
+      )
+      expect(indicator).toMatchObject({ id, position, playerId })
+      expect(indicator.screenPosition?.x).toBeCloseTo(772.16)
+      expect(indicator.screenPosition?.y).toBeCloseTo(628.33)
+      expect(managers.indicator.isManaging(indicator)).toBe(true)
+      expect(managers.indicator.getById(indicator.id)).toEqual(indicator)
+      expectChanged([indicator])
     })
+  })
+
+  describe('registerFeedback()', () => {
+    it('registers a new feedback', () => {
+      /** @type {FeedbackIndicator} */
+      const indicator = {
+        position: mesh.absolutePosition.asArray(),
+        action: 'push'
+      }
+      expect(managers.indicator.isManaging(/** @type {?} */ (indicator))).toBe(
+        false
+      )
+
+      managers.indicator.registerFeedback(indicator)
+      const managed = /** @type {ManagedFeedback} */ (indicator)
+      expect(managed.isFeedback).toBe(true)
+      expect(managed.id).toBeDefined()
+      expect(managed.screenPosition?.x).toBeCloseTo(1024)
+      expect(managed.screenPosition?.y).toBeCloseTo(512)
+      expect(managers.indicator.isManaging(/** @type {?} */ (indicator))).toBe(
+        false
+      )
+      expect(managers.indicator.getById(managed.id)).toBeUndefined()
+      expectChanged([managed])
+    })
+
+    it('does not notify for out-of-screen feedback', () => {
+      /** @type {FeedbackIndicator} */
+      const indicator = {
+        position: [10000, 0, 10000],
+        action: 'push'
+      }
+      expect(managers.indicator.isManaging(/** @type {?} */ (indicator))).toBe(
+        false
+      )
+
+      managers.indicator.registerFeedback(indicator)
+      const managed = /** @type {ManagedFeedback} */ (indicator)
+      expect(managed.isFeedback).toBe(true)
+      expect(managed.id).toBeDefined()
+      expect(managed.screenPosition?.x).toBeCloseTo(4147.67)
+      expect(managed.screenPosition?.y).toBeCloseTo(-2373.89)
+      expect(managers.indicator.isManaging(managed)).toBe(false)
+      expect(managers.indicator.getById(managed.id)).toBeUndefined()
+      expect(changeReceived).not.toHaveBeenCalled()
+    })
+
+    it('ignores postion-less indicators', () => {
+      // @ts-expect-error
+      managers.indicator.registerFeedback()
+      // @ts-expect-error
+      managers.indicator.registerFeedback({})
+      // @ts-expect-error
+      managers.indicator.registerFeedback({ position: mesh.absolutePosition })
+      expect(changeReceived).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unregisterIndicator()', () => {
+    it('ignores uncontrolled indicators', () => {
+      const indicator = { id: mesh.id, mesh }
+      expect(managers.indicator.isManaging(indicator)).toBe(false)
+
+      managers.indicator.unregisterIndicator(indicator)
+      expect(managers.indicator.isManaging(indicator)).toBe(false)
+      expect(changeReceived).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('given registered indicators', () => {
+    /** @type {ManagedIndicator[]} */
+    let indicators
+    const playerIds = [faker.string.uuid(), faker.string.uuid()]
+    /** @type {ManagedPointer[]} */
+    let pointers
+    /** @type {FeedbackIndicator} */
+    let feedback
+    /** @type {IndicatorManager} */
+    let manager
 
     beforeEach(() => {
-      mesh = createBox(faker.string.uuid(), {}, scene)
+      manager = new IndicatorManager({ scene })
+      manager.onChangeObservable.add(changeReceived)
+      indicators = [
+        { id: 'box1', size: 10 },
+        { id: 'box2', size: 5 }
+      ].map(({ id, ...props }) => {
+        const mesh = createBox(id, {})
+        const indicator = { id, mesh, ...props }
+        return manager.registerMeshIndicator(indicator)
+      })
+      pointers = JSON.parse(
+        JSON.stringify(
+          playerIds.map((playerId, rank) =>
+            manager.registerPointerIndicator(playerId, [
+              -10 + rank,
+              0,
+              -5 + rank
+            ])
+          )
+        )
+      )
+      feedback = {
+        position: indicators[0].mesh.absolutePosition.asArray(),
+        action: 'snap'
+      }
+      manager.registerFeedback(feedback)
+      changeReceived.mockReset()
+    })
+
+    it('adds screen positions', async () => {
+      const [indicator1, indicator2] = indicators
+      indicator2.mesh.setAbsolutePosition(new Vector3(10, 0, 10))
+      await waitNextRender(scene)
+      expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
+      expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
+      expect(indicator2.screenPosition?.x).toBeCloseTo(1248.18)
+      expect(indicator2.screenPosition?.y).toBeCloseTo(294.53)
+      expectChanged([...indicators, ...pointers])
+    })
+
+    it('refreshes screen positions on render', async () => {
+      const [indicator1] = indicators
+      await waitNextRender(scene)
+      expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
+      expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
+      expect(changeReceived).not.toHaveBeenCalled()
+
+      indicator1.mesh.setAbsolutePosition(new Vector3(1, 0, 1))
+      await waitNextRender(scene)
+      expect(indicator1.screenPosition?.x).toBeCloseTo(1047.94)
+      expect(indicator1.screenPosition?.y).toBeCloseTo(478.82)
+      expectChanged([...indicators, ...pointers])
+    })
+
+    it(`omits indicator outside of camera's frustum`, async () => {
+      const [indicator1, indicator2] = indicators
+      await waitNextRender(scene)
+      expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
+      expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
+      expect(changeReceived).not.toHaveBeenCalled()
+
+      indicator1.mesh.setAbsolutePosition(new Vector3(200, 0, 200))
+      await waitNextRender(scene)
+      expect(indicator1.screenPosition?.x).toBeCloseTo(2935.17)
+      expect(indicator1.screenPosition?.y).toBeCloseTo(-1258.1)
+      expectChanged([indicator2, ...pointers])
     })
 
     describe('registerMeshIndicator()', () => {
-      it('registers a mesh', () => {
-        const indicator = { id: mesh.id, mesh, size: 1 }
-        expect(manager.isManaging(indicator)).toBe(false)
+      it('updates existing indicators', async () => {
+        const [indicator1, indicator2] = indicators
+        await waitNextRender(scene)
+        expect(changeReceived).not.toHaveBeenCalled()
+        expect(manager.getById(indicator1.id)).not.toHaveProperty('custom')
 
-        expect(manager.registerMeshIndicator(indicator)).toEqual(indicator)
-        expect(manager.isManaging(indicator)).toBe(true)
-        expect(manager.getById(indicator.id)).toEqual(indicator)
-        expectChanged([
-          { id: mesh.id, screenPosition: { x: 1024, y: 500.85 }, size: 1 }
-        ])
-      })
-
-      it('automatically unregisters a mesh upon disposal', () => {
-        const indicator = { id: mesh.id, mesh, size: 1 }
-        manager.registerMeshIndicator(indicator)
-        expect(manager.isManaging(indicator)).toBe(true)
-        expectChanged([
-          { id: mesh.id, screenPosition: { x: 1024, y: 500.85 }, size: 1 }
-        ])
-
-        mesh.dispose()
-        expect(manager.isManaging(indicator)).toBe(false)
-        expectChanged([])
+        const size = 18
+        manager.registerMeshIndicator({ ...indicator1, size })
+        expect(manager.getById(indicator1.id)).toHaveProperty('size', size)
+        expectChanged([{ ...indicator1, size }, indicator2, ...pointers])
       })
     })
 
     describe('registerPointerIndicator()', () => {
-      afterEach(() => manager.pruneUnusedPointers([]))
-
-      it('registers a new pointer', () => {
-        const playerId = faker.string.uuid()
-        const position = [-10, 0, -5]
-        const id = `pointer-${playerId}`
-        expect(manager.isManaging({ id })).toBe(false)
-
-        const indicator = manager.registerPointerIndicator(playerId, position)
-        expect(indicator).toMatchObject({ id, position, playerId })
-        expect(indicator.screenPosition?.x).toBeCloseTo(772.16)
-        expect(indicator.screenPosition?.y).toBeCloseTo(628.33)
-        expect(manager.isManaging(indicator)).toBe(true)
-        expect(manager.getById(indicator.id)).toEqual(indicator)
-        expectChanged([indicator])
-      })
-    })
-
-    describe('registerFeedback()', () => {
-      it('registers a new feedback', () => {
-        /** @type {FeedbackIndicator} */
-        const indicator = {
-          position: mesh.absolutePosition.asArray(),
-          action: 'push'
-        }
-        expect(manager.isManaging(/** @type {?} */ (indicator))).toBe(false)
-
-        manager.registerFeedback(indicator)
-        const managed = /** @type {ManagedFeedback} */ (indicator)
-        expect(managed.isFeedback).toBe(true)
-        expect(managed.id).toBeDefined()
-        expect(managed.screenPosition?.x).toBeCloseTo(1024)
-        expect(managed.screenPosition?.y).toBeCloseTo(512)
-        expect(manager.isManaging(/** @type {?} */ (indicator))).toBe(false)
-        expect(manager.getById(managed.id)).toBeUndefined()
-        expectChanged([managed])
+      it('updates existing pointer', () => {
+        const position = [10, 0, 3]
+        const [pointer1, pointer2] = pointers
+        expect(manager.isManaging(pointer2)).toBe(true)
+        const pointer = manager.registerPointerIndicator(
+          pointer2.playerId,
+          position
+        )
+        expect(pointer.id).toEqual(pointer2.id)
+        expect(pointer.position).toEqual(position)
+        expect(pointer.screenPosition?.x).toBeCloseTo(1260.76)
+        expect(pointer.screenPosition?.y).toBeCloseTo(446.38)
+        expect(manager.isManaging(pointer)).toBe(true)
+        expect(manager.getById(pointer.id)).toEqual(pointer)
+        expectChanged([...indicators, pointer1, pointer])
       })
 
-      it('does not notify for out-of-screen feedback', () => {
-        /** @type {FeedbackIndicator} */
-        const indicator = {
-          position: [10000, 0, 10000],
-          action: 'push'
-        }
-        expect(manager.isManaging(/** @type {?} */ (indicator))).toBe(false)
-
-        manager.registerFeedback(indicator)
-        const managed = /** @type {ManagedFeedback} */ (indicator)
-        expect(managed.isFeedback).toBe(true)
-        expect(managed.id).toBeDefined()
-        expect(managed.screenPosition?.x).toBeCloseTo(4147.67)
-        expect(managed.screenPosition?.y).toBeCloseTo(-2373.89)
-        expect(manager.isManaging(managed)).toBe(false)
-        expect(manager.getById(managed.id)).toBeUndefined()
-        expect(changeReceived).not.toHaveBeenCalled()
-      })
-
-      it('ignores postion-less indicators', () => {
-        // @ts-expect-error
-        manager.registerFeedback()
-        // @ts-expect-error
-        manager.registerFeedback({})
-        // @ts-expect-error
-        manager.registerFeedback({ position: mesh.absolutePosition })
+      it('does not updates with the same position', () => {
+        const [pointer] = pointers
+        const indicator = manager.registerPointerIndicator(
+          pointer.playerId,
+          pointer.position
+        )
+        expect(indicator).toEqual(pointer)
         expect(changeReceived).not.toHaveBeenCalled()
       })
     })
 
     describe('unregisterIndicator()', () => {
-      it('ignores uncontrolled indicators', () => {
-        const indicator = { id: mesh.id, mesh }
-        expect(manager.isManaging(indicator)).toBe(false)
-
-        manager.unregisterIndicator(indicator)
-        expect(manager.isManaging(indicator)).toBe(false)
-        expect(changeReceived).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('given registered indicators', () => {
-      /** @type {ManagedIndicator[]} */
-      let indicators
-      const playerIds = [faker.string.uuid(), faker.string.uuid()]
-      /** @type {ManagedPointer[]} */
-      let pointers
-      /** @type {FeedbackIndicator} */
-      let feedback
-
-      beforeEach(() => {
-        manager.init({ scene })
-        indicators = [
-          { id: 'box1', size: 10 },
-          { id: 'box2', size: 5 }
-        ].map(({ id, ...props }) => {
-          const mesh = createBox(id, {})
-          const indicator = { id, mesh, ...props }
-          return manager.registerMeshIndicator(indicator)
-        })
-        pointers = JSON.parse(
-          JSON.stringify(
-            playerIds.map((playerId, rank) =>
-              manager.registerPointerIndicator(playerId, [
-                -10 + rank,
-                0,
-                -5 + rank
-              ])
-            )
-          )
-        )
-        feedback = {
-          position: indicators[0].mesh.absolutePosition.asArray(),
-          action: 'snap'
-        }
-        manager.registerFeedback(feedback)
-        changeReceived.mockReset()
-      })
-
-      it('adds screen positions', async () => {
+      it('forgets controlled indicators', async () => {
         const [indicator1, indicator2] = indicators
-        indicator2.mesh.setAbsolutePosition(new Vector3(10, 0, 10))
-        await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
-        expect(indicator2.screenPosition?.x).toBeCloseTo(1248.18)
-        expect(indicator2.screenPosition?.y).toBeCloseTo(294.53)
-        expectChanged([...indicators, ...pointers])
-      })
-
-      it('refreshes screen positions on render', async () => {
-        const [indicator1] = indicators
-        await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
-        expect(changeReceived).not.toHaveBeenCalled()
-
-        indicator1.mesh.setAbsolutePosition(new Vector3(1, 0, 1))
-        await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(1047.94)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(478.82)
-        expectChanged([...indicators, ...pointers])
-      })
-
-      it(`omits indicator outside of camera's frustum`, async () => {
-        const [indicator1, indicator2] = indicators
-        await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(1024)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(500.85)
-        expect(changeReceived).not.toHaveBeenCalled()
-
-        indicator1.mesh.setAbsolutePosition(new Vector3(200, 0, 200))
-        await waitNextRender(scene)
-        expect(indicator1.screenPosition?.x).toBeCloseTo(2935.17)
-        expect(indicator1.screenPosition?.y).toBeCloseTo(-1258.1)
+        manager.unregisterIndicator(indicator1)
+        expect(manager.isManaging(indicator1)).toBe(false)
+        expect(manager.getById(indicator1.id)).not.toBeDefined()
         expectChanged([indicator2, ...pointers])
+
+        indicator1.mesh.setAbsolutePosition(new Vector3(10, 0, 10))
+        await waitNextRender(scene)
+        expect(changeReceived).not.toHaveBeenCalled()
       })
 
-      describe('registerMeshIndicator()', () => {
-        it('updates existing indicators', async () => {
-          const [indicator1, indicator2] = indicators
-          await waitNextRender(scene)
-          expect(changeReceived).not.toHaveBeenCalled()
-          expect(manager.getById(indicator1.id)).not.toHaveProperty('custom')
-
-          const size = 18
-          manager.registerMeshIndicator({ ...indicator1, size })
-          expect(manager.getById(indicator1.id)).toHaveProperty('size', size)
-          expectChanged([{ ...indicator1, size }, indicator2, ...pointers])
-        })
-      })
-
-      describe('registerPointerIndicator()', () => {
-        it('updates existing pointer', () => {
-          const position = [10, 0, 3]
-          const [pointer1, pointer2] = pointers
-          expect(manager.isManaging(pointer2)).toBe(true)
-          const pointer = manager.registerPointerIndicator(
-            pointer2.playerId,
-            position
-          )
-          expect(pointer.id).toEqual(pointer2.id)
-          expect(pointer.position).toEqual(position)
-          expect(pointer.screenPosition?.x).toBeCloseTo(1260.76)
-          expect(pointer.screenPosition?.y).toBeCloseTo(446.38)
-          expect(manager.isManaging(pointer)).toBe(true)
-          expect(manager.getById(pointer.id)).toEqual(pointer)
-          expectChanged([...indicators, pointer1, pointer])
-        })
-
-        it('does not updates with the same position', () => {
-          const [pointer] = pointers
-          const indicator = manager.registerPointerIndicator(
-            pointer.playerId,
-            pointer.position
-          )
-          expect(indicator).toEqual(pointer)
-          expect(changeReceived).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('unregisterIndicator()', () => {
-        it('forgets controlled indicators', async () => {
-          const [indicator1, indicator2] = indicators
-          manager.unregisterIndicator(indicator1)
-          expect(manager.isManaging(indicator1)).toBe(false)
-          expect(manager.getById(indicator1.id)).not.toBeDefined()
-          expectChanged([indicator2, ...pointers])
-
-          indicator1.mesh.setAbsolutePosition(new Vector3(10, 0, 10))
-          await waitNextRender(scene)
-          expect(changeReceived).not.toHaveBeenCalled()
-        })
-
-        it('forgets controlled pointers', async () => {
-          const [pointer1, pointer2] = pointers
-          manager.unregisterIndicator(pointer1)
-          expect(manager.isManaging(pointer1)).toBe(false)
-          expect(manager.getById(pointer1.id)).not.toBeDefined()
-          expectChanged([...indicators, pointer2])
-          await waitNextRender(scene)
-          expect(changeReceived).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('pruneUnusedPointers()', () => {
-        it('removes unused pointer', () => {
-          const [pointer1, pointer2] = pointers
-          expect(manager.isManaging(pointer1)).toBe(true)
-          expect(manager.isManaging(pointer2)).toBe(true)
-          manager.pruneUnusedPointers(playerIds.slice(1))
-          expect(manager.isManaging(pointer1)).toBe(false)
-          expect(manager.isManaging(pointer2)).toBe(true)
-          expectChanged([...indicators, pointer2])
-        })
-
-        it('ignores unmanaged playerId', () => {
-          const [pointer1, pointer2] = pointers
-          expect(manager.isManaging(pointer1)).toBe(true)
-          expect(manager.isManaging(pointer2)).toBe(true)
-          manager.pruneUnusedPointers([faker.string.uuid(), ...playerIds])
-          expect(manager.isManaging(pointer1)).toBe(true)
-          expect(manager.isManaging(pointer2)).toBe(true)
-          expect(changeReceived).not.toHaveBeenCalled()
-        })
+      it('forgets controlled pointers', async () => {
+        const [pointer1, pointer2] = pointers
+        manager.unregisterIndicator(pointer1)
+        expect(manager.isManaging(pointer1)).toBe(false)
+        expect(manager.getById(pointer1.id)).not.toBeDefined()
+        expectChanged([...indicators, pointer2])
+        await waitNextRender(scene)
+        expect(changeReceived).not.toHaveBeenCalled()
       })
     })
 
-    function expectChanged(
-      /** @type {(Partial<ManagedIndicator>|Partial<ManagedPointer>|Partial<ManagedFeedback>)[]} */ indicators = []
-    ) {
-      expect(changeReceived).toHaveBeenCalledTimes(1)
-      const changed = changeReceived.mock.calls[0][0]
-      expect(changed).toHaveLength(indicators.length)
-      for (const [
-        rank,
-        // do not compare mesh because vi fail to serialize them
-        // @ts-expect-error
-        // eslint-disable-next-line no-unused-vars
-        { mesh, screenPosition, ...expected }
-      ] of indicators.entries()) {
-        // do not compare mesh because vi fail to serialize them
-        // eslint-disable-next-line no-unused-vars
-        const { mesh, ...actual } = changed[rank]
-        expect(actual).toMatchObject(expected)
-        expectScreenPosition(
-          changed[rank].screenPosition,
-          screenPosition ?? { x: 0, y: 0 },
-          `indicator #${rank}`
-        )
-      }
-      changeReceived.mockReset()
-    }
+    describe('pruneUnusedPointers()', () => {
+      it('removes unused pointer', () => {
+        const [pointer1, pointer2] = pointers
+        expect(manager.isManaging(pointer1)).toBe(true)
+        expect(manager.isManaging(pointer2)).toBe(true)
+        manager.pruneUnusedPointers(playerIds.slice(1))
+        expect(manager.isManaging(pointer1)).toBe(false)
+        expect(manager.isManaging(pointer2)).toBe(true)
+        expectChanged([...indicators, pointer2])
+      })
+
+      it('ignores unmanaged playerId', () => {
+        const [pointer1, pointer2] = pointers
+        expect(manager.isManaging(pointer1)).toBe(true)
+        expect(manager.isManaging(pointer2)).toBe(true)
+        manager.pruneUnusedPointers([faker.string.uuid(), ...playerIds])
+        expect(manager.isManaging(pointer1)).toBe(true)
+        expect(manager.isManaging(pointer2)).toBe(true)
+        expect(changeReceived).not.toHaveBeenCalled()
+      })
+    })
   })
+
+  function expectChanged(
+    /** @type {(Partial<ManagedIndicator>|Partial<ManagedPointer>|Partial<ManagedFeedback>)[]} */ indicators = []
+  ) {
+    expect(changeReceived).toHaveBeenCalledTimes(1)
+    const changed = changeReceived.mock.calls[0][0]
+    expect(changed).toHaveLength(indicators.length)
+    for (const [
+      rank,
+      // do not compare mesh because vi fail to serialize them
+      // @ts-expect-error
+      // eslint-disable-next-line no-unused-vars
+      { mesh, screenPosition, ...expected }
+    ] of indicators.entries()) {
+      // do not compare mesh because vi fail to serialize them
+      // eslint-disable-next-line no-unused-vars
+      const { mesh, ...actual } = changed[rank]
+      expect(actual).toMatchObject(expected)
+      expectScreenPosition(
+        changed[rank].screenPosition,
+        screenPosition ?? { x: 0, y: 0 },
+        `indicator #${rank}`
+      )
+    }
+    changeReceived.mockReset()
+  }
 })

--- a/apps/web/tests/3d/managers/indicator.test.js
+++ b/apps/web/tests/3d/managers/indicator.test.js
@@ -29,11 +29,14 @@ describe('IndicatorManager', () => {
   /** @type {Mesh} */
   let mesh
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    managers = created.managers
-    managers.indicator.onChangeObservable.add(changeReceived)
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      managers = created.managers
+      managers.indicator.onChangeObservable.add(changeReceived)
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/tests/3d/managers/input.test.js
+++ b/apps/web/tests/3d/managers/input.test.js
@@ -1739,6 +1739,29 @@ describe('managers.Input', () => {
       )
     })
 
+    it('stops all operations on pointer leave', () => {
+      const pointer = { x: 975, y: 535 }
+      const pointerId = 50
+      const startEvent = triggerEvent(pointerMove, {
+        ...move(pointer, 50, -25),
+        pointerId
+      })
+      const event = triggerEvent('pointerleave')
+
+      expectEvents({ hovers: 2 })
+      const meshId = meshes[1].id
+      expectsDataWithMesh(
+        hovers[0],
+        { type: 'hoverStart', event: startEvent },
+        meshId
+      )
+      expectsDataWithMesh(
+        hovers[1],
+        { type: 'hoverStop', event: { ...event, pointerId } },
+        meshId
+      )
+    })
+
     it('updates hovered on camera move', () => {
       const event = triggerEvent(pointerMove, {
         x: 1000,

--- a/apps/web/tests/3d/managers/move.test.js
+++ b/apps/web/tests/3d/managers/move.test.js
@@ -76,13 +76,16 @@ describe('managers.Move', () => {
   /** @type {string} */
   let playerId
 
-  configures3dTestEngine(created => {
-    ;({ scene, handScene, camera, managers, playerId } = created)
-    managers.hand.enabled = true
-    actionObserver = managers.control.onActionObservable.add(actionRecorded)
-    moveObserver = managers.move.onMoveObservable.add(moveRecorded)
-    preMoveObserver = managers.move.onPreMoveObservable.add(preMoveRecorded)
-  })
+  configures3dTestEngine(
+    created => {
+      ;({ scene, handScene, camera, managers, playerId } = created)
+      managers.hand.enabled = true
+      actionObserver = managers.control.onActionObservable.add(actionRecorded)
+      moveObserver = managers.move.onMoveObservable.add(moveRecorded)
+      preMoveObserver = managers.move.onPreMoveObservable.add(preMoveRecorded)
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/tests/3d/managers/replay.test.js
+++ b/apps/web/tests/3d/managers/replay.test.js
@@ -7,10 +7,6 @@
  * @typedef {import('@tabulous/server/src/graphql').HistoryRecord} HistoryRecord
  * @typedef {import('@tabulous/server/src/graphql').Mesh} SerializedMesh
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { createCard } from '@src/3d/meshes'

--- a/apps/web/tests/3d/managers/replay.test.js
+++ b/apps/web/tests/3d/managers/replay.test.js
@@ -13,18 +13,13 @@
  */
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
-import {
-  controlManager,
-  handManager,
-  replayManager as manager
-} from '@src/3d/managers'
 import { createCard } from '@src/3d/meshes'
 import { animateMove } from '@src/3d/utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { configures3dTestEngine } from '../../test-utils'
 
-describe('ControlManager', () => {
+describe('managers.Control', () => {
   /** @type {Engine} */
   let engine
   /** @type {Scene} */
@@ -36,55 +31,50 @@ describe('ControlManager', () => {
   /** @type {HistoryRecord[]} */
   let history
   let rank = 0
-  const playerId = 'player1'
-  const handOverlay = document.createElement('div')
-  const renderWidth = 480
-  const renderHeight = 350
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+  /** @type {string} */
+  let playerId
 
-  configures3dTestEngine(
-    created => {
-      ;({ engine, scene } = created)
-      engine.serialize = vi.fn()
-      manager.onHistoryObservable.add(data => (history = data))
-      manager.onReplayRankObservable.add(value => (rank = value))
-      handManager.init({ ...created, playerId, overlay: handOverlay })
-      manager.init({
-        engine,
-        history: [],
-        playerId
-      })
-      expect(rank).toBe(0)
-      expect(history).toEqual([])
-    },
-    { renderWidth, renderHeight }
-  )
+  configures3dTestEngine(created => {
+    ;({ engine, scene, managers, playerId } = created)
+    engine.serialize = vi.fn()
+    managers.replay.onHistoryObservable.add(data => (history = data))
+    managers.replay.onReplayRankObservable.add(value => (rank = value))
+    managers.replay.init({ managers, history: [], playerId })
+    managers.hand.enabled = true
+    expect(rank).toBe(0)
+    expect(history).toEqual([])
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()
-    manager.reset()
+    managers.replay.reset()
     mesh = createCard(
       { id: 'box1', texture: '', flippable: {}, rotable: {}, drawable: {} },
+      managers,
       scene
     )
     mesh2 = createCard(
       { id: 'box2', texture: '', flippable: {}, rotable: {}, drawable: {} },
+      managers,
       scene
     )
   })
 
   describe('given initialized with empty history', () => {
     it('is not replaying', () => {
-      expect(manager.isReplaying).toBe(false)
-      expect(manager.save).toBeNull()
+      expect(managers.replay.isReplaying).toBe(false)
+      expect(managers.replay.save).toBeNull()
       expect(rank).toBe(0)
       expect(history).toEqual([])
     })
 
     it('can not replay history', async () => {
-      await manager.replayHistory(0)
-      await manager.replayHistory(10)
-      expect(manager.isReplaying).toBe(false)
-      expect(manager.save).toBeNull()
+      await managers.replay.replayHistory(0)
+      await managers.replay.replayHistory(10)
+      expect(managers.replay.isReplaying).toBe(false)
+      expect(managers.replay.save).toBeNull()
       expect(rank).toBe(0)
       expect(history).toEqual([])
     })
@@ -94,7 +84,7 @@ describe('ControlManager', () => {
       let currentRank
 
       beforeEach(() => {
-        currentRank = manager.rank
+        currentRank = managers.replay.rank
       })
 
       it('records moves', () => {
@@ -103,14 +93,14 @@ describe('ControlManager', () => {
           pos: [0, 0, 0],
           prev: [1, 1, 1]
         }
-        manager.record({ ...move, fromHand: false }, playerId)
+        managers.replay.record({ ...move, fromHand: false }, playerId)
         expect(history[0]).toEqual({
           ...move,
           time: expect.any(Number),
           playerId
         })
         expect(rank).toBe(currentRank + 1)
-        expect(manager.rank).toBe(currentRank + 1)
+        expect(managers.replay.rank).toBe(currentRank + 1)
       })
 
       it('records action with no revert', () => {
@@ -120,7 +110,7 @@ describe('ControlManager', () => {
           fn: 'flip',
           args: []
         }
-        manager.record({ ...action, fromHand: false }, playerId)
+        managers.replay.record({ ...action, fromHand: false }, playerId)
         expect(history[0]).toEqual({
           ...action,
           args: undefined,
@@ -129,7 +119,7 @@ describe('ControlManager', () => {
           playerId
         })
         expect(rank).toBe(currentRank + 1)
-        expect(manager.rank).toBe(currentRank + 1)
+        expect(managers.replay.rank).toBe(currentRank + 1)
       })
 
       it('can record action with revert', () => {
@@ -140,7 +130,7 @@ describe('ControlManager', () => {
           args: [mesh2.id, false],
           revert: [1, false, [0, 1, 2], 0]
         }
-        manager.record({ ...action, fromHand: false }, playerId)
+        managers.replay.record({ ...action, fromHand: false }, playerId)
         expect(history[0]).toEqual({
           ...action,
           args: undefined,
@@ -151,7 +141,7 @@ describe('ControlManager', () => {
           playerId
         })
         expect(rank).toBe(currentRank + 1)
-        expect(manager.rank).toBe(currentRank + 1)
+        expect(managers.replay.rank).toBe(currentRank + 1)
       })
 
       it('automatically records action', async () => {
@@ -165,22 +155,22 @@ describe('ControlManager', () => {
           playerId
         })
         expect(rank).toBe(currentRank + 1)
-        expect(manager.rank).toBe(currentRank + 1)
+        expect(managers.replay.rank).toBe(currentRank + 1)
       })
 
       it('ignores local actions', async () => {
-        await controlManager.apply({ meshId: mesh.id, fn: 'flip', args: [] })
+        await managers.control.apply({ meshId: mesh.id, fn: 'flip', args: [] })
         expect(history).toHaveLength(0)
         expect(rank).toBe(currentRank)
-        expect(manager.rank).toBe(currentRank)
+        expect(managers.replay.rank).toBe(currentRank)
       })
 
       it('ignores actions from hand', async () => {
         const action = { meshId: mesh.id, pos: [0, 0, 0], prev: [0, 0, 0] }
-        manager.record({ ...action, fromHand: true }, playerId)
+        managers.replay.record({ ...action, fromHand: true }, playerId)
         expect(history).toHaveLength(0)
         expect(rank).toBe(currentRank)
-        expect(manager.rank).toBe(currentRank)
+        expect(managers.replay.rank).toBe(currentRank)
       })
 
       it('collapses moves together', () => {
@@ -204,8 +194,8 @@ describe('ControlManager', () => {
           prev: [-2, 0.5, -2]
         }
 
-        manager.record({ ...move1_1, fromHand: false }, playerId)
-        manager.record({ ...move2_1, fromHand: false }, playerId2)
+        managers.replay.record({ ...move1_1, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_1, fromHand: false }, playerId2)
         expect(history).toEqual([
           {
             ...move1_1,
@@ -219,13 +209,13 @@ describe('ControlManager', () => {
           }
         ])
 
-        manager.record({ ...move1_2, fromHand: false }, playerId) // collapse with 1_1
+        managers.replay.record({ ...move1_2, fromHand: false }, playerId) // collapse with 1_1
         expect(history).toEqual([
           { ...move2_1, time: expect.any(Number), playerId: playerId2 },
           { ...move1_2, prev: move1_1.prev, time: expect.any(Number), playerId }
         ])
 
-        manager.record({ ...move2_2, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_2, fromHand: false }, playerId)
         expect(history).toEqual([
           { ...move2_1, time: expect.any(Number), playerId: playerId2 },
           {
@@ -237,7 +227,7 @@ describe('ControlManager', () => {
           { ...move2_2, time: expect.any(Number), playerId }
         ])
 
-        manager.record({ ...move1_3, fromHand: false }, playerId2)
+        managers.replay.record({ ...move1_3, fromHand: false }, playerId2)
         expect(history).toEqual([
           { ...move2_1, time: expect.any(Number), playerId: playerId2 },
           {
@@ -250,7 +240,7 @@ describe('ControlManager', () => {
           { ...move1_3, time: expect.any(Number), playerId: playerId2 }
         ])
 
-        manager.record({ ...move2_3, fromHand: false }, playerId) // collapse with 2_2
+        managers.replay.record({ ...move2_3, fromHand: false }, playerId) // collapse with 2_2
         expect(history).toEqual([
           { ...move2_1, time: expect.any(Number), playerId: playerId2 },
           {
@@ -283,12 +273,12 @@ describe('ControlManager', () => {
           prev: [-1, 0.5, -1]
         }
 
-        manager.record({ ...move1_1, fromHand: false }, playerId)
-        manager.record({ ...move2_1, fromHand: false }, playerId2)
-        manager.record({ ...draw2, fromHand: false }, playerId2)
-        manager.record({ ...draw1, fromHand: false }, playerId)
-        manager.record({ ...move1_2, fromHand: false }, playerId)
-        manager.record({ ...move2_2, fromHand: false }, playerId2)
+        managers.replay.record({ ...move1_1, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_1, fromHand: false }, playerId2)
+        managers.replay.record({ ...draw2, fromHand: false }, playerId2)
+        managers.replay.record({ ...draw1, fromHand: false }, playerId)
+        managers.replay.record({ ...move1_2, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_2, fromHand: false }, playerId2)
         expect(history).toEqual([
           { ...move1_1, time: expect.any(Number), playerId },
           { ...move2_1, time: expect.any(Number), playerId: playerId2 },
@@ -328,12 +318,12 @@ describe('ControlManager', () => {
           prev: [-1, 0.5, -1]
         }
 
-        manager.record({ ...move1_1, fromHand: false }, playerId)
-        manager.record({ ...move2_1, fromHand: false }, playerId2)
-        manager.record({ ...play2, fromHand: false }, playerId2)
-        manager.record({ ...play1, fromHand: false }, playerId)
-        manager.record({ ...move1_2, fromHand: false }, playerId)
-        manager.record({ ...move2_2, fromHand: false }, playerId2)
+        managers.replay.record({ ...move1_1, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_1, fromHand: false }, playerId2)
+        managers.replay.record({ ...play2, fromHand: false }, playerId2)
+        managers.replay.record({ ...play1, fromHand: false }, playerId)
+        managers.replay.record({ ...move1_2, fromHand: false }, playerId)
+        managers.replay.record({ ...move2_2, fromHand: false }, playerId2)
         expect(history).toEqual([
           {
             ...play2,
@@ -388,7 +378,7 @@ describe('ControlManager', () => {
         addState()
         let prev = mesh.absolutePosition.asArray()
         await animateMove(mesh, Vector3.FromArray([1, 0, 2]), null)
-        controlManager.record({
+        managers.control.record({
           mesh,
           pos: mesh.absolutePosition.asArray(),
           prev
@@ -398,7 +388,7 @@ describe('ControlManager', () => {
         addState('flipped1')
         prev = mesh.absolutePosition.asArray()
         await animateMove(mesh, Vector3.FromArray([-2, 0, 2]), null)
-        controlManager.record({
+        managers.control.record({
           mesh,
           pos: mesh.absolutePosition.asArray(),
           prev
@@ -411,50 +401,53 @@ describe('ControlManager', () => {
       })
 
       it('can replay backwards', async () => {
-        await manager.replayHistory(2)
+        await managers.replay.replayHistory(2)
         expect(rank).toBe(2)
         expect(getStates(true)).toEqual(states.get('flipped1'))
-        await manager.replayHistory(0)
+        await managers.replay.replayHistory(0)
         expect(rank).toBe(0)
         expect(getStates(true)).toEqual(states.get('initial'))
       })
 
       it('can not replay less than 0', async () => {
-        await manager.replayHistory(1)
+        await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
         expect(getStates(true)).toEqual(states.get('moved1'))
-        await manager.replayHistory(-1)
+        await managers.replay.replayHistory(-1)
         expect(rank).toBe(1)
         expect(getStates(true)).toEqual(states.get('moved1'))
       })
 
       it('can replay forwards', async () => {
-        await manager.replayHistory(1)
+        await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
         expect(getStates(true)).toEqual(states.get('moved1'))
-        await manager.replayHistory(2)
+        await managers.replay.replayHistory(2)
         expect(rank).toBe(3)
         expect(getStates(true)).toEqual(states.get('moved2'))
-        await manager.replayHistory(3)
+        await managers.replay.replayHistory(3)
         expect(rank).toBe(4)
         expect(getStates(true)).toEqual(states.get('rotated1'))
       })
 
       it('can not replay more than history length', async () => {
-        await manager.replayHistory(10)
+        await managers.replay.replayHistory(10)
         expect(rank).toBe(history.length)
         expect(getStates(true)).toEqual(states.get('drawn2'))
       })
 
       it('can not replay concurrently', async () => {
-        await Promise.all([manager.replayHistory(1), manager.replayHistory(2)])
+        await Promise.all([
+          managers.replay.replayHistory(1),
+          managers.replay.replayHistory(2)
+        ])
         expect(rank).toBe(1)
         expect(getStates(true)).toEqual(states.get('moved1'))
       })
 
       it('does not update rank when recording action', async () => {
         const length = history.length
-        await manager.replayHistory(1)
+        await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
         expect(getStates(true)).toEqual(states.get('moved1'))
         await mesh.metadata.rotate?.()

--- a/apps/web/tests/3d/managers/replay.test.js
+++ b/apps/web/tests/3d/managers/replay.test.js
@@ -36,16 +36,19 @@ describe('managers.Control', () => {
   /** @type {string} */
   let playerId
 
-  configures3dTestEngine(created => {
-    ;({ engine, scene, managers, playerId } = created)
-    engine.serialize = vi.fn()
-    managers.replay.onHistoryObservable.add(data => (history = data))
-    managers.replay.onReplayRankObservable.add(value => (rank = value))
-    managers.replay.init({ managers, history: [], playerId })
-    managers.hand.enabled = true
-    expect(rank).toBe(0)
-    expect(history).toEqual([])
-  })
+  configures3dTestEngine(
+    created => {
+      ;({ engine, scene, managers, playerId } = created)
+      engine.serialize = vi.fn()
+      managers.replay.onHistoryObservable.add(data => (history = data))
+      managers.replay.onReplayRankObservable.add(value => (rank = value))
+      managers.replay.init({ managers, history: [], playerId })
+      managers.hand.enabled = true
+      expect(rank).toBe(0)
+      expect(history).toEqual([])
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -421,7 +424,7 @@ describe('managers.Control', () => {
       }
 
       function addState(name = 'initial') {
-        states.set(name, getStates())
+        states.set(name, getStates(true))
       }
 
       beforeEach(async () => {
@@ -458,37 +461,37 @@ describe('managers.Control', () => {
       it('can replay backwards', async () => {
         await managers.replay.replayHistory(2)
         expect(rank).toBe(2)
-        expect(getStates(true)).toEqual(states.get('flipped1'))
+        expect(getStates()).toEqual(states.get('flipped1'))
         await managers.replay.replayHistory(0)
         expect(rank).toBe(0)
-        expect(getStates(true)).toEqual(states.get('initial'))
+        expect(getStates()).toEqual(states.get('initial'))
       })
 
       it('can not replay less than 0', async () => {
         await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
-        expect(getStates(true)).toEqual(states.get('moved1'))
+        expect(getStates()).toEqual(states.get('moved1'))
         await managers.replay.replayHistory(-1)
         expect(rank).toBe(1)
-        expect(getStates(true)).toEqual(states.get('moved1'))
+        expect(getStates()).toEqual(states.get('moved1'))
       })
 
       it('can replay forwards', async () => {
         await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
-        expect(getStates(true)).toEqual(states.get('moved1'))
+        expect(getStates()).toEqual(states.get('moved1'))
         await managers.replay.replayHistory(2)
         expect(rank).toBe(3)
-        expect(getStates(true)).toEqual(states.get('moved2'))
+        expect(getStates()).toEqual(states.get('moved2'))
         await managers.replay.replayHistory(3)
         expect(rank).toBe(4)
-        expect(getStates(true)).toEqual(states.get('rotated1'))
+        expect(getStates()).toEqual(states.get('rotated1'))
       })
 
       it('can not replay more than history length', async () => {
         await managers.replay.replayHistory(10)
         expect(rank).toBe(history.length)
-        expect(getStates(true)).toEqual(states.get('flipped2'))
+        expect(getStates()).toEqual(states.get('flipped2'))
       })
 
       it('can not replay concurrently', async () => {
@@ -497,14 +500,14 @@ describe('managers.Control', () => {
           managers.replay.replayHistory(2)
         ])
         expect(rank).toBe(1)
-        expect(getStates(true)).toEqual(states.get('moved1'))
+        expect(getStates()).toEqual(states.get('moved1'))
       })
 
       it('does not update rank when recording action', async () => {
         const length = history.length
         await managers.replay.replayHistory(1)
         expect(rank).toBe(1)
-        expect(getStates(true)).toEqual(states.get('moved1'))
+        expect(getStates()).toEqual(states.get('moved1'))
         await mesh.metadata.rotate?.()
         expect(rank).toBe(1)
         expect(history[length]).toEqual(

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -7,7 +7,6 @@
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import { AnchorBehavior } from '@src/3d/behaviors'
-import { handManager, selectionManager as manager } from '@src/3d/managers'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -16,11 +15,13 @@ import {
   expectMeshIds
 } from '../../test-utils'
 
-describe('SelectionManager', () => {
+describe('managers.Selection', () => {
   /** @type {Scene} */
   let scene
   /** @type {Scene} */
   let handScene
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
   const selectionChanged = vi.fn()
   const playerId = 'player'
   const peer1 = {
@@ -35,47 +36,30 @@ describe('SelectionManager', () => {
   configures3dTestEngine(created => {
     scene = created.scene
     handScene = created.handScene
-  })
-
-  beforeAll(() => {
-    manager.onSelectionObservable.add(selectionChanged)
+    managers = created.managers
+    managers.selection.onSelectionObservable.add(selectionChanged)
+    managers.hand.enabled = true
   })
 
   beforeEach(() => {
-    manager.clear()
-    vi.resetAllMocks()
+    managers.selection.clear()
+    vi.clearAllMocks()
   })
 
   it('has initial state', () => {
-    expect(manager.meshes.size).toEqual(0)
+    expect(managers.selection.meshes.size).toEqual(0)
     expect(selectionChanged).not.toHaveBeenCalled()
   })
 
-  describe('drawSelectionBox()', () => {
-    it('does nothing without init', () => {
-      // @ts-expect-error: it's ok to invoke with no arguments
-      manager.drawSelectionBox()
-      expect(selectionChanged).not.toHaveBeenCalled()
-    })
-  })
-
   describe('init()', () => {
-    it('assigns scenes', () => {
-      manager.init({ scene, handScene })
-      expect(manager.scene).toEqual(scene)
-      expect(manager.handScene).toEqual(handScene)
-    })
-  })
-
-  describe('updateColors()', () => {
     it('assigns overlay and main colors', () => {
       const color = faker.color.rgb().toUpperCase()
       const colorByPlayerId = new Map([
         [playerId, color],
         [peer1.id, peer1.color]
       ])
-      manager.updateColors(playerId, colorByPlayerId)
-      expect(manager.color?.toHexString()).toEqual(`${color}FF`)
+      managers.selection.init({ managers, playerId, colorByPlayerId })
+      expect(managers.selection.color?.toHexString()).toEqual(`${color}FF`)
     })
   })
 
@@ -87,13 +71,12 @@ describe('SelectionManager', () => {
     ])
 
     beforeAll(() => {
-      manager.init({ scene, handScene })
-      manager.updateColors(playerId, colorByPlayerId)
+      managers.selection.init({ managers, playerId, colorByPlayerId })
     })
 
     describe('selectWithinBox()', () => {
       it('does nothing without init', () => {
-        manager.selectWithinBox()
+        managers.selection.selectWithinBox()
         expect(selectionChanged).not.toHaveBeenCalled()
       })
     })
@@ -101,9 +84,9 @@ describe('SelectionManager', () => {
     describe('select()', () => {
       it('adds meshes to selection', () => {
         const mesh = createBox('box1', {})
-        manager.select(mesh)
-        expect(manager.meshes.has(mesh)).toBe(true)
-        expect(manager.meshes.size).toBe(1)
+        managers.selection.select(mesh)
+        expect(managers.selection.meshes.has(mesh)).toBe(true)
+        expect(managers.selection.meshes.size).toBe(1)
         expectSelected(mesh, colorByPlayerId.get(playerId))
         expect(selectionChanged).toHaveBeenCalledOnce()
         expect(selectionChanged.mock.calls[0][0].has(mesh)).toBe(true)
@@ -113,10 +96,10 @@ describe('SelectionManager', () => {
       it('adds multiple meshes to selection', () => {
         const mesh1 = createBox('box1', {})
         const mesh2 = createBox('box2', {})
-        manager.select([mesh1, mesh2])
-        expect(manager.meshes.has(mesh1)).toBe(true)
-        expect(manager.meshes.has(mesh2)).toBe(true)
-        expect(manager.meshes.size).toBe(2)
+        managers.selection.select([mesh1, mesh2])
+        expect(managers.selection.meshes.has(mesh1)).toBe(true)
+        expect(managers.selection.meshes.has(mesh2)).toBe(true)
+        expect(managers.selection.meshes.size).toBe(2)
         expectSelected(mesh1, colorByPlayerId.get(playerId))
         expectSelected(mesh2, colorByPlayerId.get(playerId))
         expect(selectionChanged).toHaveBeenCalledOnce()
@@ -128,28 +111,34 @@ describe('SelectionManager', () => {
         const box3 = createBox('box3', {})
         const box4 = createBox('box4', {})
         box1.addBehavior(
-          new AnchorBehavior({
-            anchors: [
-              { id: '1', snappedId: box2.id },
-              { id: '2', snappedId: null },
-              { id: '3', snappedId: box3.id }
-            ]
-          })
+          new AnchorBehavior(
+            {
+              anchors: [
+                { id: '1', snappedId: box2.id },
+                { id: '2', snappedId: null },
+                { id: '3', snappedId: box3.id }
+              ]
+            },
+            managers
+          )
         )
         box3.addBehavior(
-          new AnchorBehavior({
-            anchors: [
-              { id: '6', snappedId: box4.id },
-              { id: '5', snappedId: null }
-            ]
-          })
+          new AnchorBehavior(
+            {
+              anchors: [
+                { id: '6', snappedId: box4.id },
+                { id: '5', snappedId: null }
+              ]
+            },
+            managers
+          )
         )
-        manager.select(box1)
-        expect(manager.meshes.has(box1)).toBe(true)
-        expect(manager.meshes.has(box2)).toBe(true)
-        expect(manager.meshes.has(box3)).toBe(true)
-        expect(manager.meshes.has(box4)).toBe(true)
-        expect(manager.meshes.size).toBe(4)
+        managers.selection.select(box1)
+        expect(managers.selection.meshes.has(box1)).toBe(true)
+        expect(managers.selection.meshes.has(box2)).toBe(true)
+        expect(managers.selection.meshes.has(box3)).toBe(true)
+        expect(managers.selection.meshes.has(box4)).toBe(true)
+        expect(managers.selection.meshes.size).toBe(4)
         expectSelected(box1, colorByPlayerId.get(playerId))
         expectSelected(box2, colorByPlayerId.get(playerId))
         expectSelected(box3, colorByPlayerId.get(playerId))
@@ -160,22 +149,22 @@ describe('SelectionManager', () => {
       it('reorders selection based on elevation', () => {
         const mesh1 = createBox('box1', {})
         mesh1.setAbsolutePosition(new Vector3(0, 5, 0))
-        manager.select(mesh1)
+        managers.selection.select(mesh1)
         expectSelection([mesh1], colorByPlayerId.get(playerId))
 
         const mesh2 = createBox('box2', {})
         mesh2.setAbsolutePosition(new Vector3(0, -2, 0))
-        manager.select(mesh2)
+        managers.selection.select(mesh2)
         expectSelection([mesh2, mesh1], colorByPlayerId.get(playerId))
 
         const mesh3 = createBox('box3', {})
         mesh3.setAbsolutePosition(new Vector3(0, 7, 0))
-        manager.select(mesh3)
+        managers.selection.select(mesh3)
         expectSelection([mesh2, mesh1, mesh3], colorByPlayerId.get(playerId))
 
         const mesh4 = createBox('box4', {})
         mesh4.setAbsolutePosition(new Vector3(0, 2, 0))
-        manager.select(mesh4)
+        managers.selection.select(mesh4)
         expectSelection(
           [mesh2, mesh4, mesh1, mesh3],
           colorByPlayerId.get(playerId)
@@ -195,10 +184,10 @@ describe('SelectionManager', () => {
           serialize: () => ({ id: mesh.id, shape: 'box', texture: '' }),
           isLocked: true
         }
-        manager.select(mesh)
-        expect(manager.meshes.has(mesh)).toBe(false)
-        expect(manager.meshes.size).toBe(0)
-        expect(manager.meshes.size).toBe(0)
+        managers.selection.select(mesh)
+        expect(managers.selection.meshes.has(mesh)).toBe(false)
+        expect(managers.selection.meshes.size).toBe(0)
+        expect(managers.selection.meshes.size).toBe(0)
         expectSelected(mesh, null, false)
         expect(selectionChanged).not.toHaveBeenCalled()
       })
@@ -218,7 +207,7 @@ describe('SelectionManager', () => {
 
       it('does nothing without player', () => {
         // @ts-expect-error: we have not provided playerId
-        manager.apply([meshes[0].id, meshes[1].id])
+        managers.selection.apply([meshes[0].id, meshes[1].id])
         expectSelected(meshes[0], null, false)
         expectSelected(meshes[1], null, false)
         expectSelection([], null)
@@ -226,7 +215,7 @@ describe('SelectionManager', () => {
       })
 
       it('adds meshes to a peer selection', () => {
-        manager.apply([meshes[0].id, meshes[1].id], peer1.id)
+        managers.selection.apply([meshes[0].id, meshes[1].id], peer1.id)
         expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
         expectSelected(meshes[1], colorByPlayerId.get(peer1.id))
         expectSelection([], null)
@@ -238,8 +227,8 @@ describe('SelectionManager', () => {
     describe('unselect()', () => {
       it('ignores unselected meshes', () => {
         const mesh = createBox('box1', {})
-        manager.unselect([mesh])
-        expect(manager.meshes.size).toBe(0)
+        managers.selection.unselect([mesh])
+        expect(managers.selection.meshes.size).toBe(0)
         expectSelected(mesh, null, false)
         expect(selectionChanged).not.toHaveBeenCalled()
       })
@@ -250,31 +239,37 @@ describe('SelectionManager', () => {
         const box3 = createBox('box3', {})
         const box4 = createBox('box4', {})
         box1.addBehavior(
-          new AnchorBehavior({
-            anchors: [
-              { id: '1', snappedId: box2.id },
-              { id: '2', snappedId: null },
-              { id: '3', snappedId: box3.id }
-            ]
-          })
+          new AnchorBehavior(
+            {
+              anchors: [
+                { id: '1', snappedId: box2.id },
+                { id: '2', snappedId: null },
+                { id: '3', snappedId: box3.id }
+              ]
+            },
+            managers
+          )
         )
         box3.addBehavior(
-          new AnchorBehavior({
-            anchors: [
-              { id: 'a', snappedId: box4.id },
-              { id: 'b', snappedId: null }
-            ]
-          })
+          new AnchorBehavior(
+            {
+              anchors: [
+                { id: 'a', snappedId: box4.id },
+                { id: 'b', snappedId: null }
+              ]
+            },
+            managers
+          )
         )
-        manager.select(box1)
-        expect(manager.meshes.size).toBe(4)
+        managers.selection.select(box1)
+        expect(managers.selection.meshes.size).toBe(4)
 
-        manager.unselect(box3)
-        expect(manager.meshes.size).toBe(2)
-        expect(manager.meshes.has(box1)).toBe(true)
-        expect(manager.meshes.has(box2)).toBe(true)
-        expect(manager.meshes.has(box3)).toBe(false)
-        expect(manager.meshes.has(box4)).toBe(false)
+        managers.selection.unselect(box3)
+        expect(managers.selection.meshes.size).toBe(2)
+        expect(managers.selection.meshes.has(box1)).toBe(true)
+        expect(managers.selection.meshes.has(box2)).toBe(true)
+        expect(managers.selection.meshes.has(box3)).toBe(false)
+        expect(managers.selection.meshes.has(box4)).toBe(false)
         expectSelected(box1, colorByPlayerId.get(playerId))
         expectSelected(box2, colorByPlayerId.get(playerId))
         expectSelected(box3, null, false)
@@ -290,7 +285,7 @@ describe('SelectionManager', () => {
 
       beforeEach(() => {
         meshes = ['box1', 'box2', 'box3'].map(id => createBox(id, {}))
-        manager.select(meshes)
+        managers.selection.select(meshes)
         selectionChanged.mockReset()
       })
 
@@ -298,7 +293,7 @@ describe('SelectionManager', () => {
         const [mesh1, mesh2, mesh3] = meshes
         mesh1.dispose()
         mesh2.dispose()
-        expect(manager.meshes.size).toBe(1)
+        expect(managers.selection.meshes.size).toBe(1)
         expectSelected(mesh1, colorByPlayerId.get(playerId), false)
         expectSelected(mesh2, colorByPlayerId.get(playerId), false)
         expectSelected(mesh3, colorByPlayerId.get(playerId), true)
@@ -307,22 +302,22 @@ describe('SelectionManager', () => {
 
       describe('isSelectedByPeer()', () => {
         it('returns false for meshes of the active selection', () => {
-          expect(manager.isSelectedByPeer(meshes[0])).toBe(false)
-          expect(manager.isSelectedByPeer(meshes[1])).toBe(false)
-          expect(manager.isSelectedByPeer(meshes[2])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[0])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[1])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[2])).toBe(false)
         })
 
         it('returns false for unselected meshes', () => {
-          expect(manager.isSelectedByPeer(meshes[3])).toBe(false)
-          expect(manager.isSelectedByPeer(meshes[4])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[3])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[4])).toBe(false)
         })
       })
 
       describe('select()', () => {
         it('does not add the same mesh twice', () => {
-          manager.select(meshes[0])
-          expect(manager.meshes.has(meshes[0])).toBe(true)
-          expect(manager.meshes.size).toBe(3)
+          managers.selection.select(meshes[0])
+          expect(managers.selection.meshes.has(meshes[0])).toBe(true)
+          expect(managers.selection.meshes.size).toBe(3)
           expectSelected(meshes[0], colorByPlayerId.get(playerId))
           expect(selectionChanged).not.toHaveBeenCalled()
         })
@@ -330,24 +325,24 @@ describe('SelectionManager', () => {
 
       describe('getSelection()', () => {
         it('returns entire selection when it contains provided mesh', () => {
-          expectMeshIds(manager.getSelection(meshes[0]), meshes)
+          expectMeshIds(managers.selection.getSelection(meshes[0]), meshes)
         })
 
         it('returns provided mesh if it not selected', () => {
-          manager.clear()
-          manager.select([meshes[1], meshes[2]])
-          expectMeshIds(manager.getSelection(meshes[0]), [meshes[0]])
+          managers.selection.clear()
+          managers.selection.select([meshes[1], meshes[2]])
+          expectMeshIds(managers.selection.getSelection(meshes[0]), [meshes[0]])
         })
       })
 
       describe('unselect()', () => {
         it('removes selected meshes', () => {
           const [mesh1, mesh2, mesh3] = meshes
-          manager.unselect([mesh3, mesh1])
-          expect(manager.meshes.has(mesh1)).toBe(false)
-          expect(manager.meshes.has(mesh2)).toBe(true)
-          expect(manager.meshes.has(mesh3)).toBe(false)
-          expect(manager.meshes.size).toBe(1)
+          managers.selection.unselect([mesh3, mesh1])
+          expect(managers.selection.meshes.has(mesh1)).toBe(false)
+          expect(managers.selection.meshes.has(mesh2)).toBe(true)
+          expect(managers.selection.meshes.has(mesh3)).toBe(false)
+          expect(managers.selection.meshes.size).toBe(1)
           expectSelected(mesh1, colorByPlayerId.get(playerId), false)
           expectSelected(mesh2, colorByPlayerId.get(playerId))
           expectSelected(mesh3, colorByPlayerId.get(playerId), false)
@@ -358,8 +353,8 @@ describe('SelectionManager', () => {
 
       describe('clear()', () => {
         it('removes all meshes from selection', () => {
-          manager.clear()
-          expect(manager.meshes.size).toBe(0)
+          managers.selection.clear()
+          expect(managers.selection.meshes.size).toBe(0)
           expectSelected(meshes[0], null, false)
           expectSelected(meshes[1], null, false)
           expectSelected(meshes[2], null, false)
@@ -368,12 +363,12 @@ describe('SelectionManager', () => {
         })
 
         it('does not notify listener when clearing an empty selection', () => {
-          manager.clear()
-          expect(manager.meshes.size).toBe(0)
+          managers.selection.clear()
+          expect(managers.selection.meshes.size).toBe(0)
           selectionChanged.mockReset()
 
-          manager.clear()
-          expect(manager.meshes.size).toBe(0)
+          managers.selection.clear()
+          expect(managers.selection.meshes.size).toBe(0)
           expect(selectionChanged).not.toHaveBeenCalled()
         })
       })
@@ -387,15 +382,15 @@ describe('SelectionManager', () => {
         meshes = ['box1', 'box2', 'box3', 'box4', 'box5'].map(id =>
           createBox(id, {})
         )
-        manager.apply([meshes[0].id, meshes[1].id], peer1.id)
-        manager.select(meshes[2])
-        manager.apply([meshes[3].id], peer2.id)
+        managers.selection.apply([meshes[0].id, meshes[1].id], peer1.id)
+        managers.selection.select(meshes[2])
+        managers.selection.apply([meshes[3].id], peer2.id)
         selectionChanged.mockReset()
       })
 
       describe('apply()', () => {
         it('removes selected mesh', () => {
-          manager.apply([meshes[0].id], peer1.id)
+          managers.selection.apply([meshes[0].id], peer1.id)
           expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
           expectSelected(meshes[1], null, false)
           expectSelection([meshes[2]], colorByPlayerId.get(playerId))
@@ -403,7 +398,7 @@ describe('SelectionManager', () => {
         })
 
         it('ignores meshes selected by peers', () => {
-          manager.apply([meshes[0].id], peer2.id)
+          managers.selection.apply([meshes[0].id], peer2.id)
           expectSelected(meshes[0], colorByPlayerId.get(peer1.id), true)
           expectSelected(meshes[1], colorByPlayerId.get(peer1.id), true)
           expectSelection([meshes[2]], colorByPlayerId.get(playerId))
@@ -411,7 +406,7 @@ describe('SelectionManager', () => {
         })
 
         it('ignores meshes from current selection', () => {
-          manager.apply([meshes[2].id], peer2.id)
+          managers.selection.apply([meshes[2].id], peer2.id)
           expectSelection([meshes[2]], colorByPlayerId.get(playerId))
           expect(selectionChanged).not.toHaveBeenCalled()
         })
@@ -419,25 +414,25 @@ describe('SelectionManager', () => {
 
       describe('isSelectedByPeer()', () => {
         it('returns true for peer-selected meshes', () => {
-          expect(manager.isSelectedByPeer(meshes[0])).toBe(true)
-          expect(manager.isSelectedByPeer(meshes[1])).toBe(true)
-          expect(manager.isSelectedByPeer(meshes[3])).toBe(true)
+          expect(managers.selection.isSelectedByPeer(meshes[0])).toBe(true)
+          expect(managers.selection.isSelectedByPeer(meshes[1])).toBe(true)
+          expect(managers.selection.isSelectedByPeer(meshes[3])).toBe(true)
         })
 
         it('returns false for meshes of the active selection', () => {
-          expect(manager.isSelectedByPeer(meshes[2])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[2])).toBe(false)
         })
 
         it('returns false for unselected meshes', () => {
-          expect(manager.isSelectedByPeer(meshes[4])).toBe(false)
+          expect(managers.selection.isSelectedByPeer(meshes[4])).toBe(false)
         })
       })
 
       describe('unselect()', () => {
         it('ignoes meshes selected by peers', () => {
           const [mesh1, mesh2, mesh3, mesh4, mesh5] = meshes
-          manager.unselect(meshes)
-          expect(manager.meshes.size).toBe(0)
+          managers.selection.unselect(meshes)
+          expect(managers.selection.meshes.size).toBe(0)
           expectSelected(mesh1, colorByPlayerId.get(peer1.id))
           expectSelected(mesh2, colorByPlayerId.get(peer1.id))
           expectSelected(mesh3, colorByPlayerId.get(playerId), false)
@@ -472,8 +467,11 @@ describe('SelectionManager', () => {
 
       describe('drawSelectionBox()', () => {
         it('allows selecting contained meshes on main scene', () => {
-          manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
-          manager.selectWithinBox()
+          managers.selection.drawSelectionBox(
+            { x: 1000, y: 550 },
+            { x: 1100, y: 400 }
+          )
+          managers.selection.selectWithinBox()
           expectSelection([meshes[1], meshes[0]], colorByPlayerId.get(playerId))
           expect(selectionChanged).toHaveBeenCalledOnce()
           expect(selectionChanged.mock.calls[0][0].size).toBe(2)
@@ -482,9 +480,12 @@ describe('SelectionManager', () => {
         })
 
         it('append to selection', () => {
-          manager.select(meshes[4])
-          manager.drawSelectionBox({ x: 1100, y: 550 }, { x: 1000, y: 400 })
-          manager.selectWithinBox()
+          managers.selection.select(meshes[4])
+          managers.selection.drawSelectionBox(
+            { x: 1100, y: 550 },
+            { x: 1000, y: 400 }
+          )
+          managers.selection.selectWithinBox()
           expectSelection(
             [meshes[4], meshes[1], meshes[0]],
             colorByPlayerId.get(playerId)
@@ -492,9 +493,12 @@ describe('SelectionManager', () => {
         })
 
         it('allows selecting contained meshes in hand', () => {
-          vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
-          manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
-          manager.selectWithinBox()
+          vi.spyOn(managers.hand, 'isPointerInHand').mockReturnValueOnce(true)
+          managers.selection.drawSelectionBox(
+            { x: 100, y: 400 },
+            { x: 1100, y: 900 }
+          )
+          managers.selection.selectWithinBox()
           expectSelection([meshes[6], meshes[7]], colorByPlayerId.get(playerId))
           expect(selectionChanged).toHaveBeenCalledOnce()
           expect(selectionChanged.mock.calls[0][0].size).toBe(2)
@@ -503,25 +507,34 @@ describe('SelectionManager', () => {
         })
 
         it('clears selection from hand when selecting in main scene', () => {
-          manager.select(meshes[6])
-          manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
-          manager.selectWithinBox()
+          managers.selection.select(meshes[6])
+          managers.selection.drawSelectionBox(
+            { x: 1000, y: 550 },
+            { x: 1100, y: 400 }
+          )
+          managers.selection.selectWithinBox()
           expectSelection([meshes[1], meshes[0]], colorByPlayerId.get(playerId))
         })
 
         it('clears selection from main when selecting in hand', () => {
-          manager.select(meshes[4])
-          vi.spyOn(handManager, 'isPointerInHand').mockReturnValueOnce(true)
-          manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
-          manager.selectWithinBox()
+          managers.selection.select(meshes[4])
+          vi.spyOn(managers.hand, 'isPointerInHand').mockReturnValueOnce(true)
+          managers.selection.drawSelectionBox(
+            { x: 100, y: 400 },
+            { x: 1100, y: 900 }
+          )
+          managers.selection.selectWithinBox()
           expectSelection([meshes[6], meshes[7]], colorByPlayerId.get(playerId))
         })
 
         it('ignores meshes selected by peers', () => {
           const [mesh] = meshes
-          manager.apply([mesh.id], peer1.id)
-          manager.drawSelectionBox({ x: 100, y: 400 }, { x: 1100, y: 900 })
-          manager.selectWithinBox()
+          managers.selection.apply([mesh.id], peer1.id)
+          managers.selection.drawSelectionBox(
+            { x: 100, y: 400 },
+            { x: 1100, y: 900 }
+          )
+          managers.selection.selectWithinBox()
 
           expectSelected(meshes[0], colorByPlayerId.get(peer1.id))
           expectSelected(meshes[1], colorByPlayerId.get(playerId))
@@ -532,8 +545,11 @@ describe('SelectionManager', () => {
             serialize: () => ({ id: meshes[1].id, shape: 'box', texture: '' }),
             isLocked: true
           }
-          manager.drawSelectionBox({ x: 1000, y: 550 }, { x: 1100, y: 400 })
-          manager.selectWithinBox()
+          managers.selection.drawSelectionBox(
+            { x: 1000, y: 550 },
+            { x: 1100, y: 400 }
+          )
+          managers.selection.selectWithinBox()
 
           expectSelection([meshes[0]], colorByPlayerId.get(playerId))
           expect(selectionChanged).toHaveBeenCalledOnce()
@@ -544,19 +560,19 @@ describe('SelectionManager', () => {
       })
     })
   })
-})
 
-function expectSelection(
-  /** @type {Mesh[]} */ expectedMeshes,
-  /** @type {?string|undefined} */ color
-) {
-  expect([...manager.meshes].map(({ id }) => id)).toEqual(
-    expectedMeshes.map(({ id }) => id)
-  )
-  for (const [rank, mesh] of expectedMeshes.entries()) {
-    expectSelected(mesh, color, true, `mesh #${rank} selection status`)
+  function expectSelection(
+    /** @type {Mesh[]} */ expectedMeshes,
+    /** @type {?string|undefined} */ color
+  ) {
+    expect([...managers.selection.meshes].map(({ id }) => id)).toEqual(
+      expectedMeshes.map(({ id }) => id)
+    )
+    for (const [rank, mesh] of expectedMeshes.entries()) {
+      expectSelected(mesh, color, true, `mesh #${rank} selection status`)
+    }
   }
-}
+})
 
 function expectSelected(
   /** @type {Mesh} */ mesh,

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -33,13 +33,16 @@ describe('managers.Selection', () => {
     color: faker.color.rgb().toUpperCase()
   }
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    handScene = created.handScene
-    managers = created.managers
-    managers.selection.onSelectionObservable.add(selectionChanged)
-    managers.hand.enabled = true
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      handScene = created.handScene
+      managers = created.managers
+      managers.selection.onSelectionObservable.add(selectionChanged)
+      managers.hand.enabled = true
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     managers.selection.clear()

--- a/apps/web/tests/3d/managers/selection.test.js
+++ b/apps/web/tests/3d/managers/selection.test.js
@@ -206,7 +206,6 @@ describe('managers.Selection', () => {
       })
 
       it('does nothing without player', () => {
-        // @ts-expect-error: we have not provided playerId
         managers.selection.apply([meshes[0].id, meshes[1].id])
         expectSelected(meshes[0], null, false)
         expectSelected(meshes[1], null, false)

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -29,13 +29,16 @@ describe('TargetManager', () => {
   /** @type {string} */
   let color
 
-  configures3dTestEngine(created => {
-    scene = created.scene
-    handScene = created.handScene
-    managers = created.managers
-    playerId = created.playerId
-    color = managers.target.color.toHexString()
-  })
+  configures3dTestEngine(
+    created => {
+      scene = created.scene
+      handScene = created.handScene
+      managers = created.managers
+      playerId = created.playerId
+      color = managers.target.color.toHexString()
+    },
+    { isSimulation: globalThis.use3dSimulation }
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/tests/3d/managers/target.test.js
+++ b/apps/web/tests/3d/managers/target.test.js
@@ -11,8 +11,8 @@
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
 import { MoveBehavior, TargetBehavior } from '@src/3d/behaviors'
-import { selectionManager, targetManager as manager } from '@src/3d/managers'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TargetManager } from '@src/3d/managers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { configures3dTestEngine, createBox } from '../../test-utils'
 
@@ -22,521 +22,528 @@ describe('TargetManager', () => {
   let scene
   /** @type {Scene} */
   let handScene
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
+  /** @type {string} */
+  let playerId
+  /** @type {string} */
+  let color
 
   configures3dTestEngine(created => {
     scene = created.scene
     handScene = created.handScene
+    managers = created.managers
+    playerId = created.playerId
+    color = managers.target.color.toHexString()
   })
-
-  beforeAll(() => selectionManager.init({ scene, handScene }))
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     drops = []
-  })
-
-  it('has initial state', () => {
-    expect(manager.scene).toBeUndefined()
-    expect(manager.playerId).toBeUndefined()
   })
 
   describe('init()', () => {
     it('sets scene', () => {
       const playerId = faker.string.uuid()
       const color = faker.color.rgb()
-      manager.init({ scene, playerId, color })
-      expect(manager.scene).toEqual(scene)
+      const manager = new TargetManager({ scene })
+      manager.init({ managers, playerId, color })
       expect(manager.playerId).toEqual(playerId)
     })
   })
 
-  describe('given an initialized manager', () => {
-    const playerId = faker.string.uuid()
-    const color = '#00FF00FF'
+  describe('registerTargetable()', () => {
+    it('registers a mesh', () => {
+      const mesh = createBox('box3', {})
+      mesh.addBehavior(new TargetBehavior({}, managers), true)
+      expect(managers.target.isManaging(mesh)).toBe(true)
+    })
 
-    beforeAll(() => manager.init({ scene, playerId, color }))
+    it('automatically unregisters a mesh upon disposal', () => {
+      const mesh = createBox('box3', {})
+      mesh.addBehavior(new TargetBehavior({}, managers), true)
+      expect(managers.target.isManaging(mesh)).toBe(true)
 
-    describe('registerTargetable()', () => {
-      it('registers a mesh', () => {
-        const mesh = createBox('box3', {})
-        mesh.addBehavior(new TargetBehavior(), true)
-        expect(manager.isManaging(mesh)).toBe(true)
+      mesh.dispose()
+      expect(managers.target.isManaging(mesh)).toBe(false)
+    })
+
+    it('automatically unregisters a mesh upon behavior detachment', () => {
+      const mesh = createBox('box3', {})
+      const behavior = new TargetBehavior({}, managers)
+      mesh.addBehavior(behavior, true)
+      expect(managers.target.isManaging(mesh)).toBe(true)
+
+      behavior.detach()
+      expect(managers.target.isManaging(mesh)).toBe(false)
+    })
+
+    it('handles invalid behavior', () => {
+      const behavior = new TargetBehavior({}, managers)
+      managers.target.registerTargetable(behavior)
+      // @ts-expect-error: we don't provide a behavior
+      managers.target.registerTargetable()
+    })
+  })
+
+  describe('unregisterTargetable()', () => {
+    it('handles invalid behavior', () => {
+      const behavior = new TargetBehavior({}, managers)
+      managers.target.unregisterTargetable(behavior)
+      // @ts-expect-error: we don't provide a behavior
+      managers.target.unregisterTargetable()
+    })
+  })
+
+  describe('findDropZone()', () => {
+    /** @type {SingleDropZone} */
+    let zone1
+    /** @type {SingleDropZone} */
+    let zone2
+    const aboveZone1 = new Vector3(5, 1, 5)
+    const aboveZone2 = new Vector3(-5, 1, -5)
+    const aboveZone3 = new Vector3(10, 1, 10)
+
+    beforeEach(() => {
+      zone1 = createsTargetZone('target1', {
+        position: new Vector3(aboveZone1.x, 0, aboveZone1.z)
       })
-
-      it('automatically unregisters a mesh upon disposal', () => {
-        const mesh = createBox('box3', {})
-        mesh.addBehavior(new TargetBehavior(), true)
-        expect(manager.isManaging(mesh)).toBe(true)
-
-        mesh.dispose()
-        expect(manager.isManaging(mesh)).toBe(false)
-      })
-
-      it('automatically unregisters a mesh upon behavior detachment', () => {
-        const mesh = createBox('box3', {})
-        const behavior = new TargetBehavior()
-        mesh.addBehavior(behavior, true)
-        expect(manager.isManaging(mesh)).toBe(true)
-
-        behavior.detach()
-        expect(manager.isManaging(mesh)).toBe(false)
-      })
-
-      it('handles invalid behavior', () => {
-        const behavior = new TargetBehavior()
-        manager.registerTargetable(behavior)
-        // @ts-expect-error: we don't provide a behavior
-        manager.registerTargetable()
+      zone2 = createsTargetZone('target2', {
+        position: new Vector3(aboveZone2.x, 0, aboveZone2.z)
       })
     })
 
-    describe('unregisterTargetable()', () => {
-      it('handles invalid behavior', () => {
-        const behavior = new TargetBehavior()
-        manager.unregisterTargetable(behavior)
-        // @ts-expect-error: we don't provide a behavior
-        manager.unregisterTargetable()
-      })
+    it('returns nothing if mesh is not above any target', () => {
+      expect(managers.target.findDropZone(createBox('box', {}))).toBeNull()
     })
 
-    describe('findDropZone()', () => {
-      /** @type {SingleDropZone} */
-      let zone1
-      /** @type {SingleDropZone} */
-      let zone2
-      const aboveZone1 = new Vector3(5, 1, 5)
-      const aboveZone2 = new Vector3(-5, 1, -5)
-      const aboveZone3 = new Vector3(10, 1, 10)
+    it('returns targets below mesh', () => {
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone1)
 
-      beforeEach(() => {
-        zone1 = createsTargetZone('target1', {
-          position: new Vector3(aboveZone1.x, 0, aboveZone1.z)
-        })
-        zone2 = createsTargetZone('target2', {
-          position: new Vector3(aboveZone2.x, 0, aboveZone2.z)
-        })
-      })
-
-      it('returns nothing if mesh is not above any target', () => {
-        expect(manager.findDropZone(createBox('box', {}))).toBeNull()
-      })
-
-      it('returns targets below mesh', () => {
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone1)
-
-        expectActiveZone(manager.findDropZone(mesh), zone1, color)
-      })
-
-      it('ignores an overlaping target when mesh is too far from center', () => {
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone1.add(new Vector3(1, 0, 0)))
-
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('ignores targets with kinds below kind-less mesh', () => {
-        zone1.kinds = ['card']
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(aboveZone1)
-
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('ignores disabled targets', () => {
-        zone1.enabled = false
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(aboveZone1)
-
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('ignores target part of the current selection', () => {
-        selectionManager.select(/** @type {Mesh} */ (zone1.targetable.mesh))
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
-
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('ignores targets from different scene', () => {
-        const handMesh = createBox('box', {}, handScene)
-        handMesh.setAbsolutePosition(aboveZone2)
-        expect(manager.findDropZone(handMesh)).toBeNull()
-
-        createsTargetZone('target3', {
-          position: new Vector3(10, 0, 10),
-          scene: handScene
-        })
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone3)
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('ignores targets with another player Id', () => {
-        createsTargetZone('target3', {
-          position: new Vector3(10, 0, 10),
-          playerId: faker.string.uuid(),
-          scene
-        })
-        const mesh = createBox('box', {}, scene)
-        mesh.setAbsolutePosition(aboveZone3)
-
-        expect(manager.findDropZone(mesh)).toBeNull()
-      })
-
-      it('returns targets with same playerId below mesh with kind', () => {
-        const zone3 = createsTargetZone('target3', {
-          position: new Vector3(10, 0, 10),
-          playerId,
-          scene
-        })
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone3)
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone3, color)
-      })
-
-      it('returns kind-less targets below mesh with kind', () => {
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone1)
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone1, color)
-      })
-
-      it('returns targets below mesh with matching kind', () => {
-        zone1.kinds = ['card', 'box']
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(aboveZone2)
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone2, color)
-      })
-
-      it('returns closest target below mesh regardless of elevation and priorities', () => {
-        createsTargetZone('target3', {
-          position: new Vector3(0.5, 0, 0),
-          priority: 10
-        })
-        createsTargetZone('target4', { position: new Vector3(-0.5, 1, 0) })
-        const zone5 = createsTargetZone('target5', {
-          position: new Vector3(0, 0, 0)
-        })
-
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(new Vector3(0, 5, 0))
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone5, color)
-      })
-
-      it('returns highest target below mesh regardless of priorities', () => {
-        createsTargetZone('target3', {
-          position: new Vector3(0, 0, 0),
-          priority: 10
-        })
-        const zone4 = createsTargetZone('target4', {
-          position: new Vector3(0, 1, 0)
-        })
-        createsTargetZone('target5', { position: new Vector3(0, 0.5, 0) })
-
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(new Vector3(0, 5, 0))
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4, color)
-      })
-
-      it('returns highest priority target below mesh', () => {
-        createsTargetZone('target3', new Vector3(0, 0, 0))
-        const zone4 = createsTargetZone('target4', {
-          position: new Vector3(0, 0, 0),
-          priority: 2
-        })
-        createsTargetZone('target5', {
-          position: new Vector3(0, 0, 0),
-          priority: 1
-        })
-
-        const mesh = createBox('box', {})
-        mesh.setAbsolutePosition(new Vector3(0, 5, 0))
-
-        expectActiveZone(manager.findDropZone(mesh, 'box'), zone4, color)
-      })
-
-      describe('given a mesh with parts', () => {
-        /** @type {Mesh} */
-        let mesh
-
-        beforeEach(() => {
-          mesh = createBox('multi-box', { width: 2 })
-          mesh.addBehavior(
-            new MoveBehavior({ partCenters: [{ x: 0.5 }, { x: 1.5 }] }),
-            true
-          )
-          mesh.setAbsolutePosition(new Vector3(0, 1, 0))
-        })
-
-        it('returns a multi drop zone', () => {
-          const zone4 = createsTargetZone('target4', {
-            position: new Vector3(0, 0, 0)
-          })
-          const zone5 = createsTargetZone('target5', {
-            position: new Vector3(1, 0, 0)
-          })
-
-          expect(manager.findDropZone(mesh, 'box')).toEqual({
-            parts: [zone4, zone5],
-            mesh: zone4.mesh,
-            targetable: zone4.targetable
-          })
-        })
-
-        it('gives precedence to a single drop zone that ignore part', () => {
-          createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
-          createsTargetZone('target5', { position: new Vector3(1, 0, 0) })
-          const zone6 = createsTargetZone('target6', {
-            position: new Vector3(0.5, 0, 0),
-            ignoreParts: true
-          })
-
-          expect(manager.findDropZone(mesh, 'box')).toEqual(zone6)
-        })
-
-        it('returns null when at least one part is not covered', () => {
-          createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
-          createsTargetZone('target5', { position: new Vector3(-1, 0, 0) })
-
-          expect(manager.findDropZone(mesh, 'box')).toBeNull()
-        })
-
-        it('clears an active multi zone', () => {
-          createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
-          createsTargetZone('target5', { position: new Vector3(1, 0, 0) })
-
-          const multiZone = manager.findDropZone(mesh, 'box')
-          expectVisibility(multiZone, true)
-          manager.clear(multiZone)
-          expectVisibility(multiZone, false)
-        })
-      })
-
-      describe('clear()', () => {
-        beforeEach(() => {
-          const mesh = createBox('box', {})
-          mesh.setAbsolutePosition(aboveZone1)
-          manager.findDropZone(mesh, 'box')
-        })
-
-        it('clears an active zone', () => {
-          expectVisibility(zone1, true)
-          manager.clear(zone1)
-          expectVisibility(zone1, false)
-          expect(manager.dropOn(zone1)).toEqual([])
-        })
-
-        it('ignores unactive zone', () => {
-          expectVisibility(zone2, false)
-          manager.clear(zone2)
-          expectVisibility(zone2, false)
-          expect(manager.dropOn(zone2)).toEqual([])
-        })
-
-        it('handles invalid zones', () => {
-          manager.clear()
-          manager.clear(null)
-          // @ts-expect-error: it's ok to pass random object
-          manager.clear({})
-          expectVisibility(zone1, true)
-          expectVisibility(zone2, false)
-        })
-      })
-
-      describe('dropOn()', () => {
-        /** @type {Mesh[]} */
-        let meshes
-        beforeEach(() => {
-          meshes = ['box1', 'box2'].map(id => {
-            const mesh = createBox(id, {})
-            mesh.setAbsolutePosition(aboveZone1)
-            manager.findDropZone(mesh, 'box')
-            return mesh
-          })
-        })
-
-        it('ignores unactive zone', () => {
-          expect(manager.dropOn(zone2)).toEqual([])
-        })
-
-        it('drops meshes on zone and clear it', () => {
-          expectVisibility(zone1, true)
-          expect(manager.dropOn(zone1)).toEqual(meshes)
-          expectVisibility(zone1, false)
-        })
-      })
+      expectActiveZone(managers.target.findDropZone(mesh), zone1, color)
     })
 
-    describe('findPlayerZone()', () => {
-      /** @type {SingleDropZone} */
-      let zone1
-      /** @type {SingleDropZone} */
-      let zone2
+    it('ignores an overlaping target when mesh is too far from center', () => {
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone1.add(new Vector3(1, 0, 0)))
+
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('ignores targets with kinds below kind-less mesh', () => {
+      zone1.kinds = ['card']
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(aboveZone1)
+
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('ignores disabled targets', () => {
+      zone1.enabled = false
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(aboveZone1)
+
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('ignores target part of the current selection', () => {
+      managers.selection.select(/** @type {Mesh} */ (zone1.targetable.mesh))
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
+
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('ignores targets from different scene', () => {
+      const handMesh = createBox('box', {}, handScene)
+      handMesh.setAbsolutePosition(aboveZone2)
+      expect(managers.target.findDropZone(handMesh)).toBeNull()
+
+      createsTargetZone('target3', {
+        position: new Vector3(10, 0, 10),
+        scene: handScene
+      })
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone3)
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('ignores targets with another player Id', () => {
+      createsTargetZone('target3', {
+        position: new Vector3(10, 0, 10),
+        playerId: faker.string.uuid(),
+        scene
+      })
+      const mesh = createBox('box', {}, scene)
+      mesh.setAbsolutePosition(aboveZone3)
+
+      expect(managers.target.findDropZone(mesh)).toBeNull()
+    })
+
+    it('returns targets with same playerId below mesh with kind', () => {
+      const zone3 = createsTargetZone('target3', {
+        position: new Vector3(10, 0, 10),
+        playerId,
+        scene
+      })
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone3)
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone3, color)
+    })
+
+    it('returns kind-less targets below mesh with kind', () => {
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone1)
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone1, color)
+    })
+
+    it('returns targets below mesh with matching kind', () => {
+      zone1.kinds = ['card', 'box']
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(aboveZone2)
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone2, color)
+    })
+
+    it('returns closest target below mesh regardless of elevation and priorities', () => {
+      createsTargetZone('target3', {
+        position: new Vector3(0.5, 0, 0),
+        priority: 10
+      })
+      createsTargetZone('target4', { position: new Vector3(-0.5, 1, 0) })
+      const zone5 = createsTargetZone('target5', {
+        position: new Vector3(0, 0, 0)
+      })
+
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(new Vector3(0, 5, 0))
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone5, color)
+    })
+
+    it('returns highest target below mesh regardless of priorities', () => {
+      createsTargetZone('target3', {
+        position: new Vector3(0, 0, 0),
+        priority: 10
+      })
+      const zone4 = createsTargetZone('target4', {
+        position: new Vector3(0, 1, 0)
+      })
+      createsTargetZone('target5', { position: new Vector3(0, 0.5, 0) })
+
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(new Vector3(0, 5, 0))
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone4, color)
+    })
+
+    it('returns highest priority target below mesh', () => {
+      createsTargetZone('target3', new Vector3(0, 0, 0))
+      const zone4 = createsTargetZone('target4', {
+        position: new Vector3(0, 0, 0),
+        priority: 2
+      })
+      createsTargetZone('target5', {
+        position: new Vector3(0, 0, 0),
+        priority: 1
+      })
+
+      const mesh = createBox('box', {})
+      mesh.setAbsolutePosition(new Vector3(0, 5, 0))
+
+      expectActiveZone(managers.target.findDropZone(mesh, 'box'), zone4, color)
+    })
+
+    describe('given a mesh with parts', () => {
       /** @type {Mesh} */
       let mesh
 
       beforeEach(() => {
-        zone1 = createsTargetZone('target1', {
-          position: new Vector3(5, 0, 5),
-          playerId
+        mesh = createBox('multi-box', { width: 2 })
+        mesh.addBehavior(
+          new MoveBehavior({ partCenters: [{ x: 0.5 }, { x: 1.5 }] }, managers),
+          true
+        )
+        mesh.setAbsolutePosition(new Vector3(0, 1, 0))
+      })
+
+      it('returns a multi drop zone', () => {
+        const zone4 = createsTargetZone('target4', {
+          position: new Vector3(0, 0, 0)
         })
-        zone2 = createsTargetZone('target2', {
-          position: new Vector3(-5, 0, -5),
-          playerId: faker.string.uuid()
-        })
-        mesh = createBox('box', {})
-      })
-
-      it('ignores targets with kinds when providing no kind', () => {
-        zone1.kinds = ['card']
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
-
-        expect(manager.findPlayerZone(mesh)).toBeNull()
-      })
-
-      it('ignores disabled targets', () => {
-        zone1.enabled = false
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
-
-        expect(manager.findPlayerZone(mesh)).toBeNull()
-      })
-
-      it('ignores target part of the current selection', () => {
-        selectionManager.select(/** @type {Mesh} */ (zone1.targetable.mesh))
-        const mesh = createBox('box2', {})
-        mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
-
-        expect(manager.findPlayerZone(mesh)).toBeNull()
-      })
-
-      it('ignores targets from different scene', () => {
-        const mesh = createBox('box', {}, handScene)
-        expect(manager.findPlayerZone(mesh)).toBeNull()
-      })
-
-      it('returns kind-less targets for provided kind', () => {
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone1, color)
-      })
-
-      it('returns targets with matching kind', () => {
-        const zone3 = createsTargetZone('target', {
-          priority: 1,
-          playerId,
-          kinds: ['card', 'box']
-        })
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3, color)
-      })
-
-      it('returns highest target', () => {
-        const zone3 = createsTargetZone('target3', {
-          position: new Vector3(0, 1, 0),
-          playerId
-        })
-        expectActiveZone(manager.findPlayerZone(mesh, 'box'), zone3, color)
-      })
-
-      describe('clear()', () => {
-        beforeEach(() => {
-          manager.findPlayerZone(mesh, 'box')
+        const zone5 = createsTargetZone('target5', {
+          position: new Vector3(1, 0, 0)
         })
 
-        it('clears an active zone', () => {
-          expectVisibility(zone1, true)
-          manager.clear(zone1)
-          expectVisibility(zone1, false)
-          expect(manager.dropOn(zone1)).toEqual([])
-        })
-
-        it('ignores unactive zone', () => {
-          expectVisibility(zone2, false)
-          manager.clear(zone2)
-          expectVisibility(zone2, false)
-          expect(manager.dropOn(zone2)).toEqual([])
+        expect(managers.target.findDropZone(mesh, 'box')).toEqual({
+          parts: [zone4, zone5],
+          mesh: zone4.mesh,
+          targetable: zone4.targetable
         })
       })
 
-      describe('dropOn()', () => {
-        /** @type {Mesh[]} */
-        let meshes
-        beforeEach(() => {
-          meshes = ['box1', 'box2'].map(id => {
-            const mesh = createBox(id, {})
-            manager.findPlayerZone(mesh, 'box')
-            return mesh
-          })
+      it('gives precedence to a single drop zone that ignore part', () => {
+        createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
+        createsTargetZone('target5', { position: new Vector3(1, 0, 0) })
+        const zone6 = createsTargetZone('target6', {
+          position: new Vector3(0.5, 0, 0),
+          ignoreParts: true
         })
 
-        it('ignores unactive zone', () => {
-          expect(manager.dropOn(zone2)).toEqual([])
-        })
+        expect(managers.target.findDropZone(mesh, 'box')).toEqual(zone6)
+      })
 
-        it('drops meshes on zone and clear it', () => {
-          expectVisibility(zone1, true)
-          expect(manager.dropOn(zone1)).toEqual(meshes)
-          expectVisibility(zone1, false)
-        })
+      it('returns null when at least one part is not covered', () => {
+        createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
+        createsTargetZone('target5', { position: new Vector3(-1, 0, 0) })
+
+        expect(managers.target.findDropZone(mesh, 'box')).toBeNull()
+      })
+
+      it('clears an active multi zone', () => {
+        createsTargetZone('target4', { position: new Vector3(0, 0, 0) })
+        createsTargetZone('target5', { position: new Vector3(1, 0, 0) })
+
+        const multiZone = managers.target.findDropZone(mesh, 'box')
+        expectVisibility(multiZone, true)
+        managers.target.clear(multiZone)
+        expectVisibility(multiZone, false)
       })
     })
 
-    describe('canAccept()', () => {
-      it('returns false without a zone', () => {
-        expect(manager.canAccept()).toBe(false)
+    describe('clear()', () => {
+      beforeEach(() => {
+        const mesh = createBox('box', {})
+        mesh.setAbsolutePosition(aboveZone1)
+        managers.target.findDropZone(mesh, 'box')
       })
 
-      describe('given a kindless zone', () => {
-        /** @type {Partial<SingleDropZone>} */
-        let zone
+      it('clears an active zone', () => {
+        expectVisibility(zone1, true)
+        managers.target.clear(zone1)
+        expectVisibility(zone1, false)
+        expect(managers.target.dropOn(zone1)).toEqual([])
+      })
 
-        beforeEach(() => {
-          zone = { enabled: true }
-        })
+      it('ignores unactive zone', () => {
+        expectVisibility(zone2, false)
+        managers.target.clear(zone2)
+        expectVisibility(zone2, false)
+        expect(managers.target.dropOn(zone2)).toEqual([])
+      })
 
-        it('returns true without kind', () => {
-          expect(manager.canAccept(zone)).toBe(true)
-        })
+      it('handles invalid zones', () => {
+        managers.target.clear()
+        managers.target.clear(null)
+        // @ts-expect-error: it's ok to pass random object
+        managers.target.clear({})
+        expectVisibility(zone1, true)
+        expectVisibility(zone2, false)
+      })
+    })
 
-        it('returns true with kind', () => {
-          expect(manager.canAccept(zone, 'die')).toBe(true)
-        })
-
-        it('returns false when disabled', () => {
-          zone.enabled = false
-          expect(manager.canAccept(zone)).toBe(false)
+    describe('dropOn()', () => {
+      /** @type {Mesh[]} */
+      let meshes
+      beforeEach(() => {
+        meshes = ['box1', 'box2'].map(id => {
+          const mesh = createBox(id, {})
+          mesh.setAbsolutePosition(aboveZone1)
+          managers.target.findDropZone(mesh, 'box')
+          return mesh
         })
       })
 
-      describe('given a zone with kind', () => {
-        /** @type {Partial<SingleDropZone>} */
-        let zone
+      it('ignores unactive zone', () => {
+        expect(managers.target.dropOn(zone2)).toEqual([])
+      })
 
-        beforeEach(() => {
-          zone = { enabled: true, kinds: ['card', 'token'] }
-        })
+      it('drops meshes on zone and clear it', () => {
+        expectVisibility(zone1, true)
+        expect(managers.target.dropOn(zone1)).toEqual(meshes)
+        expectVisibility(zone1, false)
+      })
+    })
+  })
 
-        it('returns false without kind', () => {
-          expect(manager.canAccept(zone)).toBe(false)
-        })
+  describe('findPlayerZone()', () => {
+    /** @type {SingleDropZone} */
+    let zone1
+    /** @type {SingleDropZone} */
+    let zone2
+    /** @type {Mesh} */
+    let mesh
 
-        it('returns false with unexpected kind', () => {
-          expect(manager.canAccept(zone, 'die')).toBe(false)
-        })
+    beforeEach(() => {
+      zone1 = createsTargetZone('target1', {
+        position: new Vector3(5, 0, 5),
+        playerId
+      })
+      zone2 = createsTargetZone('target2', {
+        position: new Vector3(-5, 0, -5),
+        playerId: faker.string.uuid()
+      })
+      mesh = createBox('box', {})
+    })
 
-        it('returns true with expected kind', () => {
-          expect(manager.canAccept(zone, 'token')).toBe(true)
-        })
+    it('ignores targets with kinds when providing no kind', () => {
+      zone1.kinds = ['card']
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
 
-        it('returns false when disabled', () => {
-          zone.enabled = false
-          expect(manager.canAccept(zone, 'token')).toBe(false)
+      expect(managers.target.findPlayerZone(mesh)).toBeNull()
+    })
+
+    it('ignores disabled targets', () => {
+      zone1.enabled = false
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
+
+      expect(managers.target.findPlayerZone(mesh)).toBeNull()
+    })
+
+    it('ignores target part of the current selection', () => {
+      managers.selection.select(/** @type {Mesh} */ (zone1.targetable.mesh))
+      const mesh = createBox('box2', {})
+      mesh.setAbsolutePosition(zone1.mesh.absolutePosition)
+
+      expect(managers.target.findPlayerZone(mesh)).toBeNull()
+    })
+
+    it('ignores targets from different scene', () => {
+      const mesh = createBox('box', {}, handScene)
+      expect(managers.target.findPlayerZone(mesh)).toBeNull()
+    })
+
+    it('returns kind-less targets for provided kind', () => {
+      expectActiveZone(
+        managers.target.findPlayerZone(mesh, 'box'),
+        zone1,
+        color
+      )
+    })
+
+    it('returns targets with matching kind', () => {
+      const zone3 = createsTargetZone('target', {
+        priority: 1,
+        playerId,
+        kinds: ['card', 'box']
+      })
+      expectActiveZone(
+        managers.target.findPlayerZone(mesh, 'box'),
+        zone3,
+        color
+      )
+    })
+
+    it('returns highest target', () => {
+      const zone3 = createsTargetZone('target3', {
+        position: new Vector3(0, 1, 0),
+        playerId
+      })
+      expectActiveZone(
+        managers.target.findPlayerZone(mesh, 'box'),
+        zone3,
+        color
+      )
+    })
+
+    describe('clear()', () => {
+      beforeEach(() => {
+        managers.target.findPlayerZone(mesh, 'box')
+      })
+
+      it('clears an active zone', () => {
+        expectVisibility(zone1, true)
+        managers.target.clear(zone1)
+        expectVisibility(zone1, false)
+        expect(managers.target.dropOn(zone1)).toEqual([])
+      })
+
+      it('ignores unactive zone', () => {
+        expectVisibility(zone2, false)
+        managers.target.clear(zone2)
+        expectVisibility(zone2, false)
+        expect(managers.target.dropOn(zone2)).toEqual([])
+      })
+    })
+
+    describe('dropOn()', () => {
+      /** @type {Mesh[]} */
+      let meshes
+      beforeEach(() => {
+        meshes = ['box1', 'box2'].map(id => {
+          const mesh = createBox(id, {})
+          managers.target.findPlayerZone(mesh, 'box')
+          return mesh
         })
+      })
+
+      it('ignores unactive zone', () => {
+        expect(managers.target.dropOn(zone2)).toEqual([])
+      })
+
+      it('drops meshes on zone and clear it', () => {
+        expectVisibility(zone1, true)
+        expect(managers.target.dropOn(zone1)).toEqual(meshes)
+        expectVisibility(zone1, false)
+      })
+    })
+  })
+
+  describe('canAccept()', () => {
+    it('returns false without a zone', () => {
+      expect(managers.target.canAccept()).toBe(false)
+    })
+
+    describe('given a kindless zone', () => {
+      /** @type {Partial<SingleDropZone>} */
+      let zone
+
+      beforeEach(() => {
+        zone = { enabled: true }
+      })
+
+      it('returns true without kind', () => {
+        expect(managers.target.canAccept(zone)).toBe(true)
+      })
+
+      it('returns true with kind', () => {
+        expect(managers.target.canAccept(zone, 'die')).toBe(true)
+      })
+
+      it('returns false when disabled', () => {
+        zone.enabled = false
+        expect(managers.target.canAccept(zone)).toBe(false)
+      })
+    })
+
+    describe('given a zone with kind', () => {
+      /** @type {Partial<SingleDropZone>} */
+      let zone
+
+      beforeEach(() => {
+        zone = { enabled: true, kinds: ['card', 'token'] }
+      })
+
+      it('returns false without kind', () => {
+        expect(managers.target.canAccept(zone)).toBe(false)
+      })
+
+      it('returns false with unexpected kind', () => {
+        expect(managers.target.canAccept(zone, 'die')).toBe(false)
+      })
+
+      it('returns true with expected kind', () => {
+        expect(managers.target.canAccept(zone, 'token')).toBe(true)
+      })
+
+      it('returns false when disabled', () => {
+        zone.enabled = false
+        expect(managers.target.canAccept(zone, 'token')).toBe(false)
       })
     })
   })
@@ -548,7 +555,7 @@ describe('TargetManager', () => {
   ) {
     const targetable = createBox(`targetable-${id}`, {}, usedScene ?? scene)
     targetable.isPickable = false
-    const behavior = new TargetBehavior()
+    const behavior = new TargetBehavior({}, managers)
     behavior.onDropObservable.add(drop => drops.push(drop))
     targetable.addBehavior(behavior, true)
 

--- a/apps/web/tests/3d/meshes/box.test.js
+++ b/apps/web/tests/3d/meshes/box.test.js
@@ -7,9 +7,8 @@
 
 import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
-import { controlManager, materialManager } from '@src/3d/managers'
 import { createBox } from '@src/3d/meshes'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   configures3dTestEngine,
@@ -19,13 +18,17 @@ import {
 
 /** @type {Scene} */
 let scene
-configures3dTestEngine(created => (scene = created.scene))
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 
-beforeAll(() => materialManager.init({ scene }))
+configures3dTestEngine(created => {
+  scene = created.scene
+  managers = created.managers
+})
 
 describe('createBox()', () => {
   it('creates a box with default values, faces and no behavior', async () => {
-    const mesh = await createBox({ id: '', texture: '' }, scene)
+    const mesh = await createBox({ id: '', texture: '' }, managers, scene)
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [1, 1, 1])
     expect(mesh.isPickable).toBe(false)
@@ -38,7 +41,7 @@ describe('createBox()', () => {
 
   it('creates a box with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createBox({ id: '', texture: color }, scene)
+    const mesh = await createBox({ id: '', texture: color }, managers, scene)
     expect(mesh.name).toEqual('box')
     expectDimension(mesh, [1, 1, 1])
     expect(mesh.isPickable).toBe(false)
@@ -57,6 +60,7 @@ describe('createBox()', () => {
         depth: 2,
         transform: { yaw: Math.PI * -0.5 }
       },
+      managers,
       scene
     )
     expect(mesh.name).toEqual('box')
@@ -103,6 +107,7 @@ describe('createBox()', () => {
           faceUV,
           ...behaviors
         },
+        managers,
         scene
       )
     })
@@ -130,9 +135,9 @@ describe('createBox()', () => {
     })
 
     it('unregisters box from controllables on disposal', () => {
-      expect(controlManager.isManaging(mesh)).toBe(true)
+      expect(managers.control.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(controlManager.isManaging(mesh)).toBe(false)
+      expect(managers.control.isManaging(mesh)).toBe(false)
     })
 
     it('serialize with its state', () => {

--- a/apps/web/tests/3d/meshes/card.test.js
+++ b/apps/web/tests/3d/meshes/card.test.js
@@ -7,9 +7,8 @@
 
 import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
-import { controlManager, materialManager } from '@src/3d/managers'
 import { createCard } from '@src/3d/meshes'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   configures3dTestEngine,
@@ -19,13 +18,17 @@ import {
 
 /** @type {Scene} */
 let scene
-configures3dTestEngine(created => (scene = created.scene))
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 
-beforeAll(() => materialManager.init({ scene }))
+configures3dTestEngine(created => {
+  scene = created.scene
+  managers = created.managers
+})
 
 describe('createCard()', () => {
   it('creates a card with default values, faces and no behavior', async () => {
-    const mesh = await createCard({ id: '', texture: '' }, scene)
+    const mesh = await createCard({ id: '', texture: '' }, managers, scene)
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [3, 0.01, 4.25])
     expect(mesh.isPickable).toBe(false)
@@ -39,7 +42,7 @@ describe('createCard()', () => {
 
   it('creates a card with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createCard({ id: '', texture: color }, scene)
+    const mesh = await createCard({ id: '', texture: color }, managers, scene)
     expect(mesh.name).toEqual('card')
     expectDimension(mesh, [3, 0.01, 4.25])
     expect(mesh.isPickable).toBe(false)
@@ -57,6 +60,7 @@ describe('createCard()', () => {
         depth: 2,
         transform: { yaw: Math.PI * -0.5 }
       },
+      managers,
       scene
     )
     expect(mesh.name).toEqual('card')
@@ -103,6 +107,7 @@ describe('createCard()', () => {
           faceUV,
           ...behaviors
         },
+        managers,
         scene
       )
     })
@@ -130,9 +135,9 @@ describe('createCard()', () => {
     })
 
     it('unregisters card from controllables on disposal', () => {
-      expect(controlManager.isManaging(mesh)).toBe(true)
+      expect(managers.control.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(controlManager.isManaging(mesh)).toBe(false)
+      expect(managers.control.isManaging(mesh)).toBe(false)
     })
 
     it('serialize with its state', () => {

--- a/apps/web/tests/3d/meshes/prism.test.js
+++ b/apps/web/tests/3d/meshes/prism.test.js
@@ -7,21 +7,24 @@
 
 import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
-import { controlManager, materialManager } from '@src/3d/managers'
 import { createPrism } from '@src/3d/meshes'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { configures3dTestEngine, expectPosition } from '../../test-utils'
 
 /** @type {Scene} */
 let scene
-configures3dTestEngine(created => (scene = created.scene))
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 
-beforeAll(() => materialManager.init({ scene }))
+configures3dTestEngine(created => {
+  scene = created.scene
+  managers = created.managers
+})
 
 describe('createPrism()', () => {
   it('creates a prism with default values and no behavior', async () => {
-    const mesh = await createPrism({ id: '', texture: '' }, scene)
+    const mesh = await createPrism({ id: '', texture: '' }, managers, scene)
     const { boundingBox } = mesh.getBoundingInfo()
     expect(mesh.name).toEqual('prism')
     expect(boundingBox.extendSize.x * 2).toEqual(3)
@@ -37,7 +40,7 @@ describe('createPrism()', () => {
 
   it('creates a prism with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createPrism({ id: '', texture: color }, scene)
+    const mesh = await createPrism({ id: '', texture: color }, managers, scene)
     const { boundingBox } = mesh.getBoundingInfo()
     expect(mesh.name).toEqual('prism')
     expect(boundingBox.extendSize.x * 2).toEqual(3)
@@ -56,6 +59,7 @@ describe('createPrism()', () => {
         diameter: 2,
         transform: { roll: Math.PI * -0.5 }
       },
+      managers,
       scene
     )
     const { boundingBox } = mesh.getBoundingInfo()
@@ -104,6 +108,7 @@ describe('createPrism()', () => {
           faceUV,
           ...behaviors
         },
+        managers,
         scene
       )
     })
@@ -133,9 +138,9 @@ describe('createPrism()', () => {
     })
 
     it('unregisters prism from controllables on disposal', () => {
-      expect(controlManager.isManaging(mesh)).toBe(true)
+      expect(managers.control.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(controlManager.isManaging(mesh)).toBe(false)
+      expect(managers.control.isManaging(mesh)).toBe(false)
     })
 
     it('serialize with its state', () => {

--- a/apps/web/tests/3d/meshes/round-token.test.js
+++ b/apps/web/tests/3d/meshes/round-token.test.js
@@ -7,9 +7,8 @@
 
 import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
-import { controlManager, materialManager } from '@src/3d/managers'
 import { createRoundToken } from '@src/3d/meshes'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   configures3dTestEngine,
@@ -19,13 +18,21 @@ import {
 
 /** @type {Scene} */
 let scene
-configures3dTestEngine(created => (scene = created.scene))
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 
-beforeAll(() => materialManager.init({ scene }))
+configures3dTestEngine(created => {
+  scene = created.scene
+  managers = created.managers
+})
 
 describe('createRoundToken()', () => {
   it('creates a token with default values and no behavior', async () => {
-    const mesh = await createRoundToken({ id: '', texture: '' }, scene)
+    const mesh = await createRoundToken(
+      { id: '', texture: '' },
+      managers,
+      scene
+    )
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [2, 0.1, 2])
     expect(mesh.isPickable).toBe(false)
@@ -39,7 +46,11 @@ describe('createRoundToken()', () => {
 
   it('creates a token with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createRoundToken({ id: '', texture: color }, scene)
+    const mesh = await createRoundToken(
+      { id: '', texture: color },
+      managers,
+      scene
+    )
     expect(mesh.name).toEqual('roundToken')
     expectDimension(mesh, [2, 0.1, 2])
     expect(mesh.isPickable).toBe(false)
@@ -56,6 +67,7 @@ describe('createRoundToken()', () => {
         diameter: 2,
         transform: { roll: Math.PI * -0.5 }
       },
+      managers,
       scene
     )
     expect(mesh.name).toEqual('roundToken')
@@ -100,6 +112,7 @@ describe('createRoundToken()', () => {
           faceUV,
           ...behaviors
         },
+        managers,
         scene
       )
     })
@@ -127,9 +140,9 @@ describe('createRoundToken()', () => {
     })
 
     it('unregisters token from controllables on disposal', () => {
-      expect(controlManager.isManaging(mesh)).toBe(true)
+      expect(managers.control.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(controlManager.isManaging(mesh)).toBe(false)
+      expect(managers.control.isManaging(mesh)).toBe(false)
     })
 
     it('serialize with its state', () => {

--- a/apps/web/tests/3d/meshes/rounded-tiles.test.js
+++ b/apps/web/tests/3d/meshes/rounded-tiles.test.js
@@ -7,9 +7,8 @@
 
 import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { faker } from '@faker-js/faker'
-import { controlManager, materialManager } from '@src/3d/managers'
 import { createRoundedTile } from '@src/3d/meshes'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   configures3dTestEngine,
@@ -19,13 +18,21 @@ import {
 
 /** @type {Scene} */
 let scene
-configures3dTestEngine(created => (scene = created.scene))
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 
-beforeAll(() => materialManager.init({ scene }))
+configures3dTestEngine(created => {
+  scene = created.scene
+  managers = created.managers
+})
 
 describe('createRoundedTile()', () => {
   it('creates a tile with default values and no behavior', async () => {
-    const mesh = await createRoundedTile({ id: '', texture: '' }, scene)
+    const mesh = await createRoundedTile(
+      { id: '', texture: '' },
+      managers,
+      scene
+    )
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [3, 0.05, 3])
     expect(mesh.isPickable).toBe(false)
@@ -38,7 +45,11 @@ describe('createRoundedTile()', () => {
 
   it('creates a tile with a single color', async () => {
     const color = '#1E282F'
-    const mesh = await createRoundedTile({ id: '', texture: color }, scene)
+    const mesh = await createRoundedTile(
+      { id: '', texture: color },
+      managers,
+      scene
+    )
     expect(mesh.name).toEqual('roundedTile')
     expectDimension(mesh, [3, 0.05, 3])
     expect(mesh.isPickable).toBe(false)
@@ -58,6 +69,7 @@ describe('createRoundedTile()', () => {
         depth: 2,
         transform: { pitch: Math.PI * -0.5 }
       },
+      managers,
       scene
     )
     expect(mesh.name).toEqual('roundedTile')
@@ -113,6 +125,7 @@ describe('createRoundedTile()', () => {
           borderRadius,
           ...behaviors
         },
+        managers,
         scene
       )
     })
@@ -144,9 +157,9 @@ describe('createRoundedTile()', () => {
     })
 
     it('unregisters mesh from controllables on disposal', () => {
-      expect(controlManager.isManaging(mesh)).toBe(true)
+      expect(managers.control.isManaging(mesh)).toBe(true)
       mesh.dispose()
-      expect(controlManager.isManaging(mesh)).toBe(false)
+      expect(managers.control.isManaging(mesh)).toBe(false)
     })
 
     it('serialize with its state', () => {

--- a/apps/web/tests/3d/utils/behaviors.test.js
+++ b/apps/web/tests/3d/utils/behaviors.test.js
@@ -54,12 +54,15 @@ import {
   initialize3dEngine
 } from '../../test-utils'
 
+// TODO is it needed?
 vi.mock('@src/3d/managers/indicator')
 
 /** @type {Engine} */
 let engine
 /** @type {Mesh} */
 let box
+/** @type {import('@src/3d/managers').Managers} */
+let managers
 /** @type {typeof import('@src/3d/behaviors/anchorable').AnchorBehavior} */
 let AnchorBehavior
 /** @type {typeof import('@src/3d/behaviors/animatable').AnimateBehavior} */
@@ -84,7 +87,7 @@ let StackBehavior
 let TargetBehavior
 
 beforeAll(async () => {
-  engine = initialize3dEngine().engine
+  ;({ managers, engine } = initialize3dEngine())
   // use dynamic import to break the cyclic dependency
   ;({
     AnchorBehavior,
@@ -111,13 +114,13 @@ afterEach(() => disposeAllMeshes(box.getScene()))
 
 describe('getAnimatableBehavior() 3D utility', () => {
   it('finds rotable', () => {
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
     expect(getAnimatableBehavior(box)).toEqual(rotable)
   })
 
   it('finds flippable', () => {
-    const flippable = new FlipBehavior()
+    const flippable = new FlipBehavior({}, managers)
     box.addBehavior(flippable, true)
     expect(getAnimatableBehavior(box)).toEqual(flippable)
   })
@@ -129,41 +132,41 @@ describe('getAnimatableBehavior() 3D utility', () => {
   })
 
   it('finds drawable', () => {
-    const drawable = new DrawBehavior()
+    const drawable = new DrawBehavior({}, managers)
     box.addBehavior(drawable, true)
     expect(getAnimatableBehavior(box)).toEqual(drawable)
   })
 
   it('finds movable over others', () => {
-    const flippable = new FlipBehavior()
+    const flippable = new FlipBehavior({}, managers)
     box.addBehavior(flippable, true)
     const animatable = new AnimateBehavior()
     box.addBehavior(animatable, true)
-    const movable = new MoveBehavior()
+    const movable = new MoveBehavior({}, managers)
     box.addBehavior(movable, true)
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
-    const drawable = new DrawBehavior()
+    const drawable = new DrawBehavior({}, managers)
     box.addBehavior(drawable, true)
     expect(getAnimatableBehavior(box)).toEqual(movable)
   })
 
   it('finds flippable over others', () => {
-    const flippable = new FlipBehavior()
+    const flippable = new FlipBehavior({}, managers)
     box.addBehavior(flippable, true)
     const animatable = new AnimateBehavior()
     box.addBehavior(animatable, true)
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
-    const drawable = new DrawBehavior()
+    const drawable = new DrawBehavior({}, managers)
     box.addBehavior(drawable, true)
     expect(getAnimatableBehavior(box)).toEqual(flippable)
   })
 
   it('finds drawable over others', () => {
-    const drawable = new DrawBehavior()
+    const drawable = new DrawBehavior({}, managers)
     box.addBehavior(drawable, true)
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
     const animatable = new AnimateBehavior()
     box.addBehavior(animatable, true)
@@ -171,7 +174,7 @@ describe('getAnimatableBehavior() 3D utility', () => {
   })
 
   it('finds rotable over others', () => {
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
     const animatable = new AnimateBehavior()
     box.addBehavior(animatable, true)
@@ -185,51 +188,51 @@ describe('getAnimatableBehavior() 3D utility', () => {
 
 describe('getTargetableBehavior() 3D utility', () => {
   it('finds anchorable', () => {
-    const anchorable = new AnchorBehavior()
+    const anchorable = new AnchorBehavior({}, managers)
     box.addBehavior(anchorable, true)
     expect(getTargetableBehavior(box)).toEqual(anchorable)
   })
 
   it('finds stackable', () => {
-    const stackable = new StackBehavior()
+    const stackable = new StackBehavior({}, managers)
     box.addBehavior(stackable, true)
     expect(getTargetableBehavior(box)).toEqual(stackable)
   })
 
   it('finds targetable', () => {
-    const targetable = new TargetBehavior()
+    const targetable = new TargetBehavior({}, managers)
     box.addBehavior(targetable, true)
     expect(getTargetableBehavior(box)).toEqual(targetable)
   })
 
   it('finds quantifiable', () => {
-    const quantifiable = new QuantityBehavior()
+    const quantifiable = new QuantityBehavior({}, managers)
     box.addBehavior(quantifiable, true)
     expect(getTargetableBehavior(box)).toEqual(quantifiable)
   })
 
   it('finds stackable over others', () => {
-    const anchorable = new AnchorBehavior()
+    const anchorable = new AnchorBehavior({}, managers)
     box.addBehavior(anchorable, true)
-    const stackable = new StackBehavior()
+    const stackable = new StackBehavior({}, managers)
     box.addBehavior(stackable, true)
-    const targetable = new TargetBehavior()
+    const targetable = new TargetBehavior({}, managers)
     box.addBehavior(targetable, true)
     expect(getTargetableBehavior(box)).toEqual(stackable)
   })
 
   it('finds anchorable over quantifiable', () => {
-    const quantifiable = new QuantityBehavior()
+    const quantifiable = new QuantityBehavior({}, managers)
     box.addBehavior(quantifiable, true)
-    const anchorable = new AnchorBehavior()
+    const anchorable = new AnchorBehavior({}, managers)
     box.addBehavior(anchorable, true)
     expect(getTargetableBehavior(box)).toEqual(anchorable)
   })
 
   it('finds quantifiable over targetable', () => {
-    const quantifiable = new QuantityBehavior()
+    const quantifiable = new QuantityBehavior({}, managers)
     box.addBehavior(quantifiable, true)
-    const targetable = new TargetBehavior()
+    const targetable = new TargetBehavior({}, managers)
     box.addBehavior(targetable, true)
     expect(getTargetableBehavior(box)).toEqual(quantifiable)
   })
@@ -251,7 +254,7 @@ describe('animateMove() 3D utility', () => {
   it('moves and rotates without animation when omitting duration', async () => {
     const position = [-2, -4, -0.5]
     const rotation = [Math.PI, Math.PI * 0.5, 0]
-    box.addBehavior(new FlipBehavior(), true)
+    box.addBehavior(new FlipBehavior({}, managers), true)
     animateMove(
       box,
       Vector3.FromArray(position),
@@ -277,7 +280,7 @@ describe('animateMove() 3D utility', () => {
 
   it('moves an animatable mesh without gravity', async () => {
     const position = [10, 0.5, 4]
-    box.addBehavior(new RotateBehavior(), true)
+    box.addBehavior(new RotateBehavior({}, managers), true)
     await animateMove(box, Vector3.FromArray(position), null, 100, true)
     expectPosition(box, position)
     expectCloseVector(box.rotation, [0, 0, 0])
@@ -304,7 +307,7 @@ describe('registerBehaviors() 3D utility', () => {
       snapDistance: 0.5,
       duration: 345
     }
-    registerBehaviors(box, { movable: state })
+    registerBehaviors(box, { movable: state }, managers)
     expect(box.getBehaviorByName(MoveBehaviorName)).toHaveProperty(
       'state',
       state
@@ -313,7 +316,7 @@ describe('registerBehaviors() 3D utility', () => {
 
   it('adds flippable behavior to a mesh', () => {
     const state = { isFlipped: true, duration: 123 }
-    registerBehaviors(box, { flippable: state })
+    registerBehaviors(box, { flippable: state }, managers)
     expect(box.getBehaviorByName(FlipBehaviorName)).toHaveProperty(
       'state',
       state
@@ -322,14 +325,14 @@ describe('registerBehaviors() 3D utility', () => {
 
   it('adds rotable behavior to a mesh', () => {
     const state = { angle: Math.PI * 0.5, duration: 321 }
-    registerBehaviors(box, { rotable: state })
+    registerBehaviors(box, { rotable: state }, managers)
     const behavior = box.getBehaviorByName(RotateBehaviorName)
     expect(behavior?.state).toEqualWithAngle(state)
   })
 
   it('adds detailable behavior to a mesh', () => {
     const state = { frontImage: 'front.png', backImage: 'back.png' }
-    registerBehaviors(box, { detailable: state })
+    registerBehaviors(box, { detailable: state }, managers)
     expect(box.getBehaviorByName(DetailBehaviorName)).toHaveProperty(
       'state',
       state
@@ -353,7 +356,7 @@ describe('registerBehaviors() 3D utility', () => {
       ],
       duration: 415
     }
-    registerBehaviors(box, { anchorable: state })
+    registerBehaviors(box, { anchorable: state }, managers)
     expect(box.getBehaviorByName(AnchorBehaviorName)).toHaveProperty(
       'state',
       state
@@ -367,7 +370,7 @@ describe('registerBehaviors() 3D utility', () => {
       kinds: ['round-token'],
       duration: 415
     }
-    registerBehaviors(box, { stackable: state })
+    registerBehaviors(box, { stackable: state }, managers)
     expect(box.getBehaviorByName(StackBehaviorName)).toHaveProperty(
       'state',
       state
@@ -381,7 +384,7 @@ describe('registerBehaviors() 3D utility', () => {
       flipOnPlay: true,
       angleOnPick: 0
     }
-    registerBehaviors(box, { drawable: state })
+    registerBehaviors(box, { drawable: state }, managers)
     expect(box.getBehaviorByName(DrawBehaviorName)).toHaveProperty(
       'state',
       state
@@ -390,7 +393,7 @@ describe('registerBehaviors() 3D utility', () => {
 
   it('adds lockable behavior to a mesh', () => {
     const state = { isLocked: true }
-    registerBehaviors(box, { lockable: state })
+    registerBehaviors(box, { lockable: state }, managers)
     expect(box.getBehaviorByName(LockBehaviorName)).toHaveProperty(
       'state',
       state
@@ -398,15 +401,19 @@ describe('registerBehaviors() 3D utility', () => {
   })
 
   it('adds multiple behaviors to a mesh', () => {
-    registerBehaviors(box, {
-      detailable: { frontImage: '' },
-      movable: {},
-      stackable: { extent: 1.5 },
-      anchorable: { anchors: [] },
-      flippable: { isFlipped: false },
-      rotable: { angle: Math.PI },
-      lockable: { isLocked: false }
-    })
+    registerBehaviors(
+      box,
+      {
+        detailable: { frontImage: '' },
+        movable: {},
+        stackable: { extent: 1.5 },
+        anchorable: { anchors: [] },
+        flippable: { isFlipped: false },
+        rotable: { angle: Math.PI },
+        lockable: { isLocked: false }
+      },
+      managers
+    )
     expect(box.getBehaviorByName(AnchorBehaviorName)?.state).toEqual({
       anchors: [],
       duration: 100
@@ -433,12 +440,16 @@ describe('registerBehaviors() 3D utility', () => {
   })
 
   it('adds nothing without parameters', () => {
-    registerBehaviors(box, { animatable: true })
+    registerBehaviors(box, { animatable: true }, managers)
     expect(box.behaviors).toHaveLength(0)
   })
 
   it('adds lockable after all other behavior', () => {
-    registerBehaviors(box, { lockable: { isLocked: true }, movable: {} })
+    registerBehaviors(
+      box,
+      { lockable: { isLocked: true }, movable: {} },
+      managers
+    )
 
     expect(box.getBehaviorByName(LockBehaviorName)?.state).toEqual({
       isLocked: true
@@ -450,7 +461,7 @@ describe('registerBehaviors() 3D utility', () => {
 describe('restoreBehaviors() 3D utility', () => {
   it('restores movable behavior', () => {
     const state = { snapDistance: 0.5, duration: 345 }
-    const movable = new MoveBehavior()
+    const movable = new MoveBehavior({}, managers)
     box.addBehavior(movable, true)
     restoreBehaviors(box.behaviors, { movable: state })
     expect(movable.state).toEqual(state)
@@ -458,7 +469,7 @@ describe('restoreBehaviors() 3D utility', () => {
 
   it('restores flippable behavior', () => {
     const state = { isFlipped: true, duration: 123 }
-    const flippable = new FlipBehavior()
+    const flippable = new FlipBehavior({}, managers)
     box.addBehavior(flippable, true)
     restoreBehaviors(box.behaviors, { flippable: state })
     expect(flippable.state).toEqual(state)
@@ -466,7 +477,7 @@ describe('restoreBehaviors() 3D utility', () => {
 
   it('restores rotable behavior', () => {
     const state = { angle: Math.PI * -0.5, duration: 432 }
-    const rotable = new RotateBehavior()
+    const rotable = new RotateBehavior({}, managers)
     box.addBehavior(rotable, true)
     restoreBehaviors(box.behaviors, { rotable: state })
     expect(rotable.state).toEqualWithAngle(state)
@@ -474,7 +485,7 @@ describe('restoreBehaviors() 3D utility', () => {
 
   it('restores detailable behavior', () => {
     const state = { frontImage: 'front.png', backImage: 'back.jpg' }
-    const detailable = new DetailBehavior()
+    const detailable = new DetailBehavior({ frontImage: '' }, managers)
     box.addBehavior(detailable, true)
     restoreBehaviors(box.behaviors, { detailable: state })
     expect(detailable.state).toEqual(state)
@@ -497,7 +508,7 @@ describe('restoreBehaviors() 3D utility', () => {
       ],
       duration: 415
     }
-    const anchorable = new AnchorBehavior()
+    const anchorable = new AnchorBehavior({}, managers)
     box.addBehavior(anchorable, true)
     restoreBehaviors(box.behaviors, { anchorable: state })
     expect(anchorable.state).toEqual(state)
@@ -505,7 +516,7 @@ describe('restoreBehaviors() 3D utility', () => {
 
   it('restores lockable behavior', () => {
     const state = { isLocked: false }
-    const lockable = new LockBehavior()
+    const lockable = new LockBehavior({}, managers)
     box.addBehavior(lockable, true)
     restoreBehaviors(box.behaviors, { lockable: state })
     expect(lockable.state).toEqual(state)
@@ -518,7 +529,7 @@ describe('restoreBehaviors() 3D utility', () => {
       kinds: ['round-token'],
       duration: 415
     }
-    const stackable = new StackBehavior()
+    const stackable = new StackBehavior({}, managers)
     box.addBehavior(stackable, true)
     restoreBehaviors(box.behaviors, { stackable: state })
     expect(stackable.state).toEqual({
@@ -559,14 +570,14 @@ describe('restoreBehaviors() 3D utility', () => {
     }
     const detailable = { frontImage: 'something.png' }
     const lockable = { isLocked: false }
-    box.addBehavior(new MoveBehavior(), true)
-    box.addBehavior(new FlipBehavior(), true)
-    box.addBehavior(new RotateBehavior(), true)
-    box.addBehavior(new DetailBehavior(), true)
-    box.addBehavior(new AnchorBehavior(), true)
-    box.addBehavior(new StackBehavior(), true)
+    box.addBehavior(new MoveBehavior({}, managers), true)
+    box.addBehavior(new FlipBehavior({}, managers), true)
+    box.addBehavior(new RotateBehavior({}, managers), true)
+    box.addBehavior(new DetailBehavior({ frontImage: '' }, managers), true)
+    box.addBehavior(new AnchorBehavior({}, managers), true)
+    box.addBehavior(new StackBehavior({}, managers), true)
     box.addBehavior(new AnimateBehavior(), true)
-    box.addBehavior(new LockBehavior(), true)
+    box.addBehavior(new LockBehavior({}, managers), true)
     restoreBehaviors(box.behaviors, {
       detailable,
       movable,
@@ -592,14 +603,14 @@ describe('restoreBehaviors() 3D utility', () => {
   })
 
   it('does nothing without parameters', () => {
-    box.addBehavior(new MoveBehavior(), true)
-    box.addBehavior(new FlipBehavior(), true)
-    box.addBehavior(new RotateBehavior(), true)
-    box.addBehavior(new DetailBehavior(), true)
-    box.addBehavior(new AnchorBehavior(), true)
-    box.addBehavior(new StackBehavior(), true)
+    box.addBehavior(new MoveBehavior({}, managers), true)
+    box.addBehavior(new FlipBehavior({}, managers), true)
+    box.addBehavior(new RotateBehavior({}, managers), true)
+    box.addBehavior(new DetailBehavior({ frontImage: '' }, managers), true)
+    box.addBehavior(new AnchorBehavior({}, managers), true)
+    box.addBehavior(new StackBehavior({}, managers), true)
     box.addBehavior(new AnimateBehavior(), true)
-    box.addBehavior(new LockBehavior(), true)
+    box.addBehavior(new LockBehavior({}, managers), true)
     restoreBehaviors(box.behaviors, {})
     expect(box.getBehaviorByName(MoveBehaviorName)?.state).toEqual({
       snapDistance: 0.25,
@@ -631,14 +642,14 @@ describe('restoreBehaviors() 3D utility', () => {
 describe('serializeBehaviors() 3D utility', () => {
   it('serializes movable behavior', () => {
     const state = { snapDistance: 0.5, duration: 345 }
-    expect(serializeBehaviors([new MoveBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new MoveBehavior(state, managers)])).toEqual({
       movable: state
     })
   })
 
   it('serializes flippable behavior', () => {
     const state = { isFlipped: true, duration: 123 }
-    expect(serializeBehaviors([new FlipBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new FlipBehavior(state, managers)])).toEqual({
       flippable: state
     })
   })
@@ -646,7 +657,7 @@ describe('serializeBehaviors() 3D utility', () => {
   it('serializes rotable behavior', () => {
     const state = { angle: Math.PI, duration: 432 }
     const mesh = createBox('box1')
-    const rotable = new RotateBehavior(state)
+    const rotable = new RotateBehavior(state, managers)
     mesh.addBehavior(rotable, true)
     expect(serializeBehaviors([rotable]).rotable).toEqualWithAngle(state)
   })
@@ -658,7 +669,7 @@ describe('serializeBehaviors() 3D utility', () => {
       kinds: ['round-token'],
       duration: 415
     }
-    expect(serializeBehaviors([new StackBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new StackBehavior(state, managers)])).toEqual({
       stackable: { ...state, stackIds: [] }
     })
   })
@@ -680,28 +691,28 @@ describe('serializeBehaviors() 3D utility', () => {
       ],
       duration: 415
     }
-    expect(serializeBehaviors([new AnchorBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new AnchorBehavior(state, managers)])).toEqual({
       anchorable: state
     })
   })
 
   it('serializes detailable behavior', () => {
     const state = { frontImage: 'front.png', backImage: 'back.jpg' }
-    expect(serializeBehaviors([new DetailBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new DetailBehavior(state, managers)])).toEqual({
       detailable: state
     })
   })
 
   it('serializes drawable behavior', () => {
     const state = { duration: 415 }
-    expect(serializeBehaviors([new DrawBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new DrawBehavior(state, managers)])).toEqual({
       drawable: state
     })
   })
 
   it('serializes lockable behavior', () => {
     const state = { isLocked: true }
-    expect(serializeBehaviors([new LockBehavior(state)])).toEqual({
+    expect(serializeBehaviors([new LockBehavior(state, managers)])).toEqual({
       lockable: state
     })
   })
@@ -737,14 +748,14 @@ describe('serializeBehaviors() 3D utility', () => {
     }
     const detailable = { frontImage: 'front.png', backImage: 'back.jpg' }
     const lockable = { isLocked: false }
-    box.addBehavior(new MoveBehavior(movable), true)
-    box.addBehavior(new FlipBehavior(flippable), true)
-    box.addBehavior(new RotateBehavior(rotable), true)
-    box.addBehavior(new DetailBehavior(detailable), true)
-    box.addBehavior(new AnchorBehavior(anchorable), true)
-    box.addBehavior(new StackBehavior(stackable), true)
+    box.addBehavior(new MoveBehavior(movable, managers), true)
+    box.addBehavior(new FlipBehavior(flippable, managers), true)
+    box.addBehavior(new RotateBehavior(rotable, managers), true)
+    box.addBehavior(new DetailBehavior(detailable, managers), true)
+    box.addBehavior(new AnchorBehavior(anchorable, managers), true)
+    box.addBehavior(new StackBehavior(stackable, managers), true)
     box.addBehavior(new AnimateBehavior(), true)
-    box.addBehavior(new LockBehavior(lockable), true)
+    box.addBehavior(new LockBehavior(lockable, managers), true)
     expect(serializeBehaviors(box.behaviors)).toEqual({
       flippable,
       anchorable,
@@ -882,12 +893,15 @@ describe('isMeshFlipped()', () => {
   })
 
   it('returns false for un-flipped mesh', () => {
-    box.addBehavior(new FlipBehavior(), true)
+    box.addBehavior(new FlipBehavior({}, managers), true)
     expect(isMeshFlipped(box)).toBe(false)
   })
 
   it('returns true for flipped mesh', async () => {
-    box.addBehavior(new FlipBehavior({ isFlipped: true, duration: 50 }), true)
+    box.addBehavior(
+      new FlipBehavior({ isFlipped: true, duration: 50 }, managers),
+      true
+    )
     expect(isMeshFlipped(box)).toBe(true)
     await box.metadata.flip?.()
     expect(isMeshFlipped(box)).toBe(false)
@@ -905,7 +919,10 @@ describe('isMeshInverted()', () => {
   })
 
   it('returns true for inverted mesh', async () => {
-    box.addBehavior(new RotateBehavior({ angle: Math.PI, duration: 50 }), true)
+    box.addBehavior(
+      new RotateBehavior({ angle: Math.PI, duration: 50 }, managers),
+      true
+    )
     expect(isMeshInverted(box)).toBe(true)
     await box.metadata.rotate?.()
     expect(isMeshInverted(box)).toBe(false)
@@ -920,10 +937,10 @@ describe('isMeshInverted()', () => {
   it('returns true for inverted child mesh', async () => {
     const parent = createBox('parent')
     parent.addBehavior(
-      new RotateBehavior({ angle: Math.PI, duration: 50 }),
+      new RotateBehavior({ angle: Math.PI, duration: 50 }, managers),
       true
     )
-    box.addBehavior(new RotateBehavior({ duration: 50 }), true)
+    box.addBehavior(new RotateBehavior({ duration: 50 }, managers), true)
     box.parent = parent
     expect(isMeshInverted(parent)).toBe(true)
     expect(isMeshInverted(box)).toBe(true)
@@ -936,7 +953,7 @@ describe('isMeshLocked()', () => {
   })
 
   it('returns true for inverted mesh', async () => {
-    box.addBehavior(new LockBehavior({ isLocked: true }), true)
+    box.addBehavior(new LockBehavior({ isLocked: true }, managers), true)
     expect(isMeshLocked(box)).toBe(true)
     await box.metadata.toggleLock?.()
     expect(isMeshLocked(box)).toBe(false)
@@ -1066,28 +1083,31 @@ describe('selectDetailedFace()', () => {
   })
 
   it('returns null for a Detailable without front image', () => {
-    box.addBehavior(new DetailBehavior(), true)
+    box.addBehavior(new DetailBehavior({ frontImage: '' }, managers), true)
     expect(selectDetailedFace(box)).toBeNull()
   })
 
   it('returns front image of Detailable', () => {
     const frontImage = 'front.png'
-    box.addBehavior(new DetailBehavior({ frontImage }), true)
+    box.addBehavior(new DetailBehavior({ frontImage }, managers), true)
     expect(selectDetailedFace(box)).toEqual(frontImage)
   })
 
   it('returns null for a flipped Detailable without back image', () => {
     const frontImage = 'front.png'
-    box.addBehavior(new DetailBehavior({ frontImage }), true)
-    box.addBehavior(new FlipBehavior({ isFlipped: true }), true)
+    box.addBehavior(new DetailBehavior({ frontImage }, managers), true)
+    box.addBehavior(new FlipBehavior({ isFlipped: true }, managers), true)
     expect(selectDetailedFace(box)).toBeNull()
   })
 
   it('returns back image of a flipped Detailable', () => {
     const frontImage = 'front.png'
     const backImage = 'back.png'
-    box.addBehavior(new DetailBehavior({ frontImage, backImage }), true)
-    box.addBehavior(new FlipBehavior({ isFlipped: true }), true)
+    box.addBehavior(
+      new DetailBehavior({ frontImage, backImage }, managers),
+      true
+    )
+    box.addBehavior(new FlipBehavior({ isFlipped: true }, managers), true)
     expect(selectDetailedFace(box)).toEqual(backImage)
   })
 })

--- a/apps/web/tests/3d/utils/table.test.js
+++ b/apps/web/tests/3d/utils/table.test.js
@@ -5,37 +5,34 @@
  */
 
 import { faker } from '@faker-js/faker'
-import { materialManager } from '@src/3d/managers'
 import { createTable } from '@src/3d/utils'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { configures3dTestEngine } from '../../test-utils'
 
 describe('createTable() 3D utility', () => {
   /** @type {Scene} */
   let scene
-  /** @type {Scene} */
-  let handScene
+  /** @type {import('@src/3d/managers').Managers} */
+  let managers
 
   configures3dTestEngine(created => {
     scene = created.scene
-    handScene = created.handScene
+    managers = created.managers
   })
-
-  beforeAll(() => materialManager.init({ scene, handScene }))
 
   it('creates a table mesh with parameters', () => {
     const width = faker.number.int(999)
     const height = faker.number.int(999)
-    const texture = faker.internet.url()
-    const table = createTable({ width, height, texture }, scene)
+    const texture = `/${faker.lorem.word()}`
+    const table = createTable({ width, height, texture }, managers, scene)
     const { boundingBox } = table.getBoundingInfo()
     expect(table.name).toEqual('table')
     expect(boundingBox.extendSize.x * 2).toEqual(width)
     expect(boundingBox.extendSize.z * 2).toEqual(height)
     expect(
       /** @type {Material} */ (table.material).diffuseTexture?.name
-    ).toEqual(texture)
+    ).toEqual('https://localhost:3000' + texture)
     expect(table.isPickable).toBe(false)
     expect(table.absolutePosition.x).toEqual(0)
     expect(table.absolutePosition.y).toBeCloseTo(-0.01)
@@ -44,7 +41,7 @@ describe('createTable() 3D utility', () => {
 
   it('creates a table mesh with a color', () => {
     const texture = `${faker.internet.color().toUpperCase()}FF`
-    const table = createTable({ texture }, scene)
+    const table = createTable({ texture }, managers, scene)
     expect(
       /** @type {Material} */ (table.material).diffuseColor
         ?.toGammaSpace()
@@ -54,7 +51,7 @@ describe('createTable() 3D utility', () => {
   })
 
   it('creates a table mesh with default values', () => {
-    const table = createTable(undefined, scene)
+    const table = createTable(undefined, managers, scene)
     const { boundingBox } = table.getBoundingInfo()
     expect(table.name).toEqual('table')
     expect(boundingBox.extendSize.x * 2).toEqual(400)

--- a/apps/web/tests/components/Aside.test.js
+++ b/apps/web/tests/components/Aside.test.js
@@ -61,7 +61,7 @@ describe('Aside component', () => {
         connected: [],
         thread: [],
         playerById: new Map(),
-        user: null,
+        user,
         ...props
       }
     })
@@ -71,7 +71,6 @@ describe('Aside component', () => {
 
   it('can have friends tab only', () => {
     renderComponent({
-      user,
       friends: [{ player: players[1] }, { player: players[2] }],
       playerById: new Map(
         players.slice(0, 1).map(player => [player.id, player])
@@ -85,7 +84,6 @@ describe('Aside component', () => {
 
   it('opens friends tab when it contains requests', () => {
     renderComponent({
-      user,
       friends: [
         { player: players[1], isRequest: true },
         { player: players[2] }
@@ -103,7 +101,6 @@ describe('Aside component', () => {
   it('only has help on single player game without rules book', () => {
     renderComponent({
       game: { kind: 'belote' },
-      user,
       playerById: new Map(
         players.slice(0, 1).map(player => [player.id, player])
       )
@@ -116,7 +113,6 @@ describe('Aside component', () => {
 
   it('has help and rules book on single player game', () => {
     renderComponent({
-      user,
       game: { kind: 'splendor', rulesBookPageCount: 4 },
       playerById: toMap(players.slice(0, 1))
     })
@@ -131,7 +127,6 @@ describe('Aside component', () => {
 
   it('has help, friends and peer tabs on game without rules book', () => {
     renderComponent({
-      user,
       game: { kind: 'splendor' },
       playerById: toMap(players),
       thread
@@ -154,7 +149,6 @@ describe('Aside component', () => {
 
   it('has help, friends and peer tabs on game without rules book and no available seats', () => {
     renderComponent({
-      user,
       game: { kind: 'splendor', availableSeats: 0 },
       playerById: toMap(players),
       thread
@@ -177,7 +171,6 @@ describe('Aside component', () => {
 
   it('has help, friends, rules book and peer tabs on game', () => {
     renderComponent({
-      user,
       game: { kind: 'splendor', rulesBookPageCount: 4 },
       playerById: toMap(players),
       thread
@@ -201,7 +194,6 @@ describe('Aside component', () => {
 
   it('has only friends and peer tabs on lobby', () => {
     renderComponent({
-      user,
       game: { rulesBookPageCount: 4 },
       playerById: toMap(players),
       thread
@@ -217,7 +209,6 @@ describe('Aside component', () => {
 
   it('has streams for connected peers', async () => {
     renderComponent({
-      user,
       game: { kind: 'belote' },
       playerById: toMap(playingPlayers),
       connected,
@@ -241,7 +232,7 @@ describe('Aside component', () => {
   })
 
   it('can send messages', async () => {
-    renderComponent({ user, game: {}, playerById: toMap(players), thread })
+    renderComponent({ game: {}, playerById: toMap(players), thread })
 
     await fireEvent.click(screen.getAllByRole('tab')[1])
     expect(
@@ -265,7 +256,6 @@ describe('Aside component', () => {
 
     beforeEach(() => {
       ;({ component } = renderComponent({
-        user,
         game: { kind: 'splendor', rulesBookPageCount: 4 },
         playerById: toMap(playingPlayers),
         connected,
@@ -335,7 +325,13 @@ describe('Aside component', () => {
       await fireEvent.click(ruleTab)
       expect(screen.getByRole('tab', { selected: true })).toEqual(ruleTab)
       component.$set({
-        game: { kind: 'splendor', rulesBookPageCount: 4, meshs: [] }
+        game: {
+          id: 'blha',
+          created: Date.now(),
+          kind: 'splendor',
+          rulesBookPageCount: 4,
+          meshes: []
+        }
       })
       await tick()
       expect(screen.getByRole('tab', { selected: true })).toEqual(ruleTab)

--- a/apps/web/tests/components/Aside.test.js
+++ b/apps/web/tests/components/Aside.test.js
@@ -48,7 +48,7 @@ describe('Aside component', () => {
   const [user] = players
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     stream$.next({
       getAudioTracks: vi.fn().mockReturnValue([]),
       getVideoTracks: vi.fn().mockReturnValue([])

--- a/apps/web/tests/components/Discussion.tools.svelte
+++ b/apps/web/tests/components/Discussion.tools.svelte
@@ -11,7 +11,8 @@
   props={{
     replayRank: 0,
     playerById: new Map(players.map(player => [player.id, player])),
-    history: []
+    history: [],
+    currentPlayerId: players[2].id
   }}
   events={['sendMessage']}
   layout="centered"

--- a/apps/web/tests/components/Dropdown.test.js
+++ b/apps/web/tests/components/Dropdown.test.js
@@ -14,7 +14,7 @@ describe('Dropdown component', () => {
   const handleClick = vi.fn()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   function renderComponent(props = {}) {

--- a/apps/web/tests/components/FriendList.test.js
+++ b/apps/web/tests/components/FriendList.test.js
@@ -74,7 +74,7 @@ describe('FriendList component', () => {
   ]
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   function renderComponent(props = {}) {

--- a/apps/web/tests/components/Menu.test.js
+++ b/apps/web/tests/components/Menu.test.js
@@ -12,7 +12,7 @@ describe('Menu component', () => {
   const handleSelect = vi.fn()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     value$.set(undefined)
   })
 

--- a/apps/web/tests/components/MinimizableSection.svelte
+++ b/apps/web/tests/components/MinimizableSection.svelte
@@ -28,7 +28,12 @@
     on:change
   >
     {#if !currentTab}
-      <Discussion {playerById} {thread} {history} />
+      <Discussion
+        {playerById}
+        {thread}
+        {history}
+        currentPlayerId={players[2].id}
+      />
     {/if}
     {#if currentTab === 1}
       <span class="p-4">

--- a/apps/web/tests/components/MinimizableSection.test.js
+++ b/apps/web/tests/components/MinimizableSection.test.js
@@ -11,7 +11,7 @@ describe('MinimizableSection component', () => {
   const handleResize = vi.fn()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   describe.each([

--- a/apps/web/tests/components/QuantityButton.test.js
+++ b/apps/web/tests/components/QuantityButton.test.js
@@ -11,7 +11,7 @@ describe('QuantityButton component', () => {
   const quantity$ = writable()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     quantity$.set(1)
   })
 

--- a/apps/web/tests/components/RuleViewer.test.js
+++ b/apps/web/tests/components/RuleViewer.test.js
@@ -29,7 +29,7 @@ describe.each([{ lang: 'fr' }, { lang: 'en' }])('$lang', ({ lang }) => {
     const game = 'cards'
 
     beforeEach(() => {
-      vi.resetAllMocks()
+      vi.clearAllMocks()
     })
 
     function renderComponent(props = {}) {

--- a/apps/web/tests/components/Typeahead.test.js
+++ b/apps/web/tests/components/Typeahead.test.js
@@ -21,7 +21,7 @@ describe('Typeahead component', () => {
   const options$ = writable()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   function renderComponent(props = {}) {

--- a/apps/web/tests/components/__snapshots__/Aside.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Aside.tools.shot
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Empty 1`] = `undefined`;
-
 exports[`Friends only 1`] = `
 <main
   class="flex w-full h-screen s-704Ys9uC0Q3P"
@@ -2603,32 +2601,4 @@ exports[`Single connected, no rules book, thread 1`] = `
   </aside>
   <!--&lt;Container&gt;-->
 </main>
-`;
-
-exports[`Single entry 1`] = `
-<div
-  class="s-x5nEMCoiqeIy"
->
-  <span
-    class="material-icons s-x5nEMCoiqeIy"
-  >
-    home_filled
-  </span>
-   
-  <ol
-    class="s-x5nEMCoiqeIy"
-  >
-    <li
-      class="s-x5nEMCoiqeIy"
-    >
-      <a
-        class="s-x5nEMCoiqeIy"
-      >
-        home
-      </a>
-    </li>
-     
-    
-  </ol>
-</div>
 `;

--- a/apps/web/tests/components/__snapshots__/Aside.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Aside.tools.shot
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Empty 1`] = `undefined`;
+
 exports[`Friends only 1`] = `
 <main
   class="flex w-full h-screen s-704Ys9uC0Q3P"
@@ -2601,4 +2603,32 @@ exports[`Single connected, no rules book, thread 1`] = `
   </aside>
   <!--&lt;Container&gt;-->
 </main>
+`;
+
+exports[`Single entry 1`] = `
+<div
+  class="s-x5nEMCoiqeIy"
+>
+  <span
+    class="material-icons s-x5nEMCoiqeIy"
+  >
+    home_filled
+  </span>
+   
+  <ol
+    class="s-x5nEMCoiqeIy"
+  >
+    <li
+      class="s-x5nEMCoiqeIy"
+    >
+      <a
+        class="s-x5nEMCoiqeIy"
+      >
+        home
+      </a>
+    </li>
+     
+    
+  </ol>
+</div>
 `;

--- a/apps/web/tests/components/__snapshots__/Discussion.tools.shot
+++ b/apps/web/tests/components/__snapshots__/Discussion.tools.shot
@@ -606,6 +606,8 @@ exports[`thread and history 1`] = `
       </span>
     </button>
     <!--&lt;HistoryRecord&gt;-->
+     
+    
     
     
     <div
@@ -682,6 +684,8 @@ exports[`thread and history 1`] = `
       </span>
     </button>
     <!--&lt;HistoryRecord&gt;-->
+     
+    
     
     
     <button
@@ -720,6 +724,8 @@ exports[`thread and history 1`] = `
       </span>
     </button>
     <!--&lt;HistoryRecord&gt;-->
+     
+    
     
     
     <button
@@ -758,6 +764,8 @@ exports[`thread and history 1`] = `
       </span>
     </button>
     <!--&lt;HistoryRecord&gt;-->
+     
+    
     
     
     <span
@@ -841,6 +849,11 @@ exports[`thread and history 1`] = `
       </span>
     </button>
     <!--&lt;HistoryRecord&gt;-->
+     
+    
+    
+    
+    
     
     
   </div>

--- a/apps/web/tests/components/__snapshots__/MinimizableSection.tools.shot
+++ b/apps/web/tests/components/__snapshots__/MinimizableSection.tools.shot
@@ -488,6 +488,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -526,6 +528,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -564,6 +568,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -602,6 +608,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -647,6 +655,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>
@@ -1183,6 +1196,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -1221,6 +1236,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -1259,6 +1276,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -1297,6 +1316,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -1342,6 +1363,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>
@@ -1903,6 +1929,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -1941,6 +1969,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -1979,6 +2009,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -2017,6 +2049,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -2062,6 +2096,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>
@@ -2623,6 +2662,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -2661,6 +2702,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -2699,6 +2742,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -2737,6 +2782,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -2782,6 +2829,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>
@@ -3318,6 +3370,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -3356,6 +3410,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -3394,6 +3450,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -3432,6 +3490,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -3477,6 +3537,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>
@@ -4013,6 +4078,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -4051,6 +4118,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -4089,6 +4158,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <button
@@ -4127,6 +4198,8 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
           
           
           <span
@@ -4172,6 +4245,11 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
             </span>
           </button>
           <!--&lt;HistoryRecord&gt;-->
+           
+          
+          
+          
+          
           
           
         </div>

--- a/apps/web/tests/fixtures/Discussion.testdata.js
+++ b/apps/web/tests/fixtures/Discussion.testdata.js
@@ -80,33 +80,52 @@ Oui, évidemment, n'importe comment une tournée d'inspection peut jamais nuire,
 
 /** @type {HistoryRecord[]} */
 export const history = [
-  { playerId: '369258', fn: 'flip', time, meshId: 'box1', argsStr: '[]' },
+  {
+    playerId: '369258',
+    fn: 'flip',
+    time,
+    meshId: 'box1',
+    argsStr: '[]',
+    fromHand: false
+  },
   {
     playerId: '369258',
     pos: [1, 1, 1],
     prev: [0, 0, 0],
     time: time + 2000,
-    meshId: 'box2'
+    meshId: 'box2',
+    fromHand: false
   },
   {
     playerId: '543498',
     pos: [0, 0, 0],
     prev: [1, 1, 1],
     time: time + 3000,
-    meshId: 'box1'
+    meshId: 'box1',
+    fromHand: false
   },
   {
     playerId: '543498',
     fn: 'rotate',
     time: time + 4000,
     meshId: 'box1',
-    argsStr: '[]'
+    argsStr: '[]',
+    fromHand: false
   },
   {
     playerId: '543498',
     fn: 'draw',
     time: time + 24 * 3600000 + 1000,
     meshId: 'box2',
-    argsStr: '[]'
+    argsStr: '[]',
+    fromHand: false
+  },
+  {
+    playerId: '543498',
+    fn: 'flip',
+    time: time + 24 * 3600000 + 2000,
+    meshId: 'box2',
+    argsStr: '[]',
+    fromHand: true
   }
 ]

--- a/apps/web/tests/matchers.js
+++ b/apps/web/tests/matchers.js
@@ -1,10 +1,4 @@
 // @ts-check
-/**
- * @typedef {import('vitest').SpyInstance<?, ?>} SpyInstance
- * @typedef {import('@vitest/expect').MatcherState} MatcherState
- * @typedef {import('@vitest/expect').SyncExpectationResult} SyncExpectationResult
- */
-
 import { isA } from '@vitest/expect'
 
 export function numberCloseTo(
@@ -26,10 +20,10 @@ export function numberCloseTo(
 
 /**
  * @template {{ angle: number }} E
- * @this {MatcherState}
+ * @this {import('@vitest/expect').MatcherState}
  * @param {?} actual
  * @param {E} expected
- * @returns {SyncExpectationResult}
+ * @returns {import('@vitest/expect').SyncExpectationResult}
  */
 export function toEqualWithAngle(actual, expected) {
   const decimals = 10

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/account/+page.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/account/+page.test.js
@@ -45,7 +45,7 @@ describe.each(
     })
 
     beforeEach(() => {
-      vi.resetAllMocks()
+      vi.clearAllMocks()
     })
 
     it('debounce input and saves username', async () => {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/FPSViewer.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/FPSViewer.test.js
@@ -30,7 +30,7 @@ const fps = /** @type {BehaviorSubject<string>} */ (actualFps)
 
 describe('FPSViewer connected component', () => {
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   it('displays current frame per seconds', async () => {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/GameMenu.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/GameMenu.test.js
@@ -45,7 +45,7 @@ const toggleIndicators = /** @type {Mock<?, ?>} */ (indicators.toggleIndicators)
 
 describe('GameMenu connected component', () => {
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     isFullscreen.next(false)
     areIndicatorsVisible.next(true)
   })
@@ -101,7 +101,7 @@ describe('GameMenu connected component', () => {
   })
 
   it('can hide indicators', async () => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     await renderAndOpenComponent()
     fireEvent.click(selectHideIndicatorsOption())
     expect(toggleFullscreen).not.toHaveBeenCalled()

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/MeshDetails.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/MeshDetails.test.js
@@ -16,7 +16,7 @@ describe('/game/[gameId] MeshDetails component', () => {
   }
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   it('displays a mesh image', () => {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/Container.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/Container.test.js
@@ -11,7 +11,7 @@ describe('Parameters component', () => {
   const handleSubmit = vi.fn()
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   async function renderComponent(/** @type {Schema} */ schema) {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/utils.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/Parameters/utils.test.js
@@ -1107,7 +1107,7 @@ describe('Parameters findViolations() utility', () => {
     }
 
     beforeEach(() => {
-      vi.resetAllMocks()
+      vi.clearAllMocks()
     })
 
     it('invokes enrichProps on valid then', () => {

--- a/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/RadialMenu.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/(auth)/game/[gameid]/RadialMenu.test.js
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('/game/[gameId] Radial Menu component', () => {
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   function renderComponent(props = {}) {

--- a/apps/web/tests/routes/[[lang=lang]]/accept-terms/+page.server.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/accept-terms/+page.server.test.js
@@ -29,7 +29,7 @@ describe.each([
     const bearer = `Bearer ${faker.string.uuid()}`
 
     beforeEach(() => {
-      vi.resetAllMocks()
+      vi.clearAllMocks()
       locals = {
         bearer,
         timeZone: 'GMT',

--- a/apps/web/tests/routes/[[lang=lang]]/home/+page.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/home/+page.test.js
@@ -418,6 +418,7 @@ describe.each(
         expect(joinGame).toHaveBeenCalledWith({
           gameId: gamesWithLobbies[0].id,
           player,
+          onDeletion: expect.any(Function),
           onPromotion: expect.any(Function)
         })
         expect(joinGame).toHaveBeenCalledOnce()
@@ -428,6 +429,7 @@ describe.each(
         expect(joinGame).toHaveBeenCalledWith({
           gameId: gamesWithLobbies[0].id,
           player,
+          onDeletion: expect.any(Function),
           onPromotion: expect.any(Function)
         })
         expect(joinGame).toHaveBeenCalledOnce()
@@ -436,6 +438,7 @@ describe.each(
         expect(joinGame).toHaveBeenNthCalledWith(2, {
           gameId: gamesWithLobbies[1].id,
           player,
+          onDeletion: expect.any(Function),
           onPromotion: expect.any(Function)
         })
         expect(joinGame).toHaveBeenCalledTimes(2)
@@ -446,6 +449,7 @@ describe.each(
         expect(joinGame).toHaveBeenCalledWith({
           gameId: gamesWithLobbies[0].id,
           player,
+          onDeletion: expect.any(Function),
           onPromotion: expect.any(Function)
         })
         expect(joinGame).toHaveBeenCalledOnce()
@@ -483,6 +487,24 @@ describe.each(
             translate('labels.too-many-players', { title, maxSeats: 2 })
           )
         ).toBeInTheDocument()
+        expect(promoteGame).not.toHaveBeenCalled()
+      })
+
+      it('closes lobby when deleted by its owner', async () => {
+        await fireEvent.click(lobbyLinks[0])
+        expect(joinGame).toHaveBeenCalledWith({
+          gameId: gamesWithLobbies[0].id,
+          player,
+          onDeletion: expect.any(Function),
+          onPromotion: expect.any(Function)
+        })
+        joinGame.mock.calls[0][0]?.onDeletion?.(gamesWithLobbies[0])
+
+        expect(toastInfo).toHaveBeenCalledWith({
+          contentKey: 'labels.lobby-deleted-by-owner'
+        })
+        expect(toastInfo).toHaveBeenCalledTimes(1)
+        expect(joinGame).toHaveBeenCalledOnce()
         expect(promoteGame).not.toHaveBeenCalled()
       })
     })

--- a/apps/web/tests/routes/[[lang=lang]]/login/Form.test.js
+++ b/apps/web/tests/routes/[[lang=lang]]/login/Form.test.js
@@ -32,7 +32,7 @@ describe('Login Form component', () => {
   })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
     id$.set(undefined)
     password$.set(undefined)
   })

--- a/apps/web/tests/setup.js
+++ b/apps/web/tests/setup.js
@@ -15,6 +15,8 @@ import * as customMatchers from './matchers'
 expect.extend(matchers)
 expect.extend(customMatchers)
 
+globalThis.use3dSimulation = true
+
 vi.mock('$app/environment', () => ({ browser: true }))
 
 vi.mock('$app/navigation', () => {

--- a/apps/web/tests/stores/game-manager.test.js
+++ b/apps/web/tests/stores/game-manager.test.js
@@ -1494,6 +1494,41 @@ describe('given a mocked game engine', () => {
           expect(runSubscription).toHaveBeenCalledOnce()
         })
 
+        it('reloads game data from host', async () => {
+          await nextPromise()
+          vi.clearAllMocks()
+          const data = { type: 'game-sync', ...game }
+          lastMessageReceived.next({ data, playerId: partner1.id })
+          await nextPromise()
+          expect(engine.load).toHaveBeenCalledWith(
+            data,
+            {
+              playerId: partner2.id,
+              colorByPlayerId: buildPlayerColors(game),
+              preferences: { color: '#ffffff' }
+            },
+            false
+          )
+          expect(engine.load).toHaveBeenCalledOnce()
+          expect(loadCameraSaves).not.toHaveBeenCalled()
+          expect(loadThread).toHaveBeenCalledWith(game.messages)
+          expect(loadThread).toHaveBeenCalledOnce()
+          expect(gamePlayerByIdReceived).toHaveBeenLastCalledWith(
+            new Map(
+              (game.players ?? []).map(gamer => [
+                gamer.id,
+                {
+                  ...gamer,
+                  ...findPlayerPreferences(game, gamer.id),
+                  isHost: gamer.id === partner1.id,
+                  playing: gamer.id === partner2.id
+                }
+              ])
+            )
+          )
+          expect(runSubscription).not.toHaveBeenCalled()
+        })
+
         it('share hand with other peers', async () => {
           vi.clearAllMocks()
           const handMeshes = meshes.slice(0, 1)
@@ -1626,7 +1661,7 @@ describe('given a mocked game engine', () => {
               ]
             ])
           )
-          expect(gamePlayerByIdReceived).toHaveBeenCalledTimes(2)
+          expect(gamePlayerByIdReceived).toHaveBeenCalledTimes(4)
           expect(runSubscription).toHaveBeenCalledWith(
             graphQL.receiveGameUpdates,
             { gameId: game.id }
@@ -1710,7 +1745,7 @@ describe('given a mocked game engine', () => {
               ]
             ])
           )
-          expect(gamePlayerByIdReceived).toHaveBeenCalledTimes(2)
+          expect(gamePlayerByIdReceived).toHaveBeenCalledTimes(4)
           expect(runSubscription).not.toHaveBeenCalled()
           expect(toastReceived).toHaveBeenCalledWith({
             content: translate('labels.player-left-game', { player }),

--- a/apps/web/tests/stores/game-manager.test.js
+++ b/apps/web/tests/stores/game-manager.test.js
@@ -1,7 +1,6 @@
 // @ts-check
 /**
  * @typedef {import('@babylonjs/core').Engine} Engine
- * @typedef {import('@src/3d/managers/camera').cameraManager} cameraManager
  * @typedef {import('@src/3d/managers/camera').CameraPosition} CameraPosition
  * @typedef {import('@src/3d/managers/control').Action} Action
  * @typedef {import('@src/3d/managers/control').Move} Move
@@ -158,7 +157,7 @@ const cameraSaves = /** @type {BehaviorSubject<CameraPosition[]>} */ (
   actualCameraSaves
 )
 const loadCameraSaves =
-  /** @type {Mock<Parameters<cameraManager['loadSaves']>, Promise<void>>} */ (
+  /** @type {Mock<Parameters<import('@src/3d/managers').CameraManager['loadSaves']>, Promise<void>>} */ (
     actualLoadCameraSaves
   )
 const remoteSelection = /** @type {Subject<PlayerSelection>} */ (

--- a/apps/web/tests/stores/notifications.test.js
+++ b/apps/web/tests/stores/notifications.test.js
@@ -20,7 +20,7 @@ describe('Notification store notify()', () => {
   })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   describe('given visible window', () => {

--- a/apps/web/tests/stores/players.test.js
+++ b/apps/web/tests/stores/players.test.js
@@ -45,7 +45,7 @@ const turnCredentials = {
 const token = faker.string.uuid()
 
 beforeEach(() => {
-  vi.resetAllMocks()
+  vi.clearAllMocks()
 })
 
 describe('searchPlayers()', () => {

--- a/apps/web/tests/stores/stream.test.js
+++ b/apps/web/tests/stores/stream.test.js
@@ -54,7 +54,7 @@ describe('Media Stream store', () => {
   })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   afterAll(() => {

--- a/apps/web/tests/stores/stream.test.js
+++ b/apps/web/tests/stores/stream.test.js
@@ -93,11 +93,11 @@ describe('Media Stream store', () => {
         expect.stringMatching(noMediaMessage)
       )
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(camerasReceived).toHaveBeenCalledTimes(1)
-      expect(currentCameraReceived).toHaveBeenCalledTimes(1)
-      expect(micsReceived).toHaveBeenCalledTimes(1)
-      expect(currentMicReceived).toHaveBeenCalledTimes(1)
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(camerasReceived).toHaveBeenCalledOnce()
+      expect(currentCameraReceived).toHaveBeenCalledOnce()
+      expect(micsReceived).toHaveBeenCalledOnce()
+      expect(currentMicReceived).toHaveBeenCalledOnce()
       expect(localStreamChangeReceived).not.toHaveBeenCalled()
     })
 
@@ -122,7 +122,7 @@ describe('Media Stream store', () => {
 
   describe('given acquireMediaStream() got unauthorized media', () => {
     beforeEach(async () => {
-      // @ts-expect-error navigator.mediaDevices is readonly
+      // @ts-expect-error -- navigator.mediaDevices is readonly
       mediaDevicesMock = navigator.mediaDevices = {
         addEventListener: vi.fn(),
         enumerateDevices: vi.fn().mockRejectedValue(new Error('unauthorized')),
@@ -174,7 +174,9 @@ describe('Media Stream store', () => {
   describe('given acquireMediaStream() got authorized media', () => {
     const stream = {
       id: faker.string.uuid(),
-      getTracks: vi.fn()
+      getTracks: vi.fn(),
+      getAudioTracks: vi.fn().mockReturnValue([]),
+      getVideoTracks: vi.fn().mockReturnValue([])
     }
 
     const devices = /** @type {MediaDeviceInfo[]} */ ([
@@ -211,10 +213,10 @@ describe('Media Stream store', () => {
       expectCurrentCamera(devices[0])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(camerasReceived).toHaveBeenCalledTimes(1)
-      expect(micsReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(camerasReceived).toHaveBeenCalledOnce()
+      expect(micsReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it('returns the same stream to all "parallel" acquisition requests', async () => {
@@ -225,7 +227,7 @@ describe('Media Stream store', () => {
       expect(streams[0]).toBe(streams[1])
       expect(streams[0]).toBe(streams[2])
       expect(get(stream$)).toEqual(streams[0])
-      expect(mediaDevicesMock.getUserMedia).toHaveBeenCalledTimes(1)
+      expect(mediaDevicesMock.getUserMedia).toHaveBeenCalledOnce()
     })
 
     it('uses desired camera', async () => {
@@ -237,8 +239,8 @@ describe('Media Stream store', () => {
       expectCurrentCamera(devices[1])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it('uses desired microphone', async () => {
@@ -250,8 +252,8 @@ describe('Media Stream store', () => {
       expectCurrentCamera(devices[0])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it('reuses last microphone and camera', async () => {
@@ -265,8 +267,8 @@ describe('Media Stream store', () => {
       expectCurrentCamera(devices[1])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it(`defaults to first device when last can't be found`, async () => {
@@ -280,13 +282,13 @@ describe('Media Stream store', () => {
       expectCurrentCamera(devices[0])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it('does not enumerate devices twice', async () => {
       await acquireMediaStream()
-      expect(mediaDevicesMock.enumerateDevices).toHaveBeenCalledTimes(1)
+      expect(mediaDevicesMock.enumerateDevices).toHaveBeenCalledOnce()
     })
 
     it('handles no camera at all', async () => {
@@ -301,10 +303,10 @@ describe('Media Stream store', () => {
       expect(get(currentCamera$)).toBeNull()
       expect(get(cameras$)).toEqual([])
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(camerasReceived).toHaveBeenCalledTimes(1)
-      expect(micsReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(camerasReceived).toHaveBeenCalledOnce()
+      expect(micsReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     it('handles no audio at all', async () => {
@@ -319,10 +321,10 @@ describe('Media Stream store', () => {
       expectCurrentCamera(cameras[0])
       expect(get(cameras$)).toEqual(cameras)
       expect(logger.warn).not.toHaveBeenCalled()
-      expect(streamReceived).toHaveBeenCalledTimes(1)
-      expect(camerasReceived).toHaveBeenCalledTimes(1)
-      expect(micsReceived).toHaveBeenCalledTimes(1)
-      expect(localStreamChangeReceived).not.toHaveBeenCalled()
+      expect(streamReceived).toHaveBeenCalledOnce()
+      expect(camerasReceived).toHaveBeenCalledOnce()
+      expect(micsReceived).toHaveBeenCalledOnce()
+      expect(localStreamChangeReceived).toHaveBeenCalledOnce()
     })
 
     describe('releaseMediaStream()', () => {
@@ -330,8 +332,8 @@ describe('Media Stream store', () => {
         const tracks = [{ stop: vi.fn() }, { stop: vi.fn() }]
         stream.getTracks.mockReturnValue(tracks)
         releaseMediaStream()
-        expect(tracks[0].stop).toHaveBeenCalledTimes(1)
-        expect(tracks[1].stop).toHaveBeenCalledTimes(1)
+        expect(tracks[0].stop).toHaveBeenCalledOnce()
+        expect(tracks[1].stop).toHaveBeenCalledOnce()
         expect(get(stream$)).toBeNull()
         expect(get(currentMic$)).toBeNull()
         expect(get(currentCamera$)).toBeNull()
@@ -341,14 +343,42 @@ describe('Media Stream store', () => {
     })
 
     describe('recordStreamChange()', () => {
-      it('emits a state change', () => {
-        const state = {
-          muted: faker.datatype.boolean(),
-          stopped: faker.datatype.boolean()
-        }
+      it('can mute stream', () => {
+        const audioTracks = [{ enabled: true }, { enabled: true }]
+        stream.getAudioTracks.mockReturnValue(audioTracks)
+        localStreamChangeReceived.mockClear()
+        const state = { muted: true, stopped: false }
+        recordStreamChange(state)
+        expect(audioTracks[0].enabled).toBeFalse()
+        expect(audioTracks[1].enabled).toBeFalse()
+        expect(localStreamChangeReceived).toHaveBeenCalledWith(state)
+        expect(localStreamChangeReceived).toHaveBeenCalledOnce()
+      })
+
+      it('can stop stream', () => {
+        const videoTracks = [{ enabled: true }, { enabled: true }]
+        stream.getVideoTracks.mockReturnValue(videoTracks)
+        localStreamChangeReceived.mockClear()
+        const state = { muted: false, stopped: true }
         recordStreamChange(state)
         expect(localStreamChangeReceived).toHaveBeenCalledWith(state)
-        expect(localStreamChangeReceived).toHaveBeenCalledTimes(1)
+        expect(localStreamChangeReceived).toHaveBeenCalledOnce()
+      })
+
+      it('can unmute and resume streams', () => {
+        const audioTracks = [{ enabled: false }, { enabled: false }]
+        const videoTracks = [{ enabled: false }, { enabled: false }]
+        stream.getAudioTracks.mockReturnValue(audioTracks)
+        stream.getVideoTracks.mockReturnValue(videoTracks)
+        localStreamChangeReceived.mockClear()
+        const state = { muted: false, stopped: false }
+        recordStreamChange(state)
+        expect(audioTracks[0].enabled).toBeTrue()
+        expect(audioTracks[1].enabled).toBeTrue()
+        expect(videoTracks[0].enabled).toBeTrue()
+        expect(videoTracks[1].enabled).toBeTrue()
+        expect(localStreamChangeReceived).toHaveBeenCalledWith(state)
+        expect(localStreamChangeReceived).toHaveBeenCalledOnce()
       })
     })
   })
@@ -356,7 +386,7 @@ describe('Media Stream store', () => {
   function expectCurrentMic(/** @type {MediaDeviceInfo} */ device) {
     expect(get(currentMic$)).toEqual(device)
     expect(localStorage.lastMicId).toEqual(device.deviceId)
-    expect(currentMicReceived).toHaveBeenCalledTimes(1)
+    expect(currentMicReceived).toHaveBeenCalledOnce()
     expect(currentMicReceived).toHaveBeenCalledWith(device)
     currentMicReceived.mockClear()
   }
@@ -364,7 +394,7 @@ describe('Media Stream store', () => {
   function expectCurrentCamera(/** @type {MediaDeviceInfo} */ device) {
     expect(get(currentCamera$)).toEqual(device)
     expect(localStorage.lastCameraId).toEqual(device.deviceId)
-    expect(currentCameraReceived).toHaveBeenCalledTimes(1)
+    expect(currentCameraReceived).toHaveBeenCalledOnce()
     expect(currentCameraReceived).toHaveBeenCalledWith(device)
     currentCameraReceived.mockClear()
   }

--- a/apps/web/tests/stores/toaster.test.js
+++ b/apps/web/tests/stores/toaster.test.js
@@ -25,7 +25,7 @@ describe('Toaster store', () => {
   })
 
   beforeEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   afterAll(() => subscription.unsubscribe())

--- a/apps/web/tests/test-utils.js
+++ b/apps/web/tests/test-utils.js
@@ -19,10 +19,6 @@
  * @typedef {import('fastify').FastifyInstance} FastifyInstance
  */
 /**
- * @template {any[]} Args, Return
- * @typedef {import('vitest').SpyInstance<Args, Return>} SpyInstance
- */
-/**
  * @template T
  * @typedef {import('rxjs').Observable<T>} Observable
  */
@@ -171,7 +167,7 @@ export function initialize3dEngine({
     handScene.render()
   })
   engine.inputElement = document.body
-  engine.isSimulation = isSimulation
+  engine.simulation = isSimulation ? null : engine
 
   const scene = main.scene
 
@@ -520,7 +516,7 @@ export function expectQuantityIndicator({ indicator }, mesh, quantity = 1) {
 }
 
 /**
- * @param {SpyInstance<Parameters<IndicatorManager['registerFeedback']>, void>} registerFeedbackSpy - spy for indicatorManager.registerFeedback().
+ * @param {import('vitest').Spy<IndicatorManager['registerFeedback']>} registerFeedbackSpy - spy for indicatorManager.registerFeedback().
  * @param {ActionName|'unlock'|'lock'} action - the expected action reported.
  * @param {...(number[]|Mesh)} meshesOrPositions - expected mesh or position (Vector3 components) for this feedback.
  */
@@ -610,7 +606,7 @@ export async function waitNextRender(scene) {
 }
 
 /**
- * @param {SpyInstance<[MoveDetails], void>} moveRecorded - spy attached to moveManager.onMoveObservable.
+ * @param {import('vitest').SpyInstance<[MoveDetails], void>} moveRecorded - spy attached to moveManager.onMoveObservable.
  * @param {...Mesh} meshes - expected list of moved meshes.
  */
 export function expectMoveRecorded(moveRecorded, ...meshes) {

--- a/apps/web/tests/utils/game-interaction.test.js
+++ b/apps/web/tests/utils/game-interaction.test.js
@@ -19,10 +19,6 @@
  * @template {Record<string, ?>} T
  * @typedef {{[K in keyof T]: T[K] extends () => any ? Mock<Parameters<T[K]>, ReturnType<T[K]>> : T[K]}} MockedObject
  */
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
 
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { faker } from '@faker-js/faker'
@@ -1066,9 +1062,9 @@ describe('Game interaction model', () => {
   })
 
   describe('attachInputs()', () => {
-    /** @type {SpyInstance<Parameters<import('@src/3d/managers').SelectionManager['drawSelectionBox']>, ReturnType<import('@src/3d/managers').SelectionManager['drawSelectionBox']>>} */
+    /** @type {import('vitest').Spy<import('@src/3d/managers').SelectionManager['drawSelectionBox']>} */
     let drawSelectionBox
-    /** @type {SpyInstance<Parameters<import('@src/3d/managers').SelectionManager['selectWithinBox']>, ReturnType<import('@src/3d/managers').SelectionManager['selectWithinBox']>>} */
+    /** @type {import('vitest').Spy<import('@src/3d/managers').SelectionManager['selectWithinBox']>} */
     let selectWithinBox
 
     beforeAll(() => {

--- a/apps/web/tests/utils/logger.test.js
+++ b/apps/web/tests/utils/logger.test.js
@@ -1,24 +1,19 @@
 // @ts-check
-/**
- * @template {any[]} P, R
- * @typedef {import('vitest').SpyInstance<P, R>} SpyInstance
- */
-
 import { faker } from '@faker-js/faker'
 import { makeLogger } from '@src/utils/logger'
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('Logger', () => {
-  /** @type {SpyInstance<Parameters<typeof console.trace>, void>} */
+  /** @type {import('vitest').Spy<typeof console.trace>} */
   let trace
-  /** @type {SpyInstance<Parameters<typeof console.log>, void>} */
+  /** @type {import('vitest').Spy<typeof console.log>} */
   let log
-  /** @type {SpyInstance<Parameters<typeof console.info>, void>} */
+  /** @type {import('vitest').Spy<typeof console.info>} */
   let info
-  /** @type {SpyInstance<Parameters<typeof console.warn>, void>} */
+  /** @type {import('vitest').Spy<typeof console.warn>} */
   let warn
-  /** @type {SpyInstance<Parameters<typeof console.error>, void>} */
+  /** @type {import('vitest').Spy<typeof console.error>} */
   let error
 
   beforeEach(() => {


### PR DESCRIPTION
### :book: What's in there?

When replaying, especially in a multi-player game, the 3D engine is managing replayed state, and can not provide the latest states for save and new peers.
This PRs introduces simulation engine: a second 3D engine which has no rendering and can handles the latest state while the "real" 3D engine renders the replayed state.

And since the simulation engine applies animations with a duration of 0, it makes tests faster.
Are also included here:

- fix(server): no redirection to home/lobby closure when owner deletes the current game/lobby.
- fix(web): peer do not apply host game state on game sync.
- fix(web): when receiving game or stream update, aside jumps to the player tab.
- fix(web): peers muted/stopped states are reset when reconnecting to game.
- feat(web): joins a simulation engine to the real engine, to maintain game state while replaying.
- feat(server, web): records hand actions in history.
- refactor(web): binds manager singletons to the 3d engine.

### :test_tube: How to test?

Simulation:

1. creates a playground game, flip, move and draw several cards,  and invite a player
   > player A is the host, its history reflects its actions, player B joins with latest state and history
1. player B performs some actions
   > they are displayed in both histories, and both states are equal
1. player A (the host), enters replay mode
   > its state is different from player B
1. player B performs some actions
   > they are displayed in both histories, but player A's state is still in replay
1. player B leaves the game, and joins a gain
   > they show the latest state, and latest history (previously, all actions since host entered replay would be lost).

Lobby deletion by host

1. player A creates a lobby and invite another player
1. player B joins the lobby
   > they are both in the lobby
1. player A leaves the lobby and deletes it
   > player B's lobby is closed with a tooltip, and the lobby does not appear in game list (previously, player would stay in the deleted lobby).

Game deletion by host

1. player A creates a game and invite another player
1. player B joins the game
   > they are both in the game
1. player A leaves the game and deletes it
   > player B's is redirected to home with a tooltip, and the game does not appear in game list (previously, player would stay in the deleted game).

Video state

1. player A creates a game and invite another player, and switch tab to rules/discussion
1. player B joins the game
   > player A's players tab automatically pops, and they both have audio and video on
1. player B switch tab to rules/discussion
1. player A (host) mutes and stops video, performs some action
   > player B is still on rules/discussion tab, hear no sound, and see latest actions
1. player B switch to players tabe
   > player B sees the "muted" icon and black video for player A
1. player B reloads the page
   > eventually they will see "muted" icon and black video. Streams are effectively stopped (previously state would be reset and streams would be live).

Hand action in history

1. player A creates a playground and invite another player
1. player A draws 3 cards, flip one, move them around in hand
   > player A's history shows draws, flip and move actions, player B's history only show draws
1. player B draws 3 cards, flip one, move them around in hand
   > player B's history also shows draws, flip and move actions, player A's history only has the new draw
1. player B replays history
   > they will see hand actions replayed as well

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers' attention on.
Otherwise,
-->
